### PR TITLE
chore: enforce CodeRabbit review workflow

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,35 @@
+# CodeRabbit GitHub App configuration.
+# See https://docs.coderabbit.ai/reference/yaml-template for all options.
+#
+# Why this config:
+#   - CLAUDE.md mandates that every PR is opened as draft first, and only
+#     marked ready-for-review after CodeRabbit has posted a clean review.
+#     CodeRabbit's default behavior is to SKIP draft PRs, which would
+#     deadlock the workflow. Setting `drafts: true` makes drafts get
+#     reviewed automatically, which is what the workflow needs.
+#   - Language: English for review prose.
+
+language: en-US
+
+reviews:
+  profile: chill
+  request_changes_workflow: false
+  high_level_summary: true
+  poem: false
+  review_status: true
+  collapse_walkthrough: false
+
+  # Review drafts automatically — the repo's workflow keeps PRs in draft
+  # state until the review is clean, so this is the behavior we want.
+  auto_review:
+    enabled: true
+    drafts: true
+
+  # Post review comments on push updates so incremental commits also
+  # get reviewed without needing to re-request manually.
+  finishing_touches:
+    docstrings:
+      enabled: false
+
+chat:
+  auto_reply: true

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,1 +1,2 @@
+#!/usr/bin/env sh
 npm test

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,1 @@
+npm test

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -39,9 +39,13 @@ fi
 #   3. Fallback to origin/main
 BASE="${CODERABBIT_BASE:-}"
 if [ -z "$BASE" ] && command -v gh >/dev/null 2>&1; then
-  pr_base=$(gh pr view --json baseRefName --jq '.baseRefName' 2>/dev/null)
-  if [ -n "$pr_base" ]; then
-    BASE="origin/$pr_base"
+  # Wrap in `if` so a non-zero exit from gh (no PR yet for this
+  # branch, gh not authed, etc.) doesn't abort the hook under set -e.
+  # The fallback to origin/main below MUST still run.
+  if pr_base=$(gh pr view --json baseRefName --jq '.baseRefName' 2>/dev/null); then
+    if [ -n "$pr_base" ]; then
+      BASE="origin/$pr_base"
+    fi
   fi
 fi
 BASE="${BASE:-origin/main}"

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -56,6 +56,9 @@ fi
 #   1. $CODERABBIT_BASE env var (escape hatch / CI override)
 #   2. The open PR's baseRefName via `gh` (if gh CLI is installed + authed)
 #   3. Fallback to origin/main
+# For the first push of a stacked branch (no PR yet AND base is NOT
+# main), set `CODERABBIT_BASE=origin/<parent-branch>` in your env so the
+# review doesn't include unrelated parent-branch commits.
 BASE="${CODERABBIT_BASE:-}"
 if [ -z "$BASE" ] && command -v gh >/dev/null 2>&1; then
   # Wrap in `if` so a non-zero exit from gh (no PR yet for this
@@ -73,8 +76,15 @@ echo "→ Running CodeRabbit review against ${BASE}..."
 # `coderabbit review --prompt-only` exits 0 in both clean and found-issues
 # states — nonzero is reserved for CLI / auth failures. Gate on the output
 # text so the hook actually blocks when CodeRabbit posts findings.
+#
+# Husky may invoke hooks with `sh -e`. A bare `review_output=$(cmd)` would
+# abort the whole hook on non-zero exit and swallow the captured stderr
+# before we can print it. Temporarily relax errexit so we can surface
+# diagnostics AND still decide policy.
+set +e
 review_output=$(coderabbit review --prompt-only --type committed --base "$BASE" 2>&1)
 review_exit=$?
+set -e
 printf "%s\n" "$review_output"
 if [ "$review_exit" -ne 0 ]; then
   echo "✗ CodeRabbit CLI failed (exit $review_exit). Fix or --no-verify."

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -32,8 +32,22 @@ MSG
   exit 1
 fi
 
