### PR TITLE
feat(engine): add Plex HTTP client with zod validation and pagination

### DIFF
--- a/apps/engine/package.json
+++ b/apps/engine/package.json
@@ -18,7 +18,8 @@
   "dependencies": {
     "@hono/node-server": "^2.0.0",
     "@pavoia/shared": "0.0.0",
-    "hono": "^4.12.14"
+    "hono": "^4.12.14",
+    "zod": "^4.3.6"
   },
   "devDependencies": {
     "@types/node": "^22.19.17",

--- a/apps/engine/src/plex/client.test.ts
+++ b/apps/engine/src/plex/client.test.ts
@@ -1,0 +1,641 @@
+import { describe, it, before, after } from "node:test";
+import assert from "node:assert/strict";
+import http, { type Server, type IncomingMessage, type ServerResponse } from "node:http";
+import type { AddressInfo } from "node:net";
+
+import { createPlexClient, PlexApiError, type PlexSkipReason } from "./client.ts";
+
+type Handler = (req: IncomingMessage, res: ServerResponse) => void | Promise<void>;
+
+/** Spin up a real HTTP server so we test the actual fetch → response path,
+    not a fetch mock. Per-test handler is swapped via `setHandler(fn)`. */
+class StubPlex {
+  private server: Server;
+  private handler: Handler = (_req, res) => {
+    res.statusCode = 500;
+    res.end();
+  };
+  port = 0;
+  requests: { method: string; url: string; headers: http.IncomingHttpHeaders }[] = [];
+
+  constructor() {
+    this.server = http.createServer(async (req, res) => {
+      this.requests.push({
+        method: req.method ?? "",
+        url: req.url ?? "",
+        headers: req.headers,
+      });
+      try {
+        await this.handler(req, res);
+      } catch (err) {
+        if (!res.headersSent) res.statusCode = 500;
+        res.end(`handler threw: ${(err as Error).message}`);
+      }
+    });
+  }
+
+  async start(): Promise<void> {
+    await new Promise<void>((resolve, reject) => {
+      this.server.once("error", reject);
+      this.server.listen(0, "127.0.0.1", () => {
+        this.server.off("error", reject);
+        resolve();
+      });
+    });
+    const addr = this.server.address() as AddressInfo;
+    this.port = addr.port;
+  }
+
+  setHandler(h: Handler): void {
+    this.handler = h;
+    this.requests = [];
+  }
+
+  get url(): string {
+    return `http://127.0.0.1:${this.port}`;
+  }
+
+  async stop(): Promise<void> {
+    await new Promise<void>((resolve, reject) =>
+      this.server.close((err) => (err ? reject(err) : resolve())),
+    );
+  }
+}
+
+const LIB_ROOT = "/home/yolan/files/plex_music_library/opus";
+
+function entry(partial: {
+  ratingKey?: string;
+  type?: string;
+  title?: string;
+  grandparentTitle?: string | null;
+  parentTitle?: string | null;
+  parentYear?: number | null;
+  duration?: number | null;
+  thumb?: string | null;
+  file?: string;
+}): Record<string, unknown> {
+  return {
+    ratingKey: partial.ratingKey ?? "1",
+    type: partial.type ?? "track",
+    title: partial.title ?? "T",
+    grandparentTitle: partial.grandparentTitle ?? "A",
+    parentTitle: partial.parentTitle ?? "B",
+    parentYear: partial.parentYear ?? 2020,
+    duration: partial.duration ?? 100_000,
+    thumb: partial.thumb ?? "/library/metadata/1/thumb/1",
+    Media: [{ Part: [{ file: partial.file ?? `${LIB_ROOT}/song.mp3` }] }],
+  };
+}
+
+function plexPlaylistFixture(overrides?: { metadata?: unknown[]; totalSize?: number }): unknown {
+  const metadata = overrides?.metadata ?? [
+    {
+      ratingKey: "12345",
+      type: "track",
+      title: "Opening Set",
+      grandparentTitle: "DJ Curator",
+      parentTitle: "Compilation Vol. 1",
+      parentYear: 2023,
+      duration: 312_000,
+      thumb: "/library/metadata/12345/thumb/1",
+      Media: [
+        { Part: [{ file: `${LIB_ROOT}/artist/album/01 - Opening Set.mp3`, size: 10_000_000 }] },
+      ],
+    },
+    {
+      ratingKey: "67890",
+      type: "track",
+      title: "Après-minuit",
+      grandparentTitle: "Café Noir",
+      parentTitle: "Nuit blanche",
+      parentYear: 2024,
+      duration: 245_000,
+      thumb: "/library/metadata/67890/thumb/1",
+      Media: [
+        { Part: [{ file: `${LIB_ROOT}/Café Noir/Nuit blanche/02 - Après-minuit.mp3` }] },
+      ],
+    },
+  ];
+  return {
+    MediaContainer: {
+      size: metadata.length,
+      totalSize: overrides?.totalSize ?? metadata.length,
+      Metadata: metadata,
+    },
+  };
+}
+
+describe("PlexClient.fetchPlaylist", () => {
+  const stub = new StubPlex();
+
+  before(async () => {
+    await stub.start();
+  });
+
+  after(async () => {
+    await stub.stop();
+  });
+
+  it("happy path: parses a 2-track playlist into Track[] with correct mapping", async () => {
+    stub.setHandler((_req, res) => {
+      res.setHeader("content-type", "application/json");
+      res.end(JSON.stringify(plexPlaylistFixture()));
+    });
+
+    const client = createPlexClient({
+      baseUrl: stub.url,
+      token: "test-token",
+      libraryRoot: LIB_ROOT,
+    });
+
+    const result = await client.fetchPlaylist(145472);
+    assert.equal(result.ratingKey, 145472);
+    assert.equal(result.tracks.length, 2);
+    assert.equal(result.skipped, 0);
+
+    const [t1, t2] = result.tracks;
+    assert.equal(t1!.plexRatingKey, 12345);
+    assert.equal(t1!.title, "Opening Set");
+    assert.equal(t1!.artist, "DJ Curator");
+    assert.equal(t1!.album, "Compilation Vol. 1");
+    assert.equal(t1!.albumYear, 2023);
+    assert.equal(t1!.durationSec, 312);
+    assert.equal(t1!.filePath, `${LIB_ROOT}/artist/album/01 - Opening Set.mp3`);
+    assert.equal(t1!.coverUrl, "/library/metadata/12345/thumb/1");
+    assert.match(t1!.fallbackHash, /^[0-9a-f]{16}$/);
+
+    assert.equal(t2!.title, "Après-minuit");
+    assert.equal(t2!.artist, "Café Noir");
+  });
+
+  it("sends the Plex token as X-Plex-Token header, not in the query string", async () => {
+    stub.setHandler((_req, res) => {
+      res.end(JSON.stringify(plexPlaylistFixture({ metadata: [] })));
+    });
+    const client = createPlexClient({
+      baseUrl: stub.url,
+      token: "secret-token-xyz",
+      libraryRoot: LIB_ROOT,
+    });
+    await client.fetchPlaylist(1);
+    const req = stub.requests.at(-1)!;
+    assert.equal(req.headers["x-plex-token"], "secret-token-xyz");
+    assert.equal(req.headers["accept"], "application/json");
+    assert.equal(
+      req.url?.toLowerCase().includes("token"),
+      false,
+      "token must not be in URL (case-insensitive)",
+    );
+    assert.equal(req.url?.includes("secret"), false);
+  });
+
+  it("requests `/playlists/:id/items` with X-Plex-Container-Start and Size", async () => {
+    stub.setHandler((_req, res) => {
+      res.end(JSON.stringify(plexPlaylistFixture({ metadata: [] })));
+    });
+    const client = createPlexClient({
+      baseUrl: stub.url,
+      token: "t",
+      libraryRoot: LIB_ROOT,
+    });
+    await client.fetchPlaylist(42);
+    const url = stub.requests.at(-1)!.url!;
+    assert.ok(url.startsWith("/playlists/42/items?"), `got ${url}`);
+    assert.match(url, /X-Plex-Container-Start=0/);
+    assert.match(url, /X-Plex-Container-Size=\d+/);
+  });
+
+  it("tolerates trailing slashes on baseUrl", async () => {
+    stub.setHandler((_req, res) => {
+      res.end(JSON.stringify(plexPlaylistFixture({ metadata: [] })));
+    });
+    const client = createPlexClient({
+      baseUrl: `${stub.url}//`,
+      token: "t",
+      libraryRoot: LIB_ROOT,
+    });
+    await client.fetchPlaylist(7);
+    assert.ok(stub.requests.at(-1)!.url!.startsWith("/playlists/7/items?"));
+  });
+
+  it("empty playlist (size=0, no Metadata): returns tracks=[], skipped=0", async () => {
+    stub.setHandler((_req, res) => {
+      res.end(JSON.stringify({ MediaContainer: { size: 0, totalSize: 0 } }));
+    });
+    const client = createPlexClient({ baseUrl: stub.url, token: "t", libraryRoot: LIB_ROOT });
+    const result = await client.fetchPlaylist(99);
+    assert.deepEqual(result.tracks, []);
+    assert.equal(result.skipped, 0);
+  });
+
+  it("401 → PlexApiError{kind:'auth'}", async () => {
+    stub.setHandler((_req, res) => {
+      res.statusCode = 401;
+      res.end('{"error":"unauthorized"}');
+    });
+    const client = createPlexClient({ baseUrl: stub.url, token: "bad", libraryRoot: LIB_ROOT });
+    await assert.rejects(
+      () => client.fetchPlaylist(1),
+      (err: unknown) => err instanceof PlexApiError && err.detail.kind === "auth",
+    );
+  });
+
+  it("403 is treated as auth as well", async () => {
+    stub.setHandler((_req, res) => {
+      res.statusCode = 403;
+      res.end("");
+    });
+    const client = createPlexClient({ baseUrl: stub.url, token: "bad", libraryRoot: LIB_ROOT });
+    await assert.rejects(
+      () => client.fetchPlaylist(1),
+      (err: unknown) => err instanceof PlexApiError && err.detail.kind === "auth",
+    );
+  });
+
+  it("404 → PlexApiError{kind:'not_found', ratingKey}", async () => {
+    stub.setHandler((_req, res) => {
+      res.statusCode = 404;
+      res.end("");
+    });
+    const client = createPlexClient({ baseUrl: stub.url, token: "t", libraryRoot: LIB_ROOT });
+    await assert.rejects(
+      () => client.fetchPlaylist(12345),
+      (err: unknown) =>
+        err instanceof PlexApiError &&
+        err.detail.kind === "not_found" &&
+        err.detail.ratingKey === 12345,
+    );
+  });
+
+  it("500 → PlexApiError{kind:'server', status}", async () => {
+    stub.setHandler((_req, res) => {
+      res.statusCode = 503;
+      res.end("plex overloaded");
+    });
+    const client = createPlexClient({ baseUrl: stub.url, token: "t", libraryRoot: LIB_ROOT });
+    await assert.rejects(
+      () => client.fetchPlaylist(1),
+      (err: unknown) =>
+        err instanceof PlexApiError &&
+        err.detail.kind === "server" &&
+        err.detail.status === 503,
+    );
+  });
+
+  it("non-JSON body → invalid_response", async () => {
+    stub.setHandler((_req, res) => {
+      res.setHeader("content-type", "text/plain");
+      res.end("<html>Plex UI</html>");
+    });
+    const client = createPlexClient({ baseUrl: stub.url, token: "t", libraryRoot: LIB_ROOT });
+    await assert.rejects(
+      () => client.fetchPlaylist(1),
+      (err: unknown) => err instanceof PlexApiError && err.detail.kind === "invalid_response",
+    );
+  });
+
+  it("JSON that doesn't match the schema → invalid_response with issue list", async () => {
+    stub.setHandler((_req, res) => {
+      res.end(JSON.stringify({ not: "a plex response" }));
+    });
+    const client = createPlexClient({ baseUrl: stub.url, token: "t", libraryRoot: LIB_ROOT });
+    await assert.rejects(
+      () => client.fetchPlaylist(1),
+      (err: unknown) => {
+        if (!(err instanceof PlexApiError)) return false;
+        if (err.detail.kind !== "invalid_response") return false;
+        assert.ok(err.detail.issues.length > 0, "should list schema issues");
+        return true;
+      },
+    );
+  });
+
+  it("inconsistent container: size>0 but Metadata:[] → invalid_response", async () => {
+    stub.setHandler((_req, res) => {
+      res.end(JSON.stringify({ MediaContainer: { size: 5, totalSize: 5, Metadata: [] } }));
+    });
+    const client = createPlexClient({ baseUrl: stub.url, token: "t", libraryRoot: LIB_ROOT });
+    await assert.rejects(
+      () => client.fetchPlaylist(1),
+      (err: unknown) => err instanceof PlexApiError && err.detail.kind === "invalid_response",
+    );
+  });
+
+  it("tolerates nullable Plex fields (grandparentTitle/parentTitle/parentYear/duration/thumb = null)", async () => {
+    stub.setHandler((_req, res) => {
+      res.end(
+        JSON.stringify(
+          plexPlaylistFixture({
+            metadata: [
+              {
+                ratingKey: "1",
+                type: "track",
+                title: "Bare",
+                grandparentTitle: null,
+                parentTitle: null,
+                parentYear: null,
+                duration: null,
+                thumb: null,
+                Media: [{ Part: [{ file: `${LIB_ROOT}/bare.mp3` }] }],
+              },
+            ],
+          }),
+        ),
+      );
+    });
+    const client = createPlexClient({ baseUrl: stub.url, token: "t", libraryRoot: LIB_ROOT });
+    const result = await client.fetchPlaylist(1);
+    assert.equal(result.tracks.length, 1);
+    const t = result.tracks[0]!;
+    assert.equal(t.artist, "Unknown artist");
+    assert.equal(t.album, "");
+    assert.equal(t.albumYear, null);
+    assert.equal(t.durationSec, 0);
+    assert.equal(t.coverUrl, null);
+  });
+
+  it("path_outside_library: rejects `..` traversal (resolved path escapes the root)", async () => {
+    const skips: PlexSkipReason[] = [];
+    stub.setHandler((_req, res) => {
+      res.end(
+        JSON.stringify(
+          plexPlaylistFixture({
+            metadata: [
+              entry({ ratingKey: "1", title: "Traversal", file: `${LIB_ROOT}/../outside.mp3` }),
+              entry({ ratingKey: "2", title: "Prefix Collision", file: `${LIB_ROOT}-evil/file.mp3` }),
+              entry({ ratingKey: "3", title: "Deep Traversal", file: `${LIB_ROOT}/subdir/../../etc/passwd` }),
+              entry({ ratingKey: "4", title: "Absolute Outside", file: "/etc/shadow" }),
+              entry({ ratingKey: "5", title: "Legit", file: `${LIB_ROOT}/real.mp3` }),
+            ],
+          }),
+        ),
+      );
+    });
+    const client = createPlexClient({
+      baseUrl: stub.url,
+      token: "t",
+      libraryRoot: LIB_ROOT,
+      onSkip: (r) => skips.push(r),
+    });
+    const result = await client.fetchPlaylist(1);
+    assert.equal(result.tracks.length, 1, `only 'Legit' should survive — got ${result.tracks.map(t => t.title).join(",")}`);
+    assert.equal(result.tracks[0]!.title, "Legit");
+    assert.equal(result.skipped, 4);
+    assert.equal(skips.filter((s) => s.reason === "path_outside_library").length, 4);
+  });
+
+  it("path_outside_library: tolerates a trailing slash on libraryRoot config", async () => {
+    stub.setHandler((_req, res) => {
+      res.end(
+        JSON.stringify(
+          plexPlaylistFixture({
+            metadata: [entry({ ratingKey: "1", title: "OK", file: `${LIB_ROOT}/ok.mp3` })],
+          }),
+        ),
+      );
+    });
+    const client = createPlexClient({
+      baseUrl: stub.url,
+      token: "t",
+      libraryRoot: `${LIB_ROOT}/`,
+    });
+    const result = await client.fetchPlaylist(1);
+    assert.equal(result.tracks.length, 1);
+  });
+
+  it("non-track Metadata entries (videos, episodes) are skipped with reason 'not_a_track'", async () => {
+    const skips: PlexSkipReason[] = [];
+    stub.setHandler((_req, res) => {
+      res.end(
+        JSON.stringify(
+          plexPlaylistFixture({
+            metadata: [
+              entry({ ratingKey: "1", type: "episode", title: "Pilot" }),
+              entry({ ratingKey: "2", type: "track", title: "Real Track" }),
+            ],
+          }),
+        ),
+      );
+    });
+    const client = createPlexClient({
+      baseUrl: stub.url,
+      token: "t",
+      libraryRoot: LIB_ROOT,
+      onSkip: (r) => skips.push(r),
+    });
+    const result = await client.fetchPlaylist(1);
+    assert.equal(result.tracks.length, 1);
+    assert.equal(result.skipped, 1);
+    assert.equal(skips[0]!.reason, "not_a_track");
+  });
+
+  it("unsafe-integer ratingKey is skipped with reason 'invalid_rating_key'", async () => {
+    const skips: PlexSkipReason[] = [];
+    stub.setHandler((_req, res) => {
+      res.end(
+        JSON.stringify(
+          plexPlaylistFixture({
+            metadata: [
+              entry({ ratingKey: "9999999999999999999", title: "Overflow" }),
+              entry({ ratingKey: "0", title: "Zero" }),
+              entry({ ratingKey: "-1", title: "Negative" }),
+              entry({ ratingKey: "abc", title: "Non-numeric" }),
+              entry({ ratingKey: "42", title: "OK" }),
+            ],
+          }),
+        ),
+      );
+    });
+    const client = createPlexClient({
+      baseUrl: stub.url,
+      token: "t",
+      libraryRoot: LIB_ROOT,
+      onSkip: (r) => skips.push(r),
+    });
+    const result = await client.fetchPlaylist(1);
+    assert.equal(result.tracks.length, 1);
+    assert.equal(result.tracks[0]!.plexRatingKey, 42);
+    assert.equal(skips.filter((s) => s.reason === "invalid_rating_key").length, 4);
+  });
+
+  it("timeout: when Plex never responds within timeoutMs → PlexApiError{kind:'timeout'}", async () => {
+    stub.setHandler(async (_req, res) => {
+      await new Promise(() => {});
+      res.end();
+    });
+    const client = createPlexClient({
+      baseUrl: stub.url,
+      token: "t",
+      libraryRoot: LIB_ROOT,
+      timeoutMs: 150,
+    });
+    await assert.rejects(
+      () => client.fetchPlaylist(1),
+      (err: unknown) =>
+        err instanceof PlexApiError &&
+        err.detail.kind === "timeout" &&
+        err.detail.timeoutMs === 150,
+    );
+  });
+
+  it("timeout: when body stalls mid-stream → PlexApiError{kind:'timeout'}", async () => {
+    stub.setHandler(async (_req, res) => {
+      res.setHeader("content-type", "application/json");
+      res.flushHeaders();
+      res.write("{");
+      await new Promise(() => {});
+      res.end();
+    });
+    const client = createPlexClient({
+      baseUrl: stub.url,
+      token: "t",
+      libraryRoot: LIB_ROOT,
+      timeoutMs: 200,
+    });
+    await assert.rejects(
+      () => client.fetchPlaylist(1),
+      (err: unknown) => err instanceof PlexApiError && err.detail.kind === "timeout",
+    );
+  });
+
+  it("network error (connection refused on known-free port): PlexApiError{kind:'network'}", async () => {
+    // Bind to port 0 → kernel assigns one → close → that port is now free
+    // with very high probability. More portable than hardcoding 127.0.0.1:1.
+    const tmp = http.createServer();
+    await new Promise<void>((resolve) => tmp.listen(0, "127.0.0.1", () => resolve()));
+    const freePort = (tmp.address() as AddressInfo).port;
+    await new Promise<void>((resolve) => tmp.close(() => resolve()));
+
+    const client = createPlexClient({
+      baseUrl: `http://127.0.0.1:${freePort}`,
+      token: "t",
+      libraryRoot: LIB_ROOT,
+      timeoutMs: 2000,
+    });
+    await assert.rejects(
+      () => client.fetchPlaylist(1),
+      (err: unknown) => err instanceof PlexApiError && err.detail.kind === "network",
+    );
+  });
+
+  it("rejects invalid ratingKey synchronously (0, negative, NaN, float, unsafe-integer)", async () => {
+    const client = createPlexClient({ baseUrl: stub.url, token: "t", libraryRoot: LIB_ROOT });
+    await assert.rejects(() => client.fetchPlaylist(0));
+    await assert.rejects(() => client.fetchPlaylist(-1));
+    await assert.rejects(() => client.fetchPlaylist(NaN));
+    await assert.rejects(() => client.fetchPlaylist(3.14));
+    await assert.rejects(() => client.fetchPlaylist(Number.MAX_SAFE_INTEGER + 1));
+  });
+
+  it("durationSec rounds to nearest second (500ms rounds up)", async () => {
+    stub.setHandler((_req, res) => {
+      res.end(
+        JSON.stringify(
+          plexPlaylistFixture({
+            metadata: [
+              entry({ ratingKey: "1", duration: 3_499 }),
+              entry({ ratingKey: "2", duration: 3_500 }),
+            ],
+          }),
+        ),
+      );
+    });
+    const client = createPlexClient({ baseUrl: stub.url, token: "t", libraryRoot: LIB_ROOT });
+    const result = await client.fetchPlaylist(1);
+    assert.equal(result.tracks[0]!.durationSec, 3);
+    assert.equal(result.tracks[1]!.durationSec, 4);
+  });
+
+  it("paginates when totalSize > page size", async () => {
+    // Simulate 3 pages of 2 tracks each = 6 tracks total, totalSize=6.
+    stub.setHandler((req, res) => {
+      const url = new URL(req.url ?? "", "http://x");
+      const start = Number(url.searchParams.get("X-Plex-Container-Start") ?? "0");
+      const page1 = [entry({ ratingKey: "1" }), entry({ ratingKey: "2" })];
+      const page2 = [entry({ ratingKey: "3" }), entry({ ratingKey: "4" })];
+      const page3 = [entry({ ratingKey: "5" }), entry({ ratingKey: "6" })];
+      // The default REQUEST_PAGE_SIZE is 5000, so our single page always
+      // satisfies the request. To actually test pagination we simulate a
+      // server that artificially pages every 2 entries.
+      const all = [...page1, ...page2, ...page3];
+      const pageSize = 2;
+      const sliced = all.slice(start, start + pageSize);
+      res.end(
+        JSON.stringify({
+          MediaContainer: { size: sliced.length, totalSize: all.length, Metadata: sliced },
+        }),
+      );
+    });
+    const client = createPlexClient({ baseUrl: stub.url, token: "t", libraryRoot: LIB_ROOT });
+    const result = await client.fetchPlaylist(1);
+    assert.equal(result.tracks.length, 6);
+    assert.deepEqual(
+      result.tracks.map((t) => t.plexRatingKey),
+      [1, 2, 3, 4, 5, 6],
+    );
+    assert.ok(stub.requests.length >= 3, `expected multiple page requests, got ${stub.requests.length}`);
+  });
+
+  it("too-many-tracks: refuses a Plex response claiming totalSize > 50_000", async () => {
+    stub.setHandler((_req, res) => {
+      res.end(
+        JSON.stringify({
+          MediaContainer: {
+            size: 1,
+            totalSize: 100_000,
+            Metadata: [entry({ ratingKey: "1" })],
+          },
+        }),
+      );
+    });
+    const client = createPlexClient({ baseUrl: stub.url, token: "t", libraryRoot: LIB_ROOT });
+    await assert.rejects(
+      () => client.fetchPlaylist(1),
+      (err: unknown) => err instanceof PlexApiError && err.detail.kind === "too_many_tracks",
+    );
+  });
+
+  it("PlexApiError.toJSON() serializes cleanly and redacts Error.stack from network.cause", async () => {
+    const err = new PlexApiError(
+      { kind: "network", cause: Object.assign(new Error("ECONNREFUSED"), { code: "ECONNREFUSED" }) },
+      "plex network error",
+    );
+    const json = err.toJSON();
+    assert.equal(json.name, "PlexApiError");
+    assert.equal(json.message, "plex network error");
+    if (json.detail.kind !== "network") throw new Error("expected network kind");
+    const cause = json.detail.cause as { name: string; message: string; code: string };
+    assert.equal(cause.message, "ECONNREFUSED");
+    assert.equal(cause.code, "ECONNREFUSED");
+    // Verify that JSON.stringify can round-trip without blowing up on circular stacks.
+    const text = JSON.stringify(err);
+    assert.ok(text.includes("ECONNREFUSED"));
+    assert.equal(text.includes("at "), false, "stack should not be in JSON output");
+  });
+
+  it("default onSkip is a no-op — no console spam", async () => {
+    const originalWarn = console.warn;
+    let warnCalls = 0;
+    console.warn = () => {
+      warnCalls++;
+    };
+    try {
+      stub.setHandler((_req, res) => {
+        res.end(
+          JSON.stringify(
+            plexPlaylistFixture({
+              metadata: [entry({ ratingKey: "1", type: "episode" })],
+            }),
+          ),
+        );
+      });
+      const client = createPlexClient({ baseUrl: stub.url, token: "t", libraryRoot: LIB_ROOT });
+      const result = await client.fetchPlaylist(1);
+      assert.equal(result.skipped, 1);
+      assert.equal(warnCalls, 0, "default onSkip must not call console.warn");
+    } finally {
+      console.warn = originalWarn;
+    }
+  });
+});

--- a/apps/engine/src/plex/client.test.ts
+++ b/apps/engine/src/plex/client.test.ts
@@ -433,6 +433,42 @@ describe("PlexClient.fetchPlaylist", () => {
     assert.equal(result.tracks.length, 1);
   });
 
+  it("path_outside_library: accepts in-library paths whose names start with dots (e.g. '...And You Will Know Us')", async () => {
+    // Regression: a naive `rel.startsWith('..')` parent-escape check
+    // would reject real folders like "...And You Will Know Us by the
+    // Trail of Dead". They are legitimately inside the library.
+    const skips: PlexSkipReason[] = [];
+    stub.setHandler((_req, res) => {
+      res.end(
+        JSON.stringify(
+          plexPlaylistFixture({
+            metadata: [
+              entry({
+                ratingKey: "1",
+                title: "Another Morning Stoner",
+                file: `${LIB_ROOT}/...And You Will Know Us by the Trail of Dead/Source Tags & Codes/01 - Another Morning Stoner.mp3`,
+              }),
+              entry({
+                ratingKey: "2",
+                title: "Hidden",
+                file: `${LIB_ROOT}/.hidden-dir/track.mp3`,
+              }),
+            ],
+          }),
+        ),
+      );
+    });
+    const client = createPlexClient({
+      baseUrl: stub.url,
+      token: "t",
+      libraryRoot: LIB_ROOT,
+      onSkip: (r) => skips.push(r),
+    });
+    const result = await client.fetchPlaylist(1);
+    assert.equal(result.tracks.length, 2, `skips=${JSON.stringify(skips)}`);
+    assert.equal(result.skipped, 0);
+  });
+
   it("non-track Metadata entries (videos, episodes) are skipped with reason 'not_a_track'", async () => {
     const skips: PlexSkipReason[] = [];
     stub.setHandler((_req, res) => {

--- a/apps/engine/src/plex/client.test.ts
+++ b/apps/engine/src/plex/client.test.ts
@@ -524,6 +524,69 @@ describe("PlexClient.fetchPlaylist", () => {
     assert.equal(skips.filter((s) => s.reason === "invalid_rating_key").length, 4);
   });
 
+  it("body stream termination (not a JSON parse error) is classified as network, not invalid_response", async () => {
+    // Simulates Plex dropping the connection after headers are sent but
+    // before the body is fully written. fetch() will reject res.json()
+    // with a TypeError ("terminated"), not a SyntaxError. Supervisors
+    // must treat this as retryable network failure, not malformed data.
+    stub.setHandler(async (_req, res) => {
+      res.setHeader("content-type", "application/json");
+      res.flushHeaders();
+      res.write("{\"MediaContainer\":{\"size\":5");
+      res.destroy();
+    });
+    const client = createPlexClient({
+      baseUrl: stub.url,
+      token: "t",
+      libraryRoot: LIB_ROOT,
+      timeoutMs: 3000,
+    });
+    await assert.rejects(
+      () => client.fetchPlaylist(1),
+      (err: unknown) => err instanceof PlexApiError && err.detail.kind === "network",
+    );
+  });
+
+  it("body that parses but isn't JSON (HTML page) is classified as invalid_response, not network", async () => {
+    stub.setHandler((_req, res) => {
+      res.setHeader("content-type", "text/plain");
+      res.end("<html>Plex UI</html>");
+    });
+    const client = createPlexClient({ baseUrl: stub.url, token: "t", libraryRoot: LIB_ROOT });
+    await assert.rejects(
+      () => client.fetchPlaylist(1),
+      (err: unknown) => err instanceof PlexApiError && err.detail.kind === "invalid_response",
+    );
+  });
+
+  it("blank/whitespace-only grandparentTitle falls back to 'Unknown artist' with stable hash", async () => {
+    // Same identity whether Plex sends null, omits the field, or sends "".
+    stub.setHandler((_req, res) => {
+      res.end(
+        JSON.stringify({
+          MediaContainer: {
+            size: 3,
+            totalSize: 3,
+            Metadata: [
+              { ratingKey: "1", type: "track", title: "T", grandparentTitle: null, parentTitle: "A", parentYear: 2020, duration: 100_000, Media: [{ Part: [{ file: `${LIB_ROOT}/a.mp3` }] }] },
+              { ratingKey: "2", type: "track", title: "T", grandparentTitle: "",   parentTitle: "A", parentYear: 2020, duration: 100_000, Media: [{ Part: [{ file: `${LIB_ROOT}/b.mp3` }] }] },
+              { ratingKey: "3", type: "track", title: "T", grandparentTitle: "   ", parentTitle: "A", parentYear: 2020, duration: 100_000, Media: [{ Part: [{ file: `${LIB_ROOT}/c.mp3` }] }] },
+            ],
+          },
+        }),
+      );
+    });
+    const client = createPlexClient({ baseUrl: stub.url, token: "t", libraryRoot: LIB_ROOT });
+    const result = await client.fetchPlaylist(1);
+    assert.equal(result.tracks.length, 3);
+    assert.ok(
+      result.tracks.every((tr) => tr.artist === "Unknown artist"),
+      `all three should normalize to Unknown artist, got ${result.tracks.map((tr) => tr.artist).join(", ")}`,
+    );
+    const hashes = new Set(result.tracks.map((tr) => tr.fallbackHash));
+    assert.equal(hashes.size, 1, `expected one fallback hash for three identical missing-artist tracks, got ${[...hashes].join(", ")}`);
+  });
+
   it("timeout: when Plex never responds within timeoutMs → PlexApiError{kind:'timeout'}", async () => {
     stub.setHandler(async (_req, res) => {
       await new Promise(() => {});

--- a/apps/engine/src/plex/client.test.ts
+++ b/apps/engine/src/plex/client.test.ts
@@ -322,6 +322,35 @@ describe("PlexClient.fetchPlaylist", () => {
     );
   });
 
+  it("inconsistent container: size !== Metadata.length (any mismatch) → invalid_response", async () => {
+    // Covers the subtle case where Plex returns some items but reports a
+    // different size — advancing pagination by `size` would skip or
+    // re-read items. Must reject, not paper over.
+    stub.setHandler((_req, res) => {
+      res.end(
+        JSON.stringify({
+          MediaContainer: {
+            size: 5,
+            totalSize: 5,
+            Metadata: [
+              entry({ ratingKey: "1" }),
+              entry({ ratingKey: "2" }),
+              entry({ ratingKey: "3" }),
+            ],
+          },
+        }),
+      );
+    });
+    const client = createPlexClient({ baseUrl: stub.url, token: "t", libraryRoot: LIB_ROOT });
+    await assert.rejects(
+      () => client.fetchPlaylist(1),
+      (err: unknown) =>
+        err instanceof PlexApiError &&
+        err.detail.kind === "invalid_response" &&
+        err.detail.issues.some((i) => i.includes("Metadata.length=3")),
+    );
+  });
+
   it("tolerates nullable Plex fields (grandparentTitle/parentTitle/parentYear/duration/thumb = null)", async () => {
     stub.setHandler((_req, res) => {
       res.end(

--- a/apps/engine/src/plex/client.test.ts
+++ b/apps/engine/src/plex/client.test.ts
@@ -577,6 +577,37 @@ describe("PlexClient.fetchPlaylist", () => {
     assert.ok(stub.requests.length >= 3, `expected multiple page requests, got ${stub.requests.length}`);
   });
 
+  it("paginates without totalSize: keeps paging until a short page arrives", async () => {
+    // Plex sometimes omits totalSize. Ensure we don't stop after the
+    // first page just because we can't read a total.
+    stub.setHandler((req, res) => {
+      const url = new URL(req.url ?? "", "http://x");
+      const start = Number(url.searchParams.get("X-Plex-Container-Start") ?? "0");
+      const all = [
+        entry({ ratingKey: "10" }),
+        entry({ ratingKey: "20" }),
+        entry({ ratingKey: "30" }),
+        entry({ ratingKey: "40" }),
+        entry({ ratingKey: "50" }),
+      ];
+      const pageSize = 2;
+      const sliced = all.slice(start, start + pageSize);
+      res.end(
+        JSON.stringify({
+          // totalSize intentionally omitted.
+          MediaContainer: { size: sliced.length, Metadata: sliced },
+        }),
+      );
+    });
+    const client = createPlexClient({ baseUrl: stub.url, token: "t", libraryRoot: LIB_ROOT });
+    const result = await client.fetchPlaylist(1);
+    assert.equal(result.tracks.length, 5);
+    assert.deepEqual(
+      result.tracks.map((t) => t.plexRatingKey),
+      [10, 20, 30, 40, 50],
+    );
+  });
+
   it("too-many-tracks: refuses a Plex response claiming totalSize > 50_000", async () => {
     stub.setHandler((_req, res) => {
       res.end(

--- a/apps/engine/src/plex/client.ts
+++ b/apps/engine/src/plex/client.ts
@@ -127,7 +127,7 @@ export function createPlexClient(config: PlexClientConfig): PlexClient {
     ratingKey: number,
     start: number,
     size: number,
-  ): Promise<{ size: number; totalSize: number; metadata: PlexTrackMetadataT[] }> {
+  ): Promise<{ size: number; totalSize: number | undefined; metadata: PlexTrackMetadataT[] }> {
     const url = `${root}/playlists/${ratingKey}/items?X-Plex-Container-Start=${start}&X-Plex-Container-Size=${size}`;
     const ac = new AbortController();
     const timer = setTimeout(() => ac.abort(), timeoutMs);
@@ -192,7 +192,11 @@ export function createPlexClient(config: PlexClientConfig): PlexClient {
       const mc = parsed.data.MediaContainer;
       const metadata = mc.Metadata ?? [];
       const pageSize = mc.size;
-      const totalSize = mc.totalSize ?? pageSize;
+      // `totalSize` is advisory. Some Plex versions omit it; collapsing
+      // undefined → pageSize would falsely cap large playlists at one
+      // page. Return undefined when unknown and let the caller keep
+      // paging until it sees an empty page or hits MAX_TOTAL_TRACKS.
+      const totalSize = mc.totalSize ?? undefined;
 
       if (pageSize > 0 && metadata.length === 0) {
         throw new PlexApiError(
@@ -218,20 +222,22 @@ export function createPlexClient(config: PlexClientConfig): PlexClient {
     const tracks: Track[] = [];
     let skipped = 0;
     let fetched = 0;
-    let totalSize = Infinity;
+    let totalSize: number | undefined;
 
-    while (fetched < totalSize) {
+    while (totalSize === undefined || fetched < totalSize) {
       const page = await fetchPage(ratingKey, fetched, REQUEST_PAGE_SIZE);
-      totalSize = page.totalSize;
+      // Adopt totalSize the first time Plex reports it. If Plex keeps
+      // omitting it, we keep paging until a short page arrives.
+      totalSize = page.totalSize ?? totalSize;
 
-      if (totalSize > MAX_TOTAL_TRACKS) {
+      if (totalSize !== undefined && totalSize > MAX_TOTAL_TRACKS) {
         throw new PlexApiError(
           { kind: "too_many_tracks", limit: MAX_TOTAL_TRACKS },
           `playlist ${ratingKey} reports totalSize=${totalSize}, refusing (limit ${MAX_TOTAL_TRACKS})`,
         );
       }
 
-      if (page.metadata.length === 0) break; // empty playlist, escape
+      if (page.metadata.length === 0) break; // nothing left, escape
 
       for (const entry of page.metadata) {
         const track = mapEntryToTrack(entry, libRootAbsolute, onSkip);
@@ -244,9 +250,15 @@ export function createPlexClient(config: PlexClientConfig): PlexClient {
 
       fetched += page.size;
 
-      // Defensive: if Plex reports totalSize but returned 0 items on a
-      // non-first page, stop to avoid an infinite loop.
-      if (page.size === 0) break;
+      // Circuit breaker: if Plex never reports totalSize, refuse to
+      // keep paging past the ceiling. Protects against a broken Plex
+      // response pinning the engine in an infinite paging loop.
+      if (totalSize === undefined && fetched >= MAX_TOTAL_TRACKS) {
+        throw new PlexApiError(
+          { kind: "too_many_tracks", limit: MAX_TOTAL_TRACKS },
+          `playlist ${ratingKey} reached ${MAX_TOTAL_TRACKS} items without Plex reporting totalSize`,
+        );
+      }
     }
 
     return { ratingKey, tracks, skipped };
@@ -270,13 +282,13 @@ function mapEntryToTrack(
     return null;
   }
 
-  const firstMedia = entry.Media[0];
+  const firstMedia = entry.Media?.[0];
   if (firstMedia === undefined) {
     onSkip({ ratingKey: entry.ratingKey, title: entry.title, reason: "missing_media" });
     return null;
   }
-  const firstPart = firstMedia.Part[0];
-  if (firstPart === undefined || firstPart.file === "") {
+  const firstPart = firstMedia.Part?.[0];
+  if (firstPart === undefined || !firstPart.file) {
     onSkip({ ratingKey: entry.ratingKey, title: entry.title, reason: "empty_path" });
     return null;
   }

--- a/apps/engine/src/plex/client.ts
+++ b/apps/engine/src/plex/client.ts
@@ -306,9 +306,18 @@ function mapEntryToTrack(
   // the library are legitimate use in this project.
   const resolved = resolvePath(firstPart.file);
   const rel = relativePath(libRootAbsolute, resolved);
+  // `rel` starts with `..` only when the path escapes the root — but we
+  // must distinguish the parent-traversal segment `..` / `../` from
+  // ordinary directory names that merely begin with dots, e.g. the band
+  // "…And You Will Know Us by the Trail of Dead" ships with folders like
+  // `...And You Will Know Us/…`. A naive `startsWith("..")` would reject
+  // those as outside-library. The correct parent-escape test is:
+  // relative path is empty (== root itself), equals `..`, or starts with
+  // `../` (POSIX) — which can only come from real parent traversal.
   const outsideLib =
     rel === "" ||
-    rel.startsWith("..") ||
+    rel === ".." ||
+    rel.startsWith("../") ||
     (rel.length >= 1 && rel[0] === "/"); // rel is absolute → outside root
   if (outsideLib) {
     onSkip({

--- a/apps/engine/src/plex/client.ts
+++ b/apps/engine/src/plex/client.ts
@@ -198,10 +198,17 @@ export function createPlexClient(config: PlexClientConfig): PlexClient {
       // paging until it sees an empty page or hits MAX_TOTAL_TRACKS.
       const totalSize = mc.totalSize ?? undefined;
 
-      if (pageSize > 0 && metadata.length === 0) {
+      // Pagination advances `fetched` by `pageSize`. Any mismatch between
+      // `pageSize` and the actual metadata array length would cause us to
+      // silently skip or re-read items, or loop forever on a zero-size
+      // non-empty page. Reject the whole response rather than paper over it.
+      if (pageSize !== metadata.length) {
         throw new PlexApiError(
-          { kind: "invalid_response", issues: [`MediaContainer.size=${pageSize} but Metadata is empty`] },
-          `plex response inconsistent: size=${pageSize} Metadata.length=0`,
+          {
+            kind: "invalid_response",
+            issues: [`MediaContainer.size=${pageSize} but Metadata.length=${metadata.length}`],
+          },
+          `plex response inconsistent: size=${pageSize} Metadata.length=${metadata.length}`,
         );
       }
 

--- a/apps/engine/src/plex/client.ts
+++ b/apps/engine/src/plex/client.ts
@@ -1,0 +1,332 @@
+// Plex HTTP client for v3 engine.
+//
+// Single responsibility: given a playlist ratingKey, return a list of
+// playable Track objects. No caching, no retries — the caller (stage
+// supervisor, lands in Task 3) decides the polling cadence (60s per
+// SLIM_V3 §"Audio engine").
+//
+// Error taxonomy is structured so supervisors can react differently to
+// "we need to retry" (network) vs "this stage is broken and needs
+// curator attention" (auth / not-found).
+
+import { resolve as resolvePath, relative as relativePath } from "node:path";
+import type { Track } from "@pavoia/shared";
+import { PlexPlaylistItemsResponse } from "./schema.ts";
+import type { PlexTrackMetadataT } from "./schema.ts";
+import { fallbackHash } from "./fallback-hash.ts";
+
+/** Hard ceiling for how many items we'll pull from a single playlist.
+ *  Largest current stage (bermuda-night) is 2040 tracks; 20 000 gives
+ *  plenty of headroom, and Plex's self-imposed per-request cap is
+ *  usually much higher on self-hosted installs. Pagination kicks in
+ *  if a playlist exceeds this — see fetchPlaylist below. */
+const REQUEST_PAGE_SIZE = 5000;
+
+/** Hard ceiling across all pages — refuses to keep paginating if a
+ *  playlist ever gets absurdly large (which would indicate a Plex bug
+ *  or a malicious response). */
+const MAX_TOTAL_TRACKS = 50_000;
+
+export type PlexClientConfig = {
+  /** Base URL of the Plex server, including scheme + port. e.g. `http://127.0.0.1:31711`. */
+  baseUrl: string;
+  /** Plex auth token (`X-Plex-Token`). Sent as header, never in query string. */
+  token: string;
+  /** Absolute library root — every track's `Part.file` must resolve to a path
+      inside this directory or it is dropped (Req D security guard).
+      Comparison is done via `path.resolve` so `..` traversal is rejected. */
+  libraryRoot: string;
+  /** Abort the HTTP request (headers AND body) if Plex doesn't respond
+      within this many ms. Defaults to 10 s. */
+  timeoutMs?: number;
+  /** Override for tests. Shape matches the global `fetch`. */
+  fetchImpl?: typeof fetch;
+  /** Called once per skipped track with a human-readable reason.
+      Defaults to a silent no-op; the stage supervisor (Task 3) is where
+      dedup / log cadence decisions belong, not inside the client. */
+  onSkip?: (reason: PlexSkipReason) => void;
+};
+
+export type PlexSkipReason = {
+  ratingKey: string | null;
+  title: string | null;
+  reason:
+    | "not_a_track"
+    | "missing_media"
+    | "empty_path"
+    | "path_outside_library"
+    | "invalid_rating_key";
+  detail?: string;
+};
+
+export type PlexError =
+  | { kind: "network"; cause: unknown }
+  | { kind: "timeout"; timeoutMs: number }
+  | { kind: "auth" }
+  | { kind: "not_found"; ratingKey: number }
+  | { kind: "server"; status: number }
+  | { kind: "unexpected_status"; status: number }
+  | { kind: "invalid_response"; issues: string[] }
+  | { kind: "too_many_tracks"; limit: number };
+
+export class PlexApiError extends Error {
+  readonly detail: PlexError;
+  constructor(detail: PlexError, message?: string) {
+    super(message ?? detail.kind);
+    this.name = "PlexApiError";
+    this.detail = detail;
+  }
+
+  /** Structured serializer for logs. Redacts `cause.stack` to keep log
+   *  lines bounded, and never includes the token (which isn't in `detail`
+   *  anyway — constructor never stores it). */
+  toJSON(): { name: string; message: string; detail: PlexError } {
+    let detail = this.detail;
+    if (detail.kind === "network") {
+      const c = detail.cause;
+      detail = {
+        kind: "network",
+        cause:
+          c instanceof Error
+            ? { name: c.name, message: c.message, code: (c as NodeJS.ErrnoException).code }
+            : typeof c === "object"
+              ? String(c)
+              : c,
+      };
+    }
+    return { name: this.name, message: this.message, detail };
+  }
+}
+
+export type FetchPlaylistResult = {
+  ratingKey: number;
+  tracks: Track[];
+  /** Count of Plex entries that were dropped (non-track type, missing file,
+      path outside library). Observability — callers can surface in /health. */
+  skipped: number;
+};
+
+export type PlexClient = {
+  fetchPlaylist(ratingKey: number): Promise<FetchPlaylistResult>;
+};
+
+export function createPlexClient(config: PlexClientConfig): PlexClient {
+  const {
+    baseUrl,
+    token,
+    libraryRoot,
+    timeoutMs = 10_000,
+    fetchImpl = fetch,
+    onSkip = () => {},
+  } = config;
+
+  const root = baseUrl.replace(/\/+$/, "");
+  const libRootAbsolute = resolvePath(libraryRoot);
+
+  async function fetchPage(
+    ratingKey: number,
+    start: number,
+    size: number,
+  ): Promise<{ size: number; totalSize: number; metadata: PlexTrackMetadataT[] }> {
+    const url = `${root}/playlists/${ratingKey}/items?X-Plex-Container-Start=${start}&X-Plex-Container-Size=${size}`;
+    const ac = new AbortController();
+    const timer = setTimeout(() => ac.abort(), timeoutMs);
+
+    try {
+      let res: Response;
+      try {
+        res = await fetchImpl(url, {
+          method: "GET",
+          signal: ac.signal,
+          headers: {
+            Accept: "application/json",
+            "X-Plex-Token": token,
+          },
+        });
+      } catch (err) {
+        if ((err as { name?: string })?.name === "AbortError") {
+          throw new PlexApiError({ kind: "timeout", timeoutMs }, `plex timed out after ${timeoutMs}ms`);
+        }
+        throw new PlexApiError({ kind: "network", cause: err }, "plex network error");
+      }
+
+      if (res.status === 401 || res.status === 403) {
+        throw new PlexApiError({ kind: "auth" }, "plex auth rejected");
+      }
+      if (res.status === 404) {
+        throw new PlexApiError({ kind: "not_found", ratingKey }, `plex playlist ${ratingKey} not found`);
+      }
+      if (res.status >= 500) {
+        throw new PlexApiError({ kind: "server", status: res.status }, `plex server error ${res.status}`);
+      }
+      if (res.status < 200 || res.status >= 300) {
+        throw new PlexApiError({ kind: "unexpected_status", status: res.status }, `plex unexpected status ${res.status}`);
+      }
+
+      let payload: unknown;
+      try {
+        // Body read is inside the abort timer; if Plex stalls mid-body,
+        // the AbortController will cancel the stream.
+        payload = await res.json();
+      } catch (err) {
+        if ((err as { name?: string })?.name === "AbortError") {
+          throw new PlexApiError({ kind: "timeout", timeoutMs }, `plex body read timed out after ${timeoutMs}ms`);
+        }
+        throw new PlexApiError(
+          { kind: "invalid_response", issues: ["response body is not valid JSON"] },
+          `plex returned non-JSON response: ${(err as Error).message}`,
+        );
+      }
+
+      const parsed = PlexPlaylistItemsResponse.safeParse(payload);
+      if (!parsed.success) {
+        const issues = parsed.error.issues.map(
+          (i) => `${i.path.join(".") || "<root>"}: ${i.message}`,
+        );
+        throw new PlexApiError(
+          { kind: "invalid_response", issues },
+          `plex response failed schema validation: ${issues.slice(0, 3).join("; ")}`,
+        );
+      }
+
+      const mc = parsed.data.MediaContainer;
+      const metadata = mc.Metadata ?? [];
+      const pageSize = mc.size;
+      const totalSize = mc.totalSize ?? pageSize;
+
+      if (pageSize > 0 && metadata.length === 0) {
+        throw new PlexApiError(
+          { kind: "invalid_response", issues: [`MediaContainer.size=${pageSize} but Metadata is empty`] },
+          `plex response inconsistent: size=${pageSize} Metadata.length=0`,
+        );
+      }
+
+      return { size: pageSize, totalSize, metadata };
+    } finally {
+      clearTimeout(timer);
+    }
+  }
+
+  async function fetchPlaylist(ratingKey: number): Promise<FetchPlaylistResult> {
+    if (!Number.isSafeInteger(ratingKey) || ratingKey < 1) {
+      throw new PlexApiError(
+        { kind: "invalid_response", issues: [`invalid ratingKey: ${ratingKey}`] },
+        `invalid ratingKey: ${ratingKey}`,
+      );
+    }
+
+    const tracks: Track[] = [];
+    let skipped = 0;
+    let fetched = 0;
+    let totalSize = Infinity;
+
+    while (fetched < totalSize) {
+      const page = await fetchPage(ratingKey, fetched, REQUEST_PAGE_SIZE);
+      totalSize = page.totalSize;
+
+      if (totalSize > MAX_TOTAL_TRACKS) {
+        throw new PlexApiError(
+          { kind: "too_many_tracks", limit: MAX_TOTAL_TRACKS },
+          `playlist ${ratingKey} reports totalSize=${totalSize}, refusing (limit ${MAX_TOTAL_TRACKS})`,
+        );
+      }
+
+      if (page.metadata.length === 0) break; // empty playlist, escape
+
+      for (const entry of page.metadata) {
+        const track = mapEntryToTrack(entry, libRootAbsolute, onSkip);
+        if (track === null) {
+          skipped++;
+          continue;
+        }
+        tracks.push(track);
+      }
+
+      fetched += page.size;
+
+      // Defensive: if Plex reports totalSize but returned 0 items on a
+      // non-first page, stop to avoid an infinite loop.
+      if (page.size === 0) break;
+    }
+
+    return { ratingKey, tracks, skipped };
+  }
+
+  return { fetchPlaylist };
+}
+
+function mapEntryToTrack(
+  entry: PlexTrackMetadataT,
+  libRootAbsolute: string,
+  onSkip: (r: PlexSkipReason) => void,
+): Track | null {
+  if (entry.type !== "track") {
+    onSkip({
+      ratingKey: entry.ratingKey,
+      title: entry.title,
+      reason: "not_a_track",
+      detail: `type=${entry.type}`,
+    });
+    return null;
+  }
+
+  const firstMedia = entry.Media[0];
+  if (firstMedia === undefined) {
+    onSkip({ ratingKey: entry.ratingKey, title: entry.title, reason: "missing_media" });
+    return null;
+  }
+  const firstPart = firstMedia.Part[0];
+  if (firstPart === undefined || firstPart.file === "") {
+    onSkip({ ratingKey: entry.ratingKey, title: entry.title, reason: "empty_path" });
+    return null;
+  }
+
+  // Normalize away `..` components and symlink-style relative prefixes.
+  // We intentionally don't `realpath` — that would require the file to
+  // exist on disk, which isn't true on the dev machine, and symlinks inside
+  // the library are legitimate use in this project.
+  const resolved = resolvePath(firstPart.file);
+  const rel = relativePath(libRootAbsolute, resolved);
+  const outsideLib =
+    rel === "" ||
+    rel.startsWith("..") ||
+    (rel.length >= 1 && rel[0] === "/"); // rel is absolute → outside root
+  if (outsideLib) {
+    onSkip({
+      ratingKey: entry.ratingKey,
+      title: entry.title,
+      reason: "path_outside_library",
+      detail: firstPart.file,
+    });
+    return null;
+  }
+
+  const ratingKeyNum = Number(entry.ratingKey);
+  if (!Number.isSafeInteger(ratingKeyNum) || ratingKeyNum < 1) {
+    onSkip({
+      ratingKey: entry.ratingKey,
+      title: entry.title,
+      reason: "invalid_rating_key",
+      detail: `ratingKey="${entry.ratingKey}"`,
+    });
+    return null;
+  }
+
+  const artist = entry.grandparentTitle ?? "Unknown artist";
+  const album = entry.parentTitle ?? "";
+
+  return {
+    plexRatingKey: ratingKeyNum,
+    fallbackHash: fallbackHash(artist, entry.title, album),
+    title: entry.title,
+    artist,
+    album,
+    albumYear: entry.parentYear ?? null,
+    durationSec:
+      entry.duration !== undefined && entry.duration !== null
+        ? Math.round(entry.duration / 1000)
+        : 0,
+    filePath: resolved,
+    coverUrl: entry.thumb ?? null,
+  };
+}

--- a/apps/engine/src/plex/client.ts
+++ b/apps/engine/src/plex/client.ts
@@ -169,12 +169,23 @@ export function createPlexClient(config: PlexClientConfig): PlexClient {
         // the AbortController will cancel the stream.
         payload = await res.json();
       } catch (err) {
-        if ((err as { name?: string })?.name === "AbortError") {
+        const errName = (err as { name?: string })?.name;
+        if (errName === "AbortError") {
           throw new PlexApiError({ kind: "timeout", timeoutMs }, `plex body read timed out after ${timeoutMs}ms`);
         }
+        // SyntaxError = JSON parse failure = genuinely malformed response.
+        // Anything else (TypeError "terminated", socket errors, etc.) is
+        // a transport failure after the headers arrived — classify as
+        // network so the supervisor knows it's retryable, not broken.
+        if (errName === "SyntaxError") {
+          throw new PlexApiError(
+            { kind: "invalid_response", issues: ["response body is not valid JSON"] },
+            `plex returned non-JSON response: ${(err as Error).message}`,
+          );
+        }
         throw new PlexApiError(
-          { kind: "invalid_response", issues: ["response body is not valid JSON"] },
-          `plex returned non-JSON response: ${(err as Error).message}`,
+          { kind: "network", cause: err },
+          `plex body read failed: ${(err as Error).message}`,
         );
       }
 
@@ -340,7 +351,12 @@ function mapEntryToTrack(
     return null;
   }
 
-  const artist = entry.grandparentTitle ?? "Unknown artist";
+  // Treat blank/whitespace-only `grandparentTitle` the same as null/undefined
+  // so a single "missing artist" case produces one stable fallbackHash
+  // (same identity) and the UI shows a consistent "Unknown artist" label.
+  const artist = entry.grandparentTitle?.trim()
+    ? entry.grandparentTitle
+    : "Unknown artist";
   const album = entry.parentTitle ?? "";
 
   return {

--- a/apps/engine/src/plex/fallback-hash.test.ts
+++ b/apps/engine/src/plex/fallback-hash.test.ts
@@ -1,0 +1,47 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+
+import { fallbackHash } from "./fallback-hash.ts";
+
+describe("fallbackHash", () => {
+  it("is deterministic — same inputs produce the same output", () => {
+    const a = fallbackHash("Aphex Twin", "Xtal", "Selected Ambient Works 85-92");
+    const b = fallbackHash("Aphex Twin", "Xtal", "Selected Ambient Works 85-92");
+    assert.equal(a, b);
+  });
+
+  it("produces 16 lowercase hex characters", () => {
+    const h = fallbackHash("a", "b", "c");
+    assert.match(h, /^[0-9a-f]{16}$/);
+  });
+
+  it("NFC-normalizes so composed vs decomposed Unicode hash identically", () => {
+    // U+00E9 (precomposed) vs U+0065 U+0301 (decomposed)
+    const precomposed = fallbackHash("Café", "Song", "Album");
+    const decomposed = fallbackHash("Cafe\u0301", "Song", "Album");
+    assert.equal(precomposed, decomposed);
+  });
+
+  it("trims surrounding whitespace before hashing", () => {
+    const tight = fallbackHash("Artist", "Title", "Album");
+    const padded = fallbackHash("  Artist  ", "\tTitle\n", " Album ");
+    assert.equal(tight, padded);
+  });
+
+  it("treats empty strings as stable inputs (not an error)", () => {
+    const h = fallbackHash("", "", "");
+    assert.match(h, /^[0-9a-f]{16}$/);
+  });
+
+  it("distinguishes tracks that only differ by album (avoids same-artist-same-title collisions)", () => {
+    const live = fallbackHash("Artist", "Song", "Live at Glastonbury");
+    const studio = fallbackHash("Artist", "Song", "Debut");
+    assert.notEqual(live, studio);
+  });
+
+  it("uses a NUL separator so (a|b|c) != (ab||c) — no adjacent-field collisions", () => {
+    const split = fallbackHash("ab", "", "c");
+    const joined = fallbackHash("a", "bc", "");
+    assert.notEqual(split, joined);
+  });
+});

--- a/apps/engine/src/plex/fallback-hash.ts
+++ b/apps/engine/src/plex/fallback-hash.ts
@@ -1,0 +1,30 @@
+import { createHash } from "node:crypto";
+
+/**
+ * Stable identity hash for a track independent of Plex's `ratingKey`.
+ *
+ * Plex re-indexes (library scans, metadata updates) can rotate `ratingKey`
+ * for the same underlying file. We need a second identity token so play
+ * history and discovery feeds survive re-indexes. This composes the three
+ * human-facing strings that together identify a track in practice.
+ *
+ * Per WEEK0_LOG.md / SLIM_V3 Codex finding #21:
+ *   Track identity = (plex_rating_key, fallback_hash(artist, title, album))
+ *
+ * Output: 16 hex chars of a SHA-256 (64 bits of entropy — enough to make
+ * accidental collisions on a library of ~20k tracks vanishingly unlikely,
+ * short enough to fit in log lines).
+ *
+ * Inputs are NFC-normalised before hashing so `é` (U+00E9) and `é`
+ * (U+0065 + U+0301) hash identically.
+ */
+export function fallbackHash(
+  artist: string,
+  title: string,
+  album: string,
+): string {
+  const canon = [artist, title, album]
+    .map((s) => s.normalize("NFC").trim())
+    .join("\u0000");
+  return createHash("sha256").update(canon, "utf8").digest("hex").slice(0, 16);
+}

--- a/apps/engine/src/plex/index.ts
+++ b/apps/engine/src/plex/index.ts
@@ -1,0 +1,9 @@
+export { createPlexClient, PlexApiError } from "./client.ts";
+export type {
+  PlexClient,
+  PlexClientConfig,
+  PlexError,
+  PlexSkipReason,
+  FetchPlaylistResult,
+} from "./client.ts";
+export { fallbackHash } from "./fallback-hash.ts";

--- a/apps/engine/src/plex/schema.ts
+++ b/apps/engine/src/plex/schema.ts
@@ -1,0 +1,57 @@
+// Zod schemas for the subset of Plex's `/playlists/:id/items` JSON that v3
+// actually consumes. Plex returns a much larger payload; we parse only the
+// fields we need and tolerate unknowns via `.loose()` so a future Plex
+// version that adds keys won't crash the engine.
+//
+// Optional fields use `.nullish()` because Plex is inconsistent — sometimes
+// keys are omitted, sometimes present as `null`, sometimes as empty string.
+//
+// References:
+//   - WEEK0_LOG.md Step 1 — verified `<Part file="...">` is a direct fs path
+//   - SLIM_V3 Codex finding #9 — "Plex API media paths may not be direct fs"
+//     (resolved: verified they are, for this library, UTF-8 end-to-end)
+
+import { z } from "zod";
+
+export const PlexPart = z
+  .object({
+    file: z.string().min(1),
+    size: z.number().int().nonnegative().nullish(),
+  })
+  .loose();
+
+export const PlexMedia = z
+  .object({
+    Part: z.array(PlexPart).min(1),
+  })
+  .loose();
+
+export const PlexTrackMetadata = z
+  .object({
+    ratingKey: z.string().min(1),
+    type: z.string(),
+    title: z.string(),
+    grandparentTitle: z.string().nullish(),
+    parentTitle: z.string().nullish(),
+    parentYear: z.number().int().nullish(),
+    duration: z.number().int().nonnegative().nullish(),
+    thumb: z.string().nullish(),
+    Media: z.array(PlexMedia).min(1),
+  })
+  .loose();
+
+export const PlexPlaylistItemsResponse = z
+  .object({
+    MediaContainer: z
+      .object({
+        size: z.number().int().nonnegative(),
+        totalSize: z.number().int().nonnegative().nullish(),
+        Metadata: z.array(PlexTrackMetadata).nullish(),
+      })
+      .loose(),
+  })
+  .loose();
+
+export type PlexPartT = z.infer<typeof PlexPart>;
+export type PlexTrackMetadataT = z.infer<typeof PlexTrackMetadata>;
+export type PlexPlaylistItemsResponseT = z.infer<typeof PlexPlaylistItemsResponse>;

--- a/apps/engine/src/plex/schema.ts
+++ b/apps/engine/src/plex/schema.ts
@@ -6,6 +6,12 @@
 // Optional fields use `.nullish()` because Plex is inconsistent — sometimes
 // keys are omitted, sometimes present as `null`, sometimes as empty string.
 //
+// Per-item constraints are intentionally lax (`file` can be empty/missing,
+// `Part` / `Media` can be empty arrays). A single malformed Plex row must
+// NOT fail the whole playlist with `invalid_response`; the mapper in
+// client.ts checks these fields and routes malformed rows to `skipped`
+// via the `empty_path` / `missing_media` reasons.
+//
 // References:
 //   - WEEK0_LOG.md Step 1 — verified `<Part file="...">` is a direct fs path
 //   - SLIM_V3 Codex finding #9 — "Plex API media paths may not be direct fs"
@@ -15,14 +21,14 @@ import { z } from "zod";
 
 export const PlexPart = z
   .object({
-    file: z.string().min(1),
+    file: z.string().nullish(),
     size: z.number().int().nonnegative().nullish(),
   })
   .loose();
 
 export const PlexMedia = z
   .object({
-    Part: z.array(PlexPart).min(1),
+    Part: z.array(PlexPart).nullish(),
   })
   .loose();
 
@@ -36,7 +42,7 @@ export const PlexTrackMetadata = z
     parentYear: z.number().int().nullish(),
     duration: z.number().int().nonnegative().nullish(),
     thumb: z.string().nullish(),
-    Media: z.array(PlexMedia).min(1),
+    Media: z.array(PlexMedia).nullish(),
   })
   .loose();
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,8 @@
       "dependencies": {
         "@hono/node-server": "^2.0.0",
         "@pavoia/shared": "0.0.0",
-        "hono": "^4.12.14"
+        "hono": "^4.12.14",
+        "zod": "^4.3.6"
       },
       "devDependencies": {
         "@types/node": "^22.19.17",
@@ -417,9 +418,21 @@
         "node": ">=12"
       }
     },
+    "node_modules/zod": {
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
+      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
     "packages/shared": {
       "name": "@pavoia/shared",
-      "version": "0.0.0"
+      "version": "0.0.0",
+      "dependencies": {
+        "zod": "^4.3.6"
+      }
     }
   }
 }

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -22,5 +22,8 @@
   "scripts": {
     "build": "tsc --build",
     "clean": "tsc --build --clean"
+  },
+  "dependencies": {
+    "zod": "^4.3.6"
   }
 }

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -34,6 +34,14 @@ export type Stage = {
   disabled: boolean;
 };
 
+/**
+ * **Engine-only track shape.** Contains the absolute filesystem path on
+ * Whatbox (`filePath`) — NEVER serialize this over HTTP or WebSocket. All
+ * client-facing code must project it to {@link PublicTrack} via
+ * {@link toPublicTrack} first.
+ *
+ * @internal
+ */
 export type Track = {
   plexRatingKey: number;
   /** Fallback identity when Plex ratingKey rotates after library maintenance. */
@@ -45,12 +53,25 @@ export type Track = {
   durationSec: number;
   /** Absolute filesystem path on Whatbox. Used by engine only, never sent to clients. */
   filePath: string;
+  /** Plex-relative thumbnail path (no token). Engine proxies via /art/:ratingKey. */
   coverUrl: string | null;
 };
 
+/**
+ * The track shape that is safe to send to clients over HTTP or WebSocket.
+ * Derived from {@link Track} by stripping `filePath`.
+ */
+export type PublicTrack = Omit<Track, "filePath">;
+
+/** Project an engine-internal Track into a client-safe PublicTrack. */
+export function toPublicTrack(t: Track): PublicTrack {
+  const { filePath: _filePath, ...publicFields } = t;
+  return publicFields;
+}
+
 export type NowPlaying = {
   stageId: StageId;
-  track: Track | null;
+  track: PublicTrack | null;
   /** Wall-clock epoch when the track started encoding. */
   startedAt: number;
   /** HLS m3u8 URL for this stage. */
@@ -60,7 +81,7 @@ export type NowPlaying = {
 export type TrackChangedEvent = {
   type: "track_changed";
   stageId: StageId;
-  track: Track;
+  track: PublicTrack;
   startedAt: number;
 };
 

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -59,14 +59,38 @@ export type Track = {
 
 /**
  * The track shape that is safe to send to clients over HTTP or WebSocket.
- * Derived from {@link Track} by stripping `filePath`.
+ *
+ * Uses an **allowlist** projection (`Pick`) rather than a denylist
+ * (`Omit<Track, "filePath">`) so that any new engine-internal field added
+ * to {@link Track} later — a debug log path, a signed URL, a local cache
+ * marker, etc. — does NOT automatically leak to clients. Each new public
+ * field has to be added here explicitly, making the audit trail obvious.
  */
-export type PublicTrack = Omit<Track, "filePath">;
+export type PublicTrack = Pick<
+  Track,
+  | "plexRatingKey"
+  | "fallbackHash"
+  | "title"
+  | "artist"
+  | "album"
+  | "albumYear"
+  | "durationSec"
+  | "coverUrl"
+>;
 
-/** Project an engine-internal Track into a client-safe PublicTrack. */
+/** Project an engine-internal Track into a client-safe PublicTrack.
+ *  Mirrors the {@link PublicTrack} Pick — keep them in sync. */
 export function toPublicTrack(t: Track): PublicTrack {
-  const { filePath: _filePath, ...publicFields } = t;
-  return publicFields;
+  return {
+    plexRatingKey: t.plexRatingKey,
+    fallbackHash: t.fallbackHash,
+    title: t.title,
+    artist: t.artist,
+    album: t.album,
+    albumYear: t.albumYear,
+    durationSec: t.durationSec,
+    coverUrl: t.coverUrl,
+  };
 }
 
 export type NowPlaying = {


### PR DESCRIPTION
## Summary

Week 1 Task 2. `fetchPlaylist(ratingKey)` returns a validated `Track[]` ready for the stage supervisor (Task 3) to feed ffmpeg. Stacked on top of #1 (`feat/week1-engine-bootstrap`).

## Why

The stage supervisor needs a clean Plex interface with a structured error taxonomy so it can react differently to *retryable* errors (network, timeout, 5xx) vs *stage-is-broken* errors (auth, not-found). Validation at the boundary with zod prevents Plex shape drift from taking down the engine.

## Design decisions

- **Single responsibility:** client returns tracks; no caching, no retries. The supervisor owns polling cadence (60 s per SLIM_V3 §Audio engine).
- **Pagination:** uses `X-Plex-Container-Start` / `X-Plex-Container-Size`. Page size 5 000, total cap 50 000 as a circuit breaker.
- **Error kinds:** `network` / `timeout` / `auth` / `not_found` / `server` / `unexpected_status` / `invalid_response` / `too_many_tracks`. `PlexApiError.toJSON()` redacts stack traces.
- **`Track` vs `PublicTrack`:** `Track` is `@internal`-tagged and contains `filePath`. `PublicTrack = Omit<Track, 'filePath'>` and is what `NowPlaying` / WS events expose. Prevents Whatbox fs paths from leaking to clients.

## Security hardening (from codex adversarial round)

- **Path traversal:** `path.resolve` + `path.relative` reject `opus/../outside.mp3`, prefix collisions (`opus-evil`), absolute paths, deep traversal — not a string prefix check.
- **X-Plex-Token:** sent as HTTP header only, never in URL (test asserts this case-insensitively).
- **Unsafe-integer ratingKeys:** `Number.isSafeInteger` (not `isInteger`) rejects `Number('9999999999999999999') → 10000000000000000000`.
- **Container consistency:** `size > 0` with empty `Metadata` → `invalid_response` instead of silently returning an empty playlist.
- **AbortController covers body:** timeout applies to headers AND body read, not just the initial connect.

## Test plan

- [x] 33 tests covering happy path, every error kind, 4 path-traversal attack vectors, nullable Plex fields, unsafe-int ratingKeys, pagination, body-stall timeouts, portable connection-refused, `toJSON` redaction, silent default `onSkip`.
- [x] `npm run typecheck` clean.
- [x] `npm test` passes 58/58 (25 from #1 + 33 here).
- [ ] Confirm stacked base auto-updates when #1 merges.
- [ ] CodeRabbit GitHub App review posts and is addressed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Plex v3 client for fetching paginated playlists and a deterministic fallback track hash.

* **Refactor**
  * Public API payloads now omit internal file path details via a new public track shape.

* **Tests**
  * Extensive tests for playlist retrieval, pagination, error classification, skip logic, and fallback-hash behavior.

* **Chores**
  * Added runtime schema validation support (zod) as a dependency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->