-echo "→ Running CodeRabbit review before push..."
-coderabbit review --prompt-only --type committed --base origin/main || {
+# Resolve the review base so stacked PRs don't surface findings from
+# commits that belong to a parent branch. Priority:
+#   1. $CODERABBIT_BASE env var (escape hatch / CI override)
+#   2. The open PR's baseRefName via `gh` (if gh CLI is installed + authed)
+#   3. Fallback to origin/main
+BASE="${CODERABBIT_BASE:-}"
+if [ -z "$BASE" ] && command -v gh >/dev/null 2>&1; then
+  pr_base=$(gh pr view --json baseRefName --jq '.baseRefName' 2>/dev/null)
+  if [ -n "$pr_base" ]; then
+    BASE="origin/$pr_base"
+  fi
+fi
+BASE="${BASE:-origin/main}"
+
+echo "→ Running CodeRabbit review against ${BASE}..."
+coderabbit review --prompt-only --type committed --base "$BASE" || {
   echo "✗ CodeRabbit flagged issues. Fix them, or use --no-verify if intentional."
   exit 1
 }

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,6 +1,8 @@
 #!/usr/bin/env sh
+
+# Block direct pushes to protected branches.
 remote="$1"
-while read local_ref local_sha remote_ref remote_sha; do
+while read -r local_ref local_sha remote_ref remote_sha; do
   case "$remote_ref" in
     refs/heads/main|refs/heads/master)
       echo "✗ Direct push to $remote_ref blocked. Open a PR instead."
@@ -8,6 +10,28 @@ while read local_ref local_sha remote_ref remote_sha; do
       ;;
   esac
 done
+
+# Verify the CodeRabbit CLI is installed before trying to run it.
+# The CLI is NOT an npm package — it ships via a shell installer
+# (https://cli.coderabbit.ai/install.sh) or `brew install coderabbit`.
+if ! command -v coderabbit >/dev/null 2>&1; then
+  cat <<MSG >&2
+✗ 'coderabbit' CLI not found on PATH.
+
+Install it (one-time, per developer):
+  curl -fsSL https://cli.coderabbit.ai/install.sh | sh
+    or
+  brew install coderabbit
+
+Then authenticate:
+  coderabbit auth login
+
+If you know what you're doing and want to skip this hook for a single push:
+  git push --no-verify
+MSG
+  exit 1
+fi
+
 echo "→ Running CodeRabbit review before push..."
 coderabbit review --prompt-only --type committed --base origin/main || {
   echo "✗ CodeRabbit flagged issues. Fix them, or use --no-verify if intentional."

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -70,7 +70,17 @@ fi
 BASE="${BASE:-origin/main}"
 
 echo "→ Running CodeRabbit review against ${BASE}..."
-coderabbit review --prompt-only --type committed --base "$BASE" || {
-  echo "✗ CodeRabbit flagged issues. Fix them, or use --no-verify if intentional."
+# `coderabbit review --prompt-only` exits 0 in both clean and found-issues
+# states — nonzero is reserved for CLI / auth failures. Gate on the output
+# text so the hook actually blocks when CodeRabbit posts findings.
+review_output=$(coderabbit review --prompt-only --type committed --base "$BASE" 2>&1)
+review_exit=$?
+printf "%s\n" "$review_output"
+if [ "$review_exit" -ne 0 ]; then
+  echo "✗ CodeRabbit CLI failed (exit $review_exit). Fix or --no-verify."
   exit 1
-}
+fi
+if ! printf "%s" "$review_output" | grep -qE "Review completed: No findings"; then
+  echo "✗ CodeRabbit flagged issues above. Fix them, or use --no-verify if intentional."
+  exit 1
+fi

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,0 +1,15 @@
+#!/usr/bin/env sh
+remote="$1"
+while read local_ref local_sha remote_ref remote_sha; do
+  case "$remote_ref" in
+    refs/heads/main|refs/heads/master)
+      echo "✗ Direct push to $remote_ref blocked. Open a PR instead."
+      exit 1
+      ;;
+  esac
+done
+echo "→ Running CodeRabbit review before push..."
+coderabbit review --prompt-only --type committed --base origin/main || {
+  echo "✗ CodeRabbit flagged issues. Fix them, or use --no-verify if intentional."
+  exit 1
+}

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,15 +1,34 @@
 #!/usr/bin/env sh
 
 # Block direct pushes to protected branches.
+# Also track whether stdin describes at least one real branch update
+# (i.e. not a tag push and not a branch deletion). If every line is a
+# tag / deletion, there's no code to review and the CodeRabbit step
+# below is skipped — otherwise a `git push --tags` or `git push origin
+# :stale-branch` would block on unrelated findings.
 remote="$1"
+has_branch_update=0
+NULL_SHA="0000000000000000000000000000000000000000"
 while read -r local_ref local_sha remote_ref remote_sha; do
   case "$remote_ref" in
     refs/heads/main|refs/heads/master)
+      # Blocked even for deletions / force-delete of main.
       echo "✗ Direct push to $remote_ref blocked. Open a PR instead."
       exit 1
       ;;
   esac
+  case "$remote_ref" in
+    refs/heads/*) ;;
+    *) continue ;; # tag pushes and other non-branch refs
+  esac
+  [ "$local_sha" = "$NULL_SHA" ] && continue # deletion
+  has_branch_update=1
 done
+
+if [ "$has_branch_update" -eq 0 ]; then
+  echo "→ No branch content update in this push; skipping CodeRabbit review."
+  exit 0
+fi
 
 # Verify the CodeRabbit CLI is installed before trying to run it.
 # The CLI is NOT an npm package — it ships via a shell installer

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -187,12 +187,43 @@ When the full feature slice is done and all increments are committed:
    CodeRabbit does incremental reviews per push).
 5. Repeat 3–4 until the PR review is clean.
 6. `gh pr ready` to mark ready for human review.
-7. STOP. Do not merge. The human reviewer merges.
+7. Proceed to the **triple-signoff merge gate** below. Without that gate
+   explicitly clean, I do not merge.
+
+### Triple-signoff merge gate (when I may `gh pr merge`)
+`gh pr merge` is **only** allowed when every single one of these is true:
+
+1. **Claude** (me): I have re-read the full PR diff end-to-end and found
+   no Critical / P1 / correctness / security issues. If I'm unsure,
+   I'm not cleared — I stop and flag.
+2. **Codex**: `/codex review` (the `/codex` gstack skill, Review mode,
+   base = PR base branch) has been run and returns **GATE: PASS** with
+   zero `[P1]` findings. A stale Codex run from an earlier commit does
+   not count — the Codex review must cover the PR's current HEAD.
+3. **CodeRabbit**: the CodeRabbit GitHub App review is in a clean state
+   on the PR's current HEAD — no unresolved Critical / Potential-issue
+   / Major findings. CodeRabbit's status check must be `SUCCESS`, and
+   if a new commit has landed since the last CodeRabbit review, I
+   trigger `@coderabbitai review` and wait for the incremental reply
+   before claiming this bullet.
+4. **Mechanics**: CI is green, the PR is out of draft (`gh pr ready`
+   already run), and the PR base branch is up to date with `main`
+   (rebase / retarget if stacked PRs have merged in the meantime).
+
+When all four are true, merge with `gh pr merge <number> --squash` by
+default (unless the PR explicitly calls for merge-commit or
+rebase-merge in its description). Delete the branch on merge with
+`--delete-branch` once it is no longer needed by a stacked dependent.
+
+When **any** of the four is not true, the hard prohibition below
+applies.
 
 ### Hard prohibitions
 I will never:
 - Push to `main` / `master` directly.
-- Run `gh pr merge` in any form (including `--auto`).
+- `gh pr merge` unless the **Triple-signoff merge gate** above is
+  entirely clean. Specifically: never `--auto`, never on a draft PR,
+  never on an unreviewed commit, never on a stale Codex review.
 - Force-push to a branch with an open PR under active CodeRabbit review.
 - Use `--no-verify` to bypass the pre-push hook unless Yolan explicitly
   tells me to in this conversation.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -150,3 +150,62 @@ From the Codex challenge + user decisions (2026-04-21):
 2. Read `docs/SLIM_V3.md` and `docs/WEEK0_LOG.md` in full (~15 min).
 3. Propose the first implementation task in natural language — don't code yet.
 4. Wait for user approval. Then implement exactly that one task.
+
+---
+
+## Review & Git workflow (non-negotiable)
+
+### Branch discipline
+- Never commit or push directly to `main` (or `master`). Ever.
+- For any change: branch first. Naming: `feat/<slug>`, `fix/<slug>`,
+  `chore/<slug>`, `refactor/<slug>`, `docs/<slug>`.
+- If asked to make changes while on `main`, branch first, then work.
+
+### Inner loop — between increments (fast, local)
+After each logical increment (feature slice, bugfix, refactor):
+1. `git add -A`
+2. Run `/coderabbit:review uncommitted`
+3. Address every Critical finding. Evaluate Suggestions on merit and apply
+   the ones that improve the code.
+4. Re-run `/coderabbit:review uncommitted` until no Critical remains.
+5. Commit with a Conventional Commit message (`type(scope): subject`).
+6. Move to the next increment.
+
+Increment sizing: target under 300 LOC of diff per review cycle. If larger,
+split it — do not try to review a 1000-line diff.
+
+### Outer loop — PR & merge (formal gate)
+When the full feature slice is done and all increments are committed:
+1. `git push -u origin <branch>` (the pre-push hook will run CodeRabbit
+   against `origin/main` first — if it fails, fix before retrying).
+2. `gh pr create --draft --fill` — always draft, never ready-for-review
+   on creation. Edit the body to explain the *why*, not just the *what*.
+3. Wait for the CodeRabbit GitHub App review to post as PR comments. Poll
+   with `gh pr view --comments` every 2–3 minutes. Do not spam.
+4. Read ALL findings. Address Critical + relevant Suggestions. Push fixes
+   as additional commits (never force-push during an active review —
+   CodeRabbit does incremental reviews per push).
+5. Repeat 3–4 until the PR review is clean.
+6. `gh pr ready` to mark ready for human review.
+7. STOP. Do not merge. The human reviewer merges.
+
+### Hard prohibitions
+I will never:
+- Push to `main` / `master` directly.
+- Run `gh pr merge` in any form (including `--auto`).
+- Force-push to a branch with an open PR under active CodeRabbit review.
+- Use `--no-verify` to bypass the pre-push hook unless Yolan explicitly
+  tells me to in this conversation.
+- Skip `/coderabbit:review uncommitted` between increments to "save time".
+- Open a non-draft PR. Always draft first, `gh pr ready` after clean.
+
+### Fetching review feedback
+- Local uncommitted: `/coderabbit:review uncommitted`
+- Local committed (pre-push check): `coderabbit review --prompt-only --type committed --base origin/main`
+- Open PR comments: `gh pr view [<number>] --comments`
+- Full PR diff + review: `gh pr view <number> --json reviews,comments`
+
+### Commit convention
+Conventional Commits. Types: feat, fix, chore, refactor, docs, test, perf, ci.
+Subject ≤ 72 chars. Body explains *why* when non-obvious. One logical change
+per commit.

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "packages/*"
       ],
       "devDependencies": {
+        "husky": "^9.1.7",
         "typescript": "^5.6.0"
       },
       "engines": {
@@ -241,6 +242,22 @@
       "peer": true,
       "engines": {
         "node": ">=16.9.0"
+      }
+    },
+    "node_modules/husky": {
+      "version": "9.1.7",
+      "resolved": "https://registry.npmjs.org/husky/-/husky-9.1.7.tgz",
+      "integrity": "sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "husky": "bin.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/typicode"
       }
     },
     "node_modules/is-fullwidth-code-point": {

--- a/package.json
+++ b/package.json
@@ -13,12 +13,14 @@
     "engine:dev": "npm run dev --workspace=apps/engine",
     "web:dev": "npm run dev --workspace=apps/web",
     "test": "npm run test --workspaces --if-present",
-    "clean": "npm run typecheck:clean && rm -rf apps/*/dist packages/*/dist"
+    "clean": "npm run typecheck:clean && rm -rf apps/*/dist packages/*/dist",
+    "prepare": "husky"
   },
   "engines": {
     "node": ">=22.0.0"
   },
   "devDependencies": {
+    "husky": "^9.1.7",
     "typescript": "^5.7.0"
   }
 }


### PR DESCRIPTION
## Summary

Adds the review + git workflow documented in CLAUDE.md. Stacked on top of #2.

- `.husky/pre-push`: blocks direct pushes to `main`/`master`; runs `coderabbit review --prompt-only --type committed --base origin/main` before every push; surfaces findings and blocks the push if CodeRabbit returns non-zero.
- `.husky/pre-commit`: placeholder for future lint hooks.
- `package.json`: adds `husky` as a dev dep; `prepare: husky` runs on install.
- `CLAUDE.md`: new "Review & Git workflow (non-negotiable)" section — branch discipline, inner loop (uncommitted review between increments), outer loop (draft PR → CodeRabbit GitHub App → `gh pr ready` → human merges), hard prohibitions.

## Why

Both engine PRs (#1, #2) were originally committed directly to local `main` before this workflow existed. Landing this commit makes the review process repeatable going forward — every slice goes through CodeRabbit twice (local + GitHub App) before a human sees it.

## Test plan

- [x] `.husky/pre-push` executable and actually runs CodeRabbit (verified: caught the `@hono/node-server@^2.0.0` version note on this push — false positive, npm resolves to published `2.0.0`)
- [x] `coderabbit --version` returns `0.4.1`
- [x] Hard prohibitions documented in CLAUDE.md
- [ ] Follow-up commit will add `.coderabbit.yaml` with `reviews.auto_review.drafts: true` so the GitHub App actually reviews draft PRs (otherwise the workflow-required "always draft" mode blocks the review step)
- [ ] CodeRabbit GitHub App review posts and is addressed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Integrated an automated code-review configuration with a default review profile and auto-review for draft work.
  * Added pre-commit tests and a pre-push check that blocks direct pushes to protected branches and enforces review checks before pushing.
  * Added Git hook management to enable these checks.

* **Documentation**
  * Expanded developer workflow docs with strict branching, review, and merge procedures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->