### PR TITLE
feat(engine): week 1 task 3 — stage supervisor (one ffmpeg per track)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,15 @@ jobs:
       - run: node --version
       - run: npm --version
 
+      # ffmpeg drives the stage supervisor's integration tests
+      # (apps/engine/src/stages/integration.test.ts). The unit tests
+      # cover argv shape + lifecycle against mocks; the integration
+      # tests exist to catch invalid flag combos or segment-output
+      # regressions that only show up under a real ffmpeg.
+      - name: Install ffmpeg
+        run: sudo apt-get update && sudo apt-get install -y --no-install-recommends ffmpeg
+      - run: ffmpeg -version | head -1
+
       - name: Install
         run: npm ci
 

--- a/apps/engine/README.md
+++ b/apps/engine/README.md
@@ -1,12 +1,12 @@
 # @pavoia/engine
 
-The audio engine for Pavoia Webradio v3. In Week 1 Task 1 (this PR), it boots a Hono HTTP server, exposes `/api/health` for the cron watchdog, and implements graceful SIGTERM / SIGINT / SIGHUP shutdown. Plex polling, per-track ffmpeg orchestration, HLS emission to `/dev/shm/1008/radio-hls/<stage>/`, and now-playing endpoints are added in later Week 1 tasks.
+The audio engine for Pavoia Webradio v3. It boots a Hono HTTP server, exposes `/api/health` for the cron watchdog, implements graceful SIGTERM / SIGINT / SIGHUP shutdown, fetches stage playlists from Plex, and runs a per-stage ffmpeg supervisor that emits HLS to `/dev/shm/1008/radio-hls/<stage>/`. Now-playing endpoints and WebSocket hub are added in later Week 1 tasks.
 
 See `../../docs/SLIM_V3.md` for the full feature scope, `../../docs/WEEK0_LOG.md` for the 16 locked requirements (A–P) that constrain the implementation, and `../../CLAUDE.md` at the repo root for onboarding.
 
 ## Status
 
-**Week 1 Task 1 — complete.** The engine bootstraps a Hono HTTP server with `/api/health` and graceful shutdown. No Plex client, no ffmpeg, no stage supervisor, no WebSocket hub, no HLS static handler yet — those land in Task 2 onward.
+**Week 1 Tasks 1–3 — complete.** The engine bootstraps the HTTP server and graceful shutdown (Task 1), has a Plex playlist client with validation + pagination (Task 2), and ships a per-stage ffmpeg supervisor with lifecycle, crash restart, and fallback looping (Task 3). What's not yet wired: `/api/stages*` endpoints, the `/hls/*` static handler, the WebSocket hub, and `deploy/bin/*` scripts — those land in Tasks 4–7.
 
 ## Scripts
 
@@ -79,21 +79,79 @@ This matches the Whatbox deploy pattern in WEEK0_LOG.md Step 2 — `@reboot` cro
 
 ```text
 src/
-├── app.ts            # createApp(), resolvePort() — pure, no side effects on import
-├── app.test.ts       # unit tests for resolvePort and the HTTP contract (via app.request())
-├── shutdown.test.ts  # integration tests: spawn the real entry point, send signals, verify exit codes
-└── index.ts          # entry point: resolves port, creates app, serves, wires signals
+├── app.ts                         # createApp(), resolvePort() — pure, no side effects on import
+├── app.test.ts                    # unit tests for resolvePort and the HTTP contract
+├── shutdown.test.ts               # integration: spawn index.ts, send signals, assert exit codes
+├── index.ts                       # entry point: resolves port, creates app, serves, wires signals
+├── plex/
+│   ├── client.ts                  # createPlexClient() → fetchPlaylist(ratingKey): FetchPlaylistResult
+│   ├── client.test.ts             # covers the full error taxonomy + pagination
+│   ├── schema.ts                  # zod schemas for the Plex playlist payload
+│   ├── fallback-hash.ts           # stable ID when ratingKey rotates
+│   ├── fallback-hash.test.ts
+│   └── index.ts                   # package-local barrel
+└── stages/
+    ├── ffmpeg-args.ts             # pure argv builder for `ffmpeg -> HLS` (Reqs K/L/M/O/P)
+    ├── ffmpeg-args.test.ts
+    ├── runner.ts                  # spawns one ffmpeg, resolves to { ok | aborted | crashed }
+    ├── runner.test.ts             # uses `node -e` as a fake ffmpeg for portability
+    ├── hls-dir.ts                 # prepare + clean the per-stage HLS output directory
+    ├── hls-dir.test.ts
+    ├── supervisor.ts              # startStage() — sequential track loop, crash restart, stop()
+    ├── supervisor.test.ts         # controlled-runner mock drives the full state machine
+    ├── integration.test.ts        # end-to-end against real ffmpeg (auto-skips if absent)
+    └── index.ts                   # public surface for the engine entry point
 ```
 
-`app.ts` has **no top-level side effects**, so unit tests import it freely without a port bind. `index.ts` does the binding and signal wiring; it is exercised by `shutdown.test.ts` which spawns it as a child process and sends real signals — so the shutdown path is actually tested end-to-end, not just reasoned about.
+`app.ts` and every `stages/*.ts` module have **no top-level side effects**, so unit tests import them freely without a port bind or fs scribbles. `index.ts` does the binding and signal wiring; it is exercised by `shutdown.test.ts` which spawns it as a child process and sends real signals.
+
+## Stage supervisor (Task 3)
+
+One `StageController` per stage. Contract:
+
+```ts
+import { startStage } from "./stages/index.ts";
+
+const ctl = startStage({
+  stageId: "opening",
+  tracks: plexResult.tracks,              // from fetchPlaylist()
+  hlsDir: "/dev/shm/1008/radio-hls/opening",
+  fallbackFile: "/path/to/curating.aac",  // loops via -stream_loop -1 when tracks is empty
+  onEvent: (e) => { /* track_started, track_ended, crash, status, ... */ },
+  onStderrLine: (line) => console.warn(`[ffmpeg:opening] ${line}`),
+});
+// ...
+await ctl.stop();  // SIGTERM current ffmpeg, SIGKILL after 5s if stubborn
+```
+
+**What it owns:**
+
+- **Directory lifecycle.** `mkdir -p` on start; wipes `index.m3u8` + `seg-*.ts` from any previous run so the first spawn is a clean slate. Between tracks the dir is NOT touched — cross-track segment numbering relies on ffmpeg's `+append_list` reading the existing m3u8 (verified in WEEK0_LOG Step 3b).
+- **One ffmpeg per track (Req K).** Built from `buildFfmpegArgs()` — see that module for the full flag list and the *why* behind each one. Track boundary = ffmpeg `exit` event in Node; no stderr parsing (Req N). Critical flag: `-re` paces input at real time, so a 5-minute track takes ~5 real minutes and the rolling 6-segment, 3-second-each HLS window stays populated.
+- **Fallback for empty playlists (Req O).** When `tracks.length === 0`, wraps the input with `-stream_loop -1` so ffmpeg never exits on its own. Status stays `curating`.
+- **Crash restart.** Non-zero exit → sleeps `restartBackoffMs` (default 500 ms) → retries the SAME track. After `maxConsecutiveCrashes` in a row (default 3) on a single track, emits `skipped_after_repeated_crashes` and advances — this is the escape hatch so a single corrupt file can't hot-loop the stage.
+- **Graceful stop.** `stop()` aborts the internal `AbortController`. The runner translates that into `SIGTERM`, escalates to `SIGKILL` after 5 s, and resolves `aborted`. `stop()` resolves after the run loop has exited and the status has transitioned to `stopped`. Idempotent: multiple concurrent `stop()` calls share the same promise.
+- **Observer safety.** A throwing `onEvent` or `onStderrLine` is swallowed — a subscriber bug can never take a stage down.
+
+**What it does NOT do** (those are later tasks):
+
+- No Plex polling loop — `tracks` is captured at start. Dynamic playlist changes land when Task 5 wires the supervisor into `index.ts` with a periodic `fetchPlaylist` refresh.
+- No HTTP endpoints, no WebSocket emission. Those consume the `StageEvent` stream from outside (Task 5).
+- No listener counting.
+
+**Testing layers:**
+
+- `ffmpeg-args.test.ts` — argv shape, flag ordering, input- vs output-option position.
+- `runner.test.ts` — spawn lifecycle via `node -e "<script>"` as a portable fake ffmpeg: exit codes, abort cooperation, SIGKILL escalation, stderr line buffering, idempotent abort, no listener leak.
+- `hls-dir.test.ts` — recursive mkdir, selective cleanup, near-miss filename safety.
+- `supervisor.test.ts` — a controlled runner mock drives the full state machine: sequential advance, wraparound, crash retry + backoff, advance after `maxConsecutiveCrashes`, empty-playlist fallback, idempotent stop, abort during backoff.
+- `integration.test.ts` — end-to-end against real ffmpeg on a lavfi-generated silence fixture. Auto-skips when ffmpeg isn't on PATH. CI installs ffmpeg explicitly for this reason (see `.github/workflows/ci.yml`).
 
 ## Deferred
 
 Coming in later Week 1 tasks:
 
-- **Task 2** — `src/plex/` Plex client (`fetchPlaylist(ratingKey): Promise<Track[]>`).
-- **Task 3** — `src/stages/` per-stage supervisor, one ffmpeg per track (Reqs K–P).
 - **Task 4** — verify HLS in a real browser (hls.js) + VLC.
-- **Task 5** — `/api/stages`, `/api/stages/:id/now`, `/hls/*` static handler.
+- **Task 5** — `/api/stages`, `/api/stages/:id/now`, `/hls/*` static handler; wire stage supervisors into `index.ts` with the 60 s Plex-polling loop.
 - **Task 6** — `deploy/bin/start-engine.sh`, cron entries, watchdog port from v2.
 - **Task 7** — ship to `v3.nicemouth.box.ca`.

--- a/apps/engine/src/stages/ffmpeg-args.test.ts
+++ b/apps/engine/src/stages/ffmpeg-args.test.ts
@@ -1,0 +1,88 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import path from "node:path";
+
+import { buildFfmpegArgs } from "./ffmpeg-args.ts";
+
+const FIXTURE = {
+  trackFilePath: "/home/yolan/files/plex_music_library/opus/artist/track.opus",
+  stageHlsDir: "/dev/shm/1008/radio-hls/opening",
+} as const;
+
+function pairValue(args: readonly string[], flag: string): string | undefined {
+  const i = args.indexOf(flag);
+  return i >= 0 ? args[i + 1] : undefined;
+}
+
+describe("buildFfmpegArgs", () => {
+  it("feeds -i with the track's absolute path", () => {
+    const args = buildFfmpegArgs(FIXTURE);
+    assert.equal(pairValue(args, "-i"), FIXTURE.trackFilePath);
+  });
+
+  it("locks AAC 128 kbps stereo 44.1 kHz and strips video", () => {
+    const args = buildFfmpegArgs(FIXTURE);
+    assert.ok(args.includes("-vn"), "-vn must be present");
+    assert.equal(pairValue(args, "-c:a"), "aac");
+    assert.equal(pairValue(args, "-b:a"), "128k");
+    assert.equal(pairValue(args, "-ac"), "2");
+    assert.equal(pairValue(args, "-ar"), "44100");
+  });
+
+  it("emits HLS with -hls_time 3 and -hls_list_size 6", () => {
+    const args = buildFfmpegArgs(FIXTURE);
+    assert.equal(pairValue(args, "-f"), "hls");
+    assert.equal(pairValue(args, "-hls_time"), "3");
+    assert.equal(pairValue(args, "-hls_list_size"), "6");
+  });
+
+  it("sets -hls_flags to the exact rolling-window combo", () => {
+    const args = buildFfmpegArgs(FIXTURE);
+    assert.equal(
+      pairValue(args, "-hls_flags"),
+      "+append_list+omit_endlist+delete_segments",
+    );
+  });
+
+  it("writes segments as seg-%05d.ts inside stageHlsDir", () => {
+    const args = buildFfmpegArgs(FIXTURE);
+    assert.equal(
+      pairValue(args, "-hls_segment_filename"),
+      path.join(FIXTURE.stageHlsDir, "seg-%05d.ts"),
+    );
+  });
+
+  it("places the m3u8 playlist as the final argv element", () => {
+    const args = buildFfmpegArgs(FIXTURE);
+    assert.equal(
+      args.at(-1),
+      path.join(FIXTURE.stageHlsDir, "index.m3u8"),
+    );
+  });
+
+  it("starts with quiet / non-interactive banner flags", () => {
+    const args = buildFfmpegArgs(FIXTURE);
+    assert.equal(args[0], "-hide_banner");
+    assert.equal(pairValue(args, "-loglevel"), "warning");
+    assert.ok(args.includes("-nostdin"), "-nostdin must be present");
+  });
+
+  it("passes paths through verbatim (argv, not shell — no escaping)", () => {
+    const args = buildFfmpegArgs({
+      trackFilePath: "/music/weird path/with 'quotes' & spaces/track.flac",
+      stageHlsDir: "/dev/shm/1008/radio-hls/opening",
+    });
+    assert.equal(
+      pairValue(args, "-i"),
+      "/music/weird path/with 'quotes' & spaces/track.flac",
+    );
+  });
+
+  it("produces a single contiguous argv with no undefined / empty entries", () => {
+    const args = buildFfmpegArgs(FIXTURE);
+    for (const [idx, v] of args.entries()) {
+      assert.equal(typeof v, "string", `argv[${idx}] must be string`);
+      assert.notEqual(v, "", `argv[${idx}] must be non-empty`);
+    }
+  });
+});

--- a/apps/engine/src/stages/ffmpeg-args.test.ts
+++ b/apps/engine/src/stages/ffmpeg-args.test.ts
@@ -11,7 +11,7 @@ const FIXTURE = {
 
 function pairValue(args: readonly string[], flag: string): string | undefined {
   const i = args.indexOf(flag);
-  return i >= 0 ? args[i + 1] : undefined;
+  return i >= 0 && i + 1 < args.length ? args[i + 1] : undefined;
 }
 
 describe("buildFfmpegArgs", () => {
@@ -20,7 +20,35 @@ describe("buildFfmpegArgs", () => {
     assert.equal(pairValue(args, "-i"), FIXTURE.trackFilePath);
   });
 
-  it("locks AAC 128 kbps stereo 44.1 kHz and strips video", () => {
+  it("paces input at real-time with -re (Req N, track exit = boundary)", () => {
+    const args = buildFfmpegArgs(FIXTURE);
+    const reIdx = args.indexOf("-re");
+    const iIdx = args.indexOf("-i");
+    assert.ok(reIdx >= 0, "-re must be present");
+    assert.ok(
+      reIdx < iIdx,
+      "-re must appear before -i (it is an input option, not global)",
+    );
+  });
+
+  it("does NOT set -stream_loop in the default (per-track) mode", () => {
+    const args = buildFfmpegArgs(FIXTURE);
+    assert.equal(args.indexOf("-stream_loop"), -1);
+  });
+
+  it("wraps input with -stream_loop -1 when loopInput: true (Req O fallback)", () => {
+    const args = buildFfmpegArgs({ ...FIXTURE, loopInput: true });
+    const loopIdx = args.indexOf("-stream_loop");
+    const iIdx = args.indexOf("-i");
+    assert.ok(loopIdx >= 0, "-stream_loop must be present");
+    assert.equal(args[loopIdx + 1], "-1");
+    assert.ok(
+      loopIdx < iIdx,
+      "-stream_loop is an input option and must precede -i",
+    );
+  });
+
+  it("locks AAC 128 kbps stereo 44.1 kHz and strips video (Req P)", () => {
     const args = buildFfmpegArgs(FIXTURE);
     assert.ok(args.includes("-vn"), "-vn must be present");
     assert.equal(pairValue(args, "-c:a"), "aac");
@@ -29,14 +57,14 @@ describe("buildFfmpegArgs", () => {
     assert.equal(pairValue(args, "-ar"), "44100");
   });
 
-  it("emits HLS with -hls_time 3 and -hls_list_size 6", () => {
+  it("emits HLS with -hls_time 3 and -hls_list_size 6 (Req L)", () => {
     const args = buildFfmpegArgs(FIXTURE);
     assert.equal(pairValue(args, "-f"), "hls");
     assert.equal(pairValue(args, "-hls_time"), "3");
     assert.equal(pairValue(args, "-hls_list_size"), "6");
   });
 
-  it("sets -hls_flags to the exact rolling-window combo", () => {
+  it("sets -hls_flags to the exact rolling-window combo (Req K)", () => {
     const args = buildFfmpegArgs(FIXTURE);
     assert.equal(
       pairValue(args, "-hls_flags"),
@@ -44,7 +72,7 @@ describe("buildFfmpegArgs", () => {
     );
   });
 
-  it("writes segments as seg-%05d.ts inside stageHlsDir", () => {
+  it("writes segments as seg-%05d.ts inside stageHlsDir (Req M)", () => {
     const args = buildFfmpegArgs(FIXTURE);
     assert.equal(
       pairValue(args, "-hls_segment_filename"),
@@ -64,7 +92,29 @@ describe("buildFfmpegArgs", () => {
     const args = buildFfmpegArgs(FIXTURE);
     assert.equal(args[0], "-hide_banner");
     assert.equal(pairValue(args, "-loglevel"), "warning");
+    assert.ok(args.includes("-nostats"), "-nostats must be present");
     assert.ok(args.includes("-nostdin"), "-nostdin must be present");
+  });
+
+  it("orders args as global → input → -i → output → outfile", () => {
+    const args = buildFfmpegArgs({ ...FIXTURE, loopInput: true });
+    const i = args.indexOf("-i");
+    const hlsFlags = args.indexOf("-hls_flags");
+    const re = args.indexOf("-re");
+    const loop = args.indexOf("-stream_loop");
+    const banner = args.indexOf("-hide_banner");
+
+    // global options before input options
+    assert.ok(banner < re, "-hide_banner before -re");
+    // input options before -i
+    assert.ok(re < i && loop < i, "-re and -stream_loop before -i");
+    // output options after -i
+    assert.ok(i < hlsFlags, "-hls_flags after -i");
+    // playlist path last
+    assert.equal(
+      args.at(-1),
+      path.join(FIXTURE.stageHlsDir, "index.m3u8"),
+    );
   });
 
   it("passes paths through verbatim (argv, not shell — no escaping)", () => {
@@ -79,7 +129,7 @@ describe("buildFfmpegArgs", () => {
   });
 
   it("produces a single contiguous argv with no undefined / empty entries", () => {
-    const args = buildFfmpegArgs(FIXTURE);
+    const args = buildFfmpegArgs({ ...FIXTURE, loopInput: true });
     for (const [idx, v] of args.entries()) {
       assert.equal(typeof v, "string", `argv[${idx}] must be string`);
       assert.notEqual(v, "", `argv[${idx}] must be non-empty`);

--- a/apps/engine/src/stages/ffmpeg-args.ts
+++ b/apps/engine/src/stages/ffmpeg-args.ts
@@ -1,0 +1,51 @@
+// Pure ffmpeg argv builder for a single track -> HLS transcode.
+//
+// Locks WEEK0_LOG reqs:
+//   K: -hls_flags +append_list+omit_endlist+delete_segments (rolling window)
+//   L: -hls_time 3, -hls_list_size 6
+//   M: segment filename pattern seg-%05d.ts
+//   P: AAC 128 kbps stereo 44.1 kHz, video stripped
+
+import path from "node:path";
+
+export interface BuildFfmpegArgsInput {
+  /** Absolute path to the audio file ffmpeg will read. */
+  trackFilePath: string;
+  /** Absolute directory where the m3u8 and .ts segments are written. */
+  stageHlsDir: string;
+}
+
+export function buildFfmpegArgs(input: BuildFfmpegArgsInput): string[] {
+  const { trackFilePath, stageHlsDir } = input;
+  const segmentPattern = path.join(stageHlsDir, "seg-%05d.ts");
+  const playlistPath = path.join(stageHlsDir, "index.m3u8");
+
+  return [
+    "-hide_banner",
+    "-loglevel",
+    "warning",
+    "-nostdin",
+    "-i",
+    trackFilePath,
+    "-vn",
+    "-c:a",
+    "aac",
+    "-b:a",
+    "128k",
+    "-ac",
+    "2",
+    "-ar",
+    "44100",
+    "-f",
+    "hls",
+    "-hls_time",
+    "3",
+    "-hls_list_size",
+    "6",
+    "-hls_flags",
+    "+append_list+omit_endlist+delete_segments",
+    "-hls_segment_filename",
+    segmentPattern,
+    playlistPath,
+  ];
+}

--- a/apps/engine/src/stages/ffmpeg-args.ts
+++ b/apps/engine/src/stages/ffmpeg-args.ts
@@ -1,32 +1,61 @@
-// Pure ffmpeg argv builder for a single track -> HLS transcode.
+// Pure ffmpeg argv builder for a single stage invocation → HLS output.
 //
-// Locks WEEK0_LOG reqs:
-//   K: -hls_flags +append_list+omit_endlist+delete_segments (rolling window)
-//   L: -hls_time 3, -hls_list_size 6
+// Locks WEEK0_LOG reqs (see docs/WEEK0_LOG.md Steps 3/3b):
+//   K: one ffmpeg per track (this builder produces one invocation's argv)
+//   L: -hls_flags +append_list+omit_endlist+delete_segments,
+//      -hls_time 3, -hls_list_size 6 (rolling 18s window, live-like)
 //   M: segment filename pattern seg-%05d.ts
-//   P: AAC 128 kbps stereo 44.1 kHz, video stripped
+//   N: track boundary = ffmpeg exit event — REQUIRES real-time pacing (`-re`)
+//      so a 5-minute track takes ~5 real minutes. Without -re, ffmpeg reads
+//      the file as fast as disk allows and exits in ~100 ms, which would
+//      collapse the rolling-window invariant and gap listeners.
+//   O: -stream_loop -1 on the curating.aac fallback so ffmpeg only exits
+//      when the supervisor aborts it, giving a stable "curating" state.
+//   P: AAC 128 kbps stereo 44.1 kHz, video stream stripped (-vn).
+//
+// Argument order matters to ffmpeg: global opts → input opts → -i <input>
+// → output opts → output file. Breaking that order produces cryptic
+// "option not found" / "unable to find a suitable output format" errors.
+// See `ffmpeg -h full` > "Main options" for the grammar.
 
 import path from "node:path";
 
 export interface BuildFfmpegArgsInput {
   /** Absolute path to the audio file ffmpeg will read. */
   trackFilePath: string;
-  /** Absolute directory where the m3u8 and .ts segments are written. */
+  /** Absolute directory where index.m3u8 and seg-*.ts are written. */
   stageHlsDir: string;
+  /**
+   * When true, wrap the input with `-stream_loop -1` so ffmpeg plays the
+   * file on repeat indefinitely. Used for the empty-playlist fallback
+   * (Req O). Default: false (single play, exit on EOF).
+   */
+  loopInput?: boolean;
 }
 
 export function buildFfmpegArgs(input: BuildFfmpegArgsInput): string[] {
-  const { trackFilePath, stageHlsDir } = input;
+  const { trackFilePath, stageHlsDir, loopInput = false } = input;
   const segmentPattern = path.join(stageHlsDir, "seg-%05d.ts");
   const playlistPath = path.join(stageHlsDir, "index.m3u8");
 
-  return [
+  const globalOpts = [
     "-hide_banner",
     "-loglevel",
     "warning",
+    // -nostats goes via a separate path than -loglevel in ffmpeg; without
+    // it, the encoder still prints `frame=... time=... bitrate=...` every
+    // ~500ms on stderr, flooding any downstream log sink.
+    "-nostats",
     "-nostdin",
-    "-i",
-    trackFilePath,
+  ];
+
+  const inputOpts = ["-re"];
+  if (loopInput) {
+    inputOpts.push("-stream_loop", "-1");
+  }
+  inputOpts.push("-i", trackFilePath);
+
+  const outputOpts = [
     "-vn",
     "-c:a",
     "aac",
@@ -46,6 +75,7 @@ export function buildFfmpegArgs(input: BuildFfmpegArgsInput): string[] {
     "+append_list+omit_endlist+delete_segments",
     "-hls_segment_filename",
     segmentPattern,
-    playlistPath,
   ];
+
+  return [...globalOpts, ...inputOpts, ...outputOpts, playlistPath];
 }

--- a/apps/engine/src/stages/hls-dir.test.ts
+++ b/apps/engine/src/stages/hls-dir.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, beforeEach, afterEach } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtemp, mkdir, writeFile, readdir, rm, stat } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import { prepareStageDir, cleanStageDir } from "./hls-dir.ts";
+
+describe("prepareStageDir", () => {
+  let work: string;
+  beforeEach(async () => {
+    work = await mkdtemp(path.join(tmpdir(), "pavoia-hlsdir-"));
+  });
+  afterEach(async () => {
+    await rm(work, { recursive: true, force: true });
+  });
+
+  it("creates a nested directory (recursive mkdir)", async () => {
+    const target = path.join(work, "a/b/c");
+    await prepareStageDir(target);
+    const st = await stat(target);
+    assert.ok(st.isDirectory());
+  });
+
+  it("is idempotent on an existing directory", async () => {
+    const target = path.join(work, "x");
+    await prepareStageDir(target);
+    await prepareStageDir(target); // must not throw EEXIST
+  });
+});
+
+describe("cleanStageDir", () => {
+  let work: string;
+  beforeEach(async () => {
+    work = await mkdtemp(path.join(tmpdir(), "pavoia-hlsclean-"));
+  });
+  afterEach(async () => {
+    await rm(work, { recursive: true, force: true });
+  });
+
+  it("returns 0 for a nonexistent directory (no error)", async () => {
+    const n = await cleanStageDir(path.join(work, "does-not-exist"));
+    assert.equal(n, 0);
+  });
+
+  it("returns 0 for an empty existing directory", async () => {
+    await mkdir(path.join(work, "empty"));
+    const n = await cleanStageDir(path.join(work, "empty"));
+    assert.equal(n, 0);
+  });
+
+  it("removes index.m3u8 and all seg-*.ts files, returns count", async () => {
+    const d = path.join(work, "stage");
+    await mkdir(d);
+    await writeFile(path.join(d, "index.m3u8"), "#EXTM3U\n");
+    await writeFile(path.join(d, "seg-00000.ts"), "a");
+    await writeFile(path.join(d, "seg-00001.ts"), "b");
+    await writeFile(path.join(d, "seg-12345.ts"), "c");
+    const n = await cleanStageDir(d);
+    assert.equal(n, 4);
+    const remaining = await readdir(d);
+    assert.deepEqual(remaining, []);
+  });
+
+  it("preserves non-HLS files (curating.aac, README, etc.)", async () => {
+    const d = path.join(work, "stage");
+    await mkdir(d);
+    await writeFile(path.join(d, "curating.aac"), "x");
+    await writeFile(path.join(d, "README"), "y");
+    await writeFile(path.join(d, "seg-00000.ts"), "z");
+    const n = await cleanStageDir(d);
+    assert.equal(n, 1);
+    const remaining = (await readdir(d)).sort();
+    assert.deepEqual(remaining, ["README", "curating.aac"]);
+  });
+
+  it("does not touch similarly-named files that don't match the HLS pattern", async () => {
+    const d = path.join(work, "stage");
+    await mkdir(d);
+    // Near-misses that must NOT be deleted.
+    await writeFile(path.join(d, "seg-.ts"), "");
+    await writeFile(path.join(d, "seg-abc.ts"), "");
+    await writeFile(path.join(d, "index.m3u8.bak"), "");
+    await writeFile(path.join(d, "prefix-seg-00000.ts"), "");
+    const n = await cleanStageDir(d);
+    assert.equal(n, 0);
+  });
+});

--- a/apps/engine/src/stages/hls-dir.test.ts
+++ b/apps/engine/src/stages/hls-dir.test.ts
@@ -4,7 +4,11 @@ import { mkdtemp, mkdir, writeFile, readdir, rm, stat } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 
-import { prepareStageDir, cleanStageDir } from "./hls-dir.ts";
+import {
+  prepareStageDir,
+  cleanStageDir,
+  pruneOrphanSegments,
+} from "./hls-dir.ts";
 
 describe("prepareStageDir", () => {
   let work: string;
@@ -84,5 +88,105 @@ describe("cleanStageDir", () => {
     await writeFile(path.join(d, "prefix-seg-00000.ts"), "");
     const n = await cleanStageDir(d);
     assert.equal(n, 0);
+  });
+});
+
+describe("pruneOrphanSegments", () => {
+  let work: string;
+  beforeEach(async () => {
+    work = await mkdtemp(path.join(tmpdir(), "pavoia-prune-"));
+  });
+  afterEach(async () => {
+    await rm(work, { recursive: true, force: true });
+  });
+
+  it("returns 0 when index.m3u8 is missing (no-op)", async () => {
+    const d = path.join(work, "stage");
+    await mkdir(d);
+    await writeFile(path.join(d, "seg-00000.ts"), "a");
+    const n = await pruneOrphanSegments(d);
+    assert.equal(n, 0);
+    assert.deepEqual(await readdir(d), ["seg-00000.ts"]);
+  });
+
+  it("returns 0 for a nonexistent directory", async () => {
+    const n = await pruneOrphanSegments(path.join(work, "nope"));
+    assert.equal(n, 0);
+  });
+
+  it("deletes seg-*.ts NOT referenced by the playlist, keeps those that ARE", async () => {
+    const d = path.join(work, "stage");
+    await mkdir(d);
+    const m3u8 = [
+      "#EXTM3U",
+      "#EXT-X-VERSION:3",
+      "#EXT-X-TARGETDURATION:3",
+      "#EXT-X-MEDIA-SEQUENCE:55",
+      "#EXTINF:3.000,",
+      "seg-00055.ts",
+      "#EXTINF:3.000,",
+      "seg-00056.ts",
+      "#EXTINF:3.000,",
+      "seg-00057.ts",
+    ].join("\n") + "\n";
+    await writeFile(path.join(d, "index.m3u8"), m3u8);
+    // Live segments: referenced in playlist.
+    await writeFile(path.join(d, "seg-00055.ts"), "a");
+    await writeFile(path.join(d, "seg-00056.ts"), "b");
+    await writeFile(path.join(d, "seg-00057.ts"), "c");
+    // Orphans from a prior ffmpeg invocation.
+    await writeFile(path.join(d, "seg-00052.ts"), "x");
+    await writeFile(path.join(d, "seg-00053.ts"), "y");
+    await writeFile(path.join(d, "seg-00054.ts"), "z");
+
+    const n = await pruneOrphanSegments(d);
+    assert.equal(n, 3);
+    const remaining = (await readdir(d)).sort();
+    assert.deepEqual(remaining, [
+      "index.m3u8",
+      "seg-00055.ts",
+      "seg-00056.ts",
+      "seg-00057.ts",
+    ]);
+  });
+
+  it("handles absolute-path entries in the playlist (takes basename)", async () => {
+    const d = path.join(work, "stage");
+    await mkdir(d);
+    // Some ffmpeg configs can emit absolute paths.
+    const absPath = path.join(d, "seg-00010.ts");
+    const m3u8 = [
+      "#EXTM3U",
+      "#EXTINF:3.000,",
+      absPath,
+    ].join("\n") + "\n";
+    await writeFile(path.join(d, "index.m3u8"), m3u8);
+    await writeFile(path.join(d, "seg-00010.ts"), "a");
+    await writeFile(path.join(d, "seg-00011.ts"), "orphan");
+
+    const n = await pruneOrphanSegments(d);
+    assert.equal(n, 1);
+    const remaining = (await readdir(d)).sort();
+    assert.deepEqual(remaining, ["index.m3u8", "seg-00010.ts"]);
+  });
+
+  it("leaves non-segment files alone (curating.aac, README, etc.)", async () => {
+    const d = path.join(work, "stage");
+    await mkdir(d);
+    await writeFile(path.join(d, "index.m3u8"), "#EXTM3U\nseg-00001.ts\n");
+    await writeFile(path.join(d, "seg-00001.ts"), "live");
+    await writeFile(path.join(d, "seg-00000.ts"), "orphan");
+    await writeFile(path.join(d, "curating.aac"), "x");
+    await writeFile(path.join(d, "README"), "y");
+
+    const n = await pruneOrphanSegments(d);
+    assert.equal(n, 1);
+    const remaining = (await readdir(d)).sort();
+    assert.deepEqual(remaining, [
+      "README",
+      "curating.aac",
+      "index.m3u8",
+      "seg-00001.ts",
+    ]);
   });
 });

--- a/apps/engine/src/stages/hls-dir.ts
+++ b/apps/engine/src/stages/hls-dir.ts
@@ -1,0 +1,48 @@
+// Filesystem helpers for a stage's HLS output directory.
+//
+// On Whatbox the target is /dev/shm/1008/radio-hls/<stage>/ (Req F);
+// locally it's a tmpdir. Either way the supervisor owns the dir and:
+//
+//   - prepareStageDir: `mkdir -p` on start, idempotent.
+//   - cleanStageDir:   remove stale index.m3u8 + seg-*.ts from a previous
+//                      run (tmpfs survives a crash even when the engine
+//                      process dies). Non-HLS files in the dir are left
+//                      alone — nothing else lives there today, but being
+//                      conservative costs nothing.
+//
+// Called once at stage-start only. Between tracks, segment continuity
+// relies on ffmpeg's +append_list flag reading the existing m3u8 and
+// continuing segment numbering — do NOT clean mid-run.
+
+import { mkdir, readdir, rm } from "node:fs/promises";
+import path from "node:path";
+
+const SEGMENT_PATTERN = /^seg-\d+\.ts$/;
+const PLAYLIST_NAME = "index.m3u8";
+
+export async function prepareStageDir(stageHlsDir: string): Promise<void> {
+  await mkdir(stageHlsDir, { recursive: true });
+}
+
+/**
+ * Returns the number of files removed. Silently tolerates a missing
+ * directory (returns 0) so callers can call it unconditionally on
+ * startup.
+ */
+export async function cleanStageDir(stageHlsDir: string): Promise<number> {
+  let entries: string[];
+  try {
+    entries = await readdir(stageHlsDir);
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === "ENOENT") return 0;
+    throw err;
+  }
+  let removed = 0;
+  for (const name of entries) {
+    if (name === PLAYLIST_NAME || SEGMENT_PATTERN.test(name)) {
+      await rm(path.join(stageHlsDir, name), { force: true });
+      removed++;
+    }
+  }
+  return removed;
+}

--- a/apps/engine/src/stages/hls-dir.ts
+++ b/apps/engine/src/stages/hls-dir.ts
@@ -14,7 +14,7 @@
 // relies on ffmpeg's +append_list flag reading the existing m3u8 and
 // continuing segment numbering — do NOT clean mid-run.
 
-import { mkdir, readdir, rm } from "node:fs/promises";
+import { mkdir, readdir, readFile, rm } from "node:fs/promises";
 import path from "node:path";
 
 const SEGMENT_PATTERN = /^seg-\d+\.ts$/;
@@ -40,6 +40,67 @@ export async function cleanStageDir(stageHlsDir: string): Promise<number> {
   let removed = 0;
   for (const name of entries) {
     if (name === PLAYLIST_NAME || SEGMENT_PATTERN.test(name)) {
+      await rm(path.join(stageHlsDir, name), { force: true });
+      removed++;
+    }
+  }
+  return removed;
+}
+
+/**
+ * Called between ffmpeg invocations to clean up segment files that
+ * ffmpeg left behind but are no longer listed in index.m3u8.
+ *
+ * Why this exists: ffmpeg's `delete_segments` flag removes segments as
+ * they roll off the playlist, but with a `hls_delete_threshold` delay
+ * (default 1 extra segment). When ffmpeg exits, any segments queued
+ * for deletion may not have been removed yet. Over many track
+ * transitions on a long-running stage, these accumulate in /dev/shm.
+ *
+ * Safe semantics: we only delete segments that (a) match the
+ * `seg-<digits>.ts` pattern AND (b) are NOT referenced by the current
+ * playlist. Anything a listener could legitimately fetch is in the
+ * playlist, so this cannot race with an in-flight HTTP GET.
+ *
+ * Returns the number of files removed. Silently tolerates a missing
+ * directory or missing playlist (returns 0).
+ */
+export async function pruneOrphanSegments(
+  stageHlsDir: string,
+): Promise<number> {
+  const playlistPath = path.join(stageHlsDir, PLAYLIST_NAME);
+  let playlist: string;
+  try {
+    playlist = await readFile(playlistPath, "utf8");
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === "ENOENT") return 0;
+    throw err;
+  }
+
+  const referenced = new Set<string>();
+  for (const rawLine of playlist.split("\n")) {
+    const line = rawLine.trim();
+    if (!line || line.startsWith("#")) continue;
+    // HLS entries can be bare names, relative paths, or absolute paths
+    // depending on how ffmpeg was configured. Take the basename and
+    // match against the seg-*.ts pattern.
+    const basename = line.split("/").pop() ?? "";
+    if (SEGMENT_PATTERN.test(basename)) {
+      referenced.add(basename);
+    }
+  }
+
+  let entries: string[];
+  try {
+    entries = await readdir(stageHlsDir);
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === "ENOENT") return 0;
+    throw err;
+  }
+
+  let removed = 0;
+  for (const name of entries) {
+    if (SEGMENT_PATTERN.test(name) && !referenced.has(name)) {
       await rm(path.join(stageHlsDir, name), { force: true });
       removed++;
     }

--- a/apps/engine/src/stages/index.ts
+++ b/apps/engine/src/stages/index.ts
@@ -10,7 +10,11 @@ export type { BuildFfmpegArgsInput } from "./ffmpeg-args.ts";
 export { runTrack } from "./runner.ts";
 export type { RunTrackInput, TrackExit } from "./runner.ts";
 
-export { prepareStageDir, cleanStageDir } from "./hls-dir.ts";
+export {
+  prepareStageDir,
+  cleanStageDir,
+  pruneOrphanSegments,
+} from "./hls-dir.ts";
 
 export { startStage, defaultSleep } from "./supervisor.ts";
 export type {

--- a/apps/engine/src/stages/index.ts
+++ b/apps/engine/src/stages/index.ts
@@ -1,0 +1,22 @@
+// Public surface of the per-stage ffmpeg supervisor.
+//
+// Task 3 deliverable — the supervisor is pure infrastructure. Wiring
+// the 10 audio stages and the /api/stages HTTP endpoints lands in
+// Task 5 (engine index.ts).
+
+export { buildFfmpegArgs } from "./ffmpeg-args.ts";
+export type { BuildFfmpegArgsInput } from "./ffmpeg-args.ts";
+
+export { runTrack } from "./runner.ts";
+export type { RunTrackInput, TrackExit } from "./runner.ts";
+
+export { prepareStageDir, cleanStageDir } from "./hls-dir.ts";
+
+export { startStage, defaultSleep } from "./supervisor.ts";
+export type {
+  StartStageConfig,
+  StageController,
+  StageStatus,
+  StageEvent,
+  RunTrackFn,
+} from "./supervisor.ts";

--- a/apps/engine/src/stages/integration.test.ts
+++ b/apps/engine/src/stages/integration.test.ts
@@ -1,0 +1,216 @@
+// End-to-end smoke test for the stage supervisor against a real ffmpeg.
+//
+// Skipped automatically when ffmpeg isn't on PATH (dev machines without
+// it, or CI environments that haven't installed it). When ffmpeg is
+// available, this is the only test that catches invalid argv combos the
+// unit tests can't — ffmpeg refusing a flag, a typo in the HLS output
+// format name, segments not actually appearing on disk, etc.
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import {
+  execFile as execFileCb,
+  type ExecFileException,
+} from "node:child_process";
+import { promisify } from "node:util";
+import {
+  mkdtemp,
+  readdir,
+  readFile,
+  rm,
+  stat,
+} from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import type { Track } from "@pavoia/shared";
+
+import { startStage, type StageEvent } from "./supervisor.ts";
+
+const execFile = promisify(execFileCb);
+
+async function ffmpegAvailable(): Promise<boolean> {
+  try {
+    await execFile("ffmpeg", ["-version"]);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function writeSilentFixture(
+  dest: string,
+  durationSec: number,
+): Promise<void> {
+  // lavfi generates silence without needing an input file. AAC 128/44.1/stereo
+  // matches the stage encoding exactly, so no resampling stage is needed in
+  // the supervisor's ffmpeg — keeps the test fast.
+  await execFile("ffmpeg", [
+    "-hide_banner",
+    "-loglevel",
+    "error",
+    "-f",
+    "lavfi",
+    "-i",
+    `anullsrc=r=44100:cl=stereo`,
+    "-t",
+    String(durationSec),
+    "-c:a",
+    "aac",
+    "-b:a",
+    "128k",
+    "-y",
+    dest,
+  ]);
+}
+
+function makeTrack(filePath: string): Track {
+  return {
+    plexRatingKey: 1,
+    fallbackHash: "integration-test00",
+    title: "silence",
+    artist: "test",
+    album: "test",
+    albumYear: null,
+    durationSec: 4,
+    filePath,
+    coverUrl: null,
+  };
+}
+
+async function waitFor(
+  predicate: () => Promise<boolean>,
+  timeoutMs: number,
+  pollMs = 100,
+): Promise<void> {
+  const start = Date.now();
+  while (Date.now() - start < timeoutMs) {
+    if (await predicate()) return;
+    await new Promise((r) => setTimeout(r, pollMs));
+  }
+  throw new Error(`timed out after ${timeoutMs}ms`);
+}
+
+describe("integration: real ffmpeg", () => {
+  it("produces an m3u8 and at least one segment from a real audio file", async (t) => {
+    if (!(await ffmpegAvailable())) {
+      t.skip("ffmpeg not available on PATH — integration test skipped");
+      return;
+    }
+
+    const work = await mkdtemp(path.join(tmpdir(), "pavoia-integ-"));
+    try {
+      const fixture = path.join(work, "silence.aac");
+      const hlsDir = path.join(work, "hls");
+      await writeSilentFixture(fixture, 4);
+
+      const events: StageEvent[] = [];
+      const stderrLines: string[] = [];
+
+      const ctl = startStage({
+        stageId: "integration",
+        tracks: [makeTrack(fixture)],
+        hlsDir,
+        fallbackFile: fixture,
+        onEvent: (e) => events.push(e),
+        onStderrLine: (l) => stderrLines.push(l),
+      });
+
+      // First segment appears ~3s in (-hls_time 3) when ffmpeg runs with -re.
+      // Allow up to 10s to be resilient on slow CI runners.
+      await waitFor(
+        async () => {
+          try {
+            const entries = await readdir(hlsDir);
+            return (
+              entries.includes("index.m3u8") &&
+              entries.some((e) => /^seg-\d+\.ts$/.test(e))
+            );
+          } catch {
+            return false;
+          }
+        },
+        10_000,
+      );
+
+      const entries = await readdir(hlsDir);
+      assert.ok(
+        entries.includes("index.m3u8"),
+        `m3u8 missing; dir=${entries.join(",")}`,
+      );
+      const segments = entries.filter((e) => /^seg-\d+\.ts$/.test(e));
+      assert.ok(
+        segments.length >= 1,
+        `expected >=1 segment; got ${segments.length}`,
+      );
+
+      // A segment file must have non-zero size.
+      if (segments[0]) {
+        const segStat = await stat(path.join(hlsDir, segments[0]));
+        assert.ok(segStat.size > 0, "segment file is empty");
+      }
+
+      // m3u8 must advertise the HLS flags we set.
+      const m3u8 = await readFile(path.join(hlsDir, "index.m3u8"), "utf8");
+      assert.match(m3u8, /#EXTM3U/);
+      assert.match(m3u8, /#EXT-X-TARGETDURATION/);
+
+      await ctl.stop();
+      assert.equal(ctl.status(), "stopped");
+    } catch (err) {
+      // Surface ffmpeg stderr to make CI failures diagnosable.
+      const cause = err as ExecFileException & { stderr?: string };
+      if (cause?.stderr) {
+        process.stderr.write(`ffmpeg stderr:\n${cause.stderr}\n`);
+      }
+      throw err;
+    } finally {
+      await rm(work, { recursive: true, force: true });
+    }
+  });
+
+  it("cleans the HLS dir on startup, removing stale segments", async (t) => {
+    if (!(await ffmpegAvailable())) {
+      t.skip("ffmpeg not available on PATH");
+      return;
+    }
+
+    const work = await mkdtemp(path.join(tmpdir(), "pavoia-integ-"));
+    try {
+      const fixture = path.join(work, "silence.aac");
+      const hlsDir = path.join(work, "hls");
+      await writeSilentFixture(fixture, 4);
+
+      // Pre-seed stale files that must be cleaned.
+      const { mkdir, writeFile } = await import("node:fs/promises");
+      await mkdir(hlsDir, { recursive: true });
+      await writeFile(path.join(hlsDir, "seg-99999.ts"), "stale");
+      await writeFile(path.join(hlsDir, "index.m3u8"), "#EXTM3U\n# stale\n");
+
+      const ctl = startStage({
+        stageId: "clean",
+        tracks: [makeTrack(fixture)],
+        hlsDir,
+        fallbackFile: fixture,
+      });
+
+      // After startup, seg-99999.ts must be gone (clean ran before spawn).
+      await waitFor(
+        async () => {
+          try {
+            const entries = await readdir(hlsDir);
+            return !entries.includes("seg-99999.ts");
+          } catch {
+            return false;
+          }
+        },
+        5000,
+      );
+      const entries = await readdir(hlsDir);
+      assert.ok(!entries.includes("seg-99999.ts"), "stale segment not cleaned");
+
+      await ctl.stop();
+    } finally {
+      await rm(work, { recursive: true, force: true });
+    }
+  });
+});

--- a/apps/engine/src/stages/integration.test.ts
+++ b/apps/engine/src/stages/integration.test.ts
@@ -26,7 +26,11 @@ import { tmpdir } from "node:os";
 import path from "node:path";
 import type { Track } from "@pavoia/shared";
 
-import { startStage, type StageEvent } from "./supervisor.ts";
+import {
+  startStage,
+  type StageController,
+  type StageEvent,
+} from "./supervisor.ts";
 
 const execFile = promisify(execFileCb);
 
@@ -100,6 +104,7 @@ describe("integration: real ffmpeg", () => {
     }
 
     const work = await mkdtemp(path.join(tmpdir(), "pavoia-integ-"));
+    let ctl: StageController | null = null;
     try {
       const fixture = path.join(work, "silence.aac");
       const hlsDir = path.join(work, "hls");
@@ -108,7 +113,7 @@ describe("integration: real ffmpeg", () => {
       const events: StageEvent[] = [];
       const stderrLines: string[] = [];
 
-      const ctl = startStage({
+      ctl = startStage({
         stageId: "integration",
         tracks: [makeTrack(fixture)],
         hlsDir,
@@ -166,6 +171,13 @@ describe("integration: real ffmpeg", () => {
       }
       throw err;
     } finally {
+      // Stop the supervisor on EVERY exit path, including assertion
+      // failures. Otherwise startStage's loop keeps respawning ffmpeg
+      // after the fixture is deleted, leaking processes and potentially
+      // hanging the test runner.
+      if (ctl && ctl.status() !== "stopped") {
+        await ctl.stop().catch(() => {});
+      }
       await rm(work, { recursive: true, force: true });
     }
   });
@@ -177,6 +189,7 @@ describe("integration: real ffmpeg", () => {
     }
 
     const work = await mkdtemp(path.join(tmpdir(), "pavoia-integ-"));
+    let ctl: StageController | null = null;
     try {
       const fixture = path.join(work, "silence.aac");
       const hlsDir = path.join(work, "hls");
@@ -187,7 +200,7 @@ describe("integration: real ffmpeg", () => {
       await writeFile(path.join(hlsDir, "seg-99999.ts"), "stale");
       await writeFile(path.join(hlsDir, "index.m3u8"), "#EXTM3U\n# stale\n");
 
-      const ctl = startStage({
+      ctl = startStage({
         stageId: "clean",
         tracks: [makeTrack(fixture)],
         hlsDir,
@@ -211,6 +224,11 @@ describe("integration: real ffmpeg", () => {
 
       await ctl.stop();
     } finally {
+      // Same pattern as the first integration test — always stop the
+      // supervisor, even on assertion failure.
+      if (ctl && ctl.status() !== "stopped") {
+        await ctl.stop().catch(() => {});
+      }
       await rm(work, { recursive: true, force: true });
     }
   });

--- a/apps/engine/src/stages/integration.test.ts
+++ b/apps/engine/src/stages/integration.test.ts
@@ -105,13 +105,13 @@ describe("integration: real ffmpeg", () => {
 
     const work = await mkdtemp(path.join(tmpdir(), "pavoia-integ-"));
     let ctl: StageController | null = null;
+    // Declared outside the try so the catch block can surface them.
+    const events: StageEvent[] = [];
+    const stderrLines: string[] = [];
     try {
       const fixture = path.join(work, "silence.aac");
       const hlsDir = path.join(work, "hls");
       await writeSilentFixture(fixture, 4);
-
-      const events: StageEvent[] = [];
-      const stderrLines: string[] = [];
 
       ctl = startStage({
         stageId: "integration",
@@ -164,10 +164,20 @@ describe("integration: real ffmpeg", () => {
       await ctl.stop();
       assert.equal(ctl.status(), "stopped");
     } catch (err) {
-      // Surface ffmpeg stderr to make CI failures diagnosable.
-      const cause = err as ExecFileException & { stderr?: string };
-      if (cause?.stderr) {
-        process.stderr.write(`ffmpeg stderr:\n${cause.stderr}\n`);
+      // Surface ffmpeg diagnostics to make CI failures debuggable.
+      // Prefer the lines captured from the supervisor's ffmpeg (the one
+      // we are actually testing); fall back to ExecFileException.stderr
+      // only if the supervisor never produced any lines (e.g. the
+      // writeSilentFixture call itself failed before startStage ran).
+      if (stderrLines.length > 0) {
+        process.stderr.write(
+          `supervisor ffmpeg stderr:\n${stderrLines.join("\n")}\n`,
+        );
+      } else {
+        const cause = err as ExecFileException & { stderr?: string };
+        if (cause?.stderr) {
+          process.stderr.write(`ffmpeg stderr:\n${cause.stderr}\n`);
+        }
       }
       throw err;
     } finally {

--- a/apps/engine/src/stages/integration.test.ts
+++ b/apps/engine/src/stages/integration.test.ts
@@ -14,11 +14,13 @@ import {
 } from "node:child_process";
 import { promisify } from "node:util";
 import {
+  mkdir,
   mkdtemp,
   readdir,
   readFile,
   rm,
   stat,
+  writeFile,
 } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
@@ -181,7 +183,6 @@ describe("integration: real ffmpeg", () => {
       await writeSilentFixture(fixture, 4);
 
       // Pre-seed stale files that must be cleaned.
-      const { mkdir, writeFile } = await import("node:fs/promises");
       await mkdir(hlsDir, { recursive: true });
       await writeFile(path.join(hlsDir, "seg-99999.ts"), "stale");
       await writeFile(path.join(hlsDir, "index.m3u8"), "#EXTM3U\n# stale\n");

--- a/apps/engine/src/stages/runner.test.ts
+++ b/apps/engine/src/stages/runner.test.ts
@@ -1,0 +1,165 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+
+import { runTrack } from "./runner.ts";
+
+/**
+ * These tests use `node -e "<script>"` as a fake ffmpeg. That lets us
+ * simulate arbitrary exit codes, signal handlers, and stderr patterns
+ * portably without shipping shell scripts. process.execPath is always
+ * available (we're IN node).
+ */
+const FAKE_FFMPEG = process.execPath;
+
+describe("runTrack", () => {
+  it("resolves { kind: 'ok' } on exit 0", async () => {
+    const ac = new AbortController();
+    const result = await runTrack({
+      ffmpegBin: FAKE_FFMPEG,
+      argv: ["-e", "process.exit(0)"],
+      signal: ac.signal,
+    });
+    assert.deepEqual(result, { kind: "ok" });
+  });
+
+  it("resolves { kind: 'crashed', code } on non-zero exit", async () => {
+    const ac = new AbortController();
+    const result = await runTrack({
+      ffmpegBin: FAKE_FFMPEG,
+      argv: ["-e", "process.exit(42)"],
+      signal: ac.signal,
+    });
+    assert.deepEqual(result, { kind: "crashed", code: 42, signal: null });
+  });
+
+  it("resolves { kind: 'aborted' } when the signal is already aborted", async () => {
+    const ac = new AbortController();
+    ac.abort();
+    const result = await runTrack({
+      ffmpegBin: FAKE_FFMPEG,
+      argv: ["-e", "process.exit(0)"],
+      signal: ac.signal,
+    });
+    assert.deepEqual(result, { kind: "aborted" });
+  });
+
+  it("resolves { kind: 'aborted' } when the signal aborts mid-run (SIGTERM cooperates)", async () => {
+    const ac = new AbortController();
+    const script = `
+      setInterval(() => {}, 1000);
+      process.on("SIGTERM", () => process.exit(143));
+    `;
+    const p = runTrack({
+      ffmpegBin: FAKE_FFMPEG,
+      argv: ["-e", script],
+      signal: ac.signal,
+      killTimeoutMs: 5000,
+    });
+    setTimeout(() => ac.abort(), 50);
+    const result = await p;
+    assert.deepEqual(result, { kind: "aborted" });
+  });
+
+  it("escalates to SIGKILL if the child ignores SIGTERM", async () => {
+    const ac = new AbortController();
+    const script = `
+      process.on("SIGTERM", () => {});
+      setInterval(() => {}, 1000);
+    `;
+    const start = Date.now();
+    const p = runTrack({
+      ffmpegBin: FAKE_FFMPEG,
+      argv: ["-e", script],
+      signal: ac.signal,
+      killTimeoutMs: 150,
+    });
+    setTimeout(() => ac.abort(), 20);
+    const result = await p;
+    assert.deepEqual(result, { kind: "aborted" });
+    // SIGKILL escalation must have happened within a reasonable window —
+    // guards against a regression where the kill timer doesn't fire.
+    assert.ok(
+      Date.now() - start < 1000,
+      `took ${Date.now() - start}ms; SIGKILL timer likely did not fire`,
+    );
+  });
+
+  it("forwards stderr to onStderrLine, split on newlines", async () => {
+    const ac = new AbortController();
+    const lines: string[] = [];
+    const script = `
+      process.stderr.write("line one\\n");
+      process.stderr.write("line two\\nline three\\n");
+      process.exit(0);
+    `;
+    await runTrack({
+      ffmpegBin: FAKE_FFMPEG,
+      argv: ["-e", script],
+      signal: ac.signal,
+      onStderrLine: (l) => lines.push(l),
+    });
+    assert.deepEqual(lines, ["line one", "line two", "line three"]);
+  });
+
+  it("never throws when onStderrLine itself throws", async () => {
+    const ac = new AbortController();
+    const script = `
+      process.stderr.write("boom\\n");
+      process.exit(0);
+    `;
+    const result = await runTrack({
+      ffmpegBin: FAKE_FFMPEG,
+      argv: ["-e", script],
+      signal: ac.signal,
+      onStderrLine: () => {
+        throw new Error("logger down");
+      },
+    });
+    assert.deepEqual(result, { kind: "ok" });
+  });
+
+  it("resolves { kind: 'crashed' } when the binary is missing", async () => {
+    const ac = new AbortController();
+    const result = await runTrack({
+      ffmpegBin: "/nonexistent/ffmpeg-xyz-does-not-exist-here",
+      argv: [],
+      signal: ac.signal,
+    });
+    assert.equal(result.kind, "crashed");
+  });
+
+  it("is safe to abort twice (idempotent)", async () => {
+    const ac = new AbortController();
+    const script = `
+      setInterval(() => {}, 1000);
+      process.on("SIGTERM", () => process.exit(0));
+    `;
+    const p = runTrack({
+      ffmpegBin: FAKE_FFMPEG,
+      argv: ["-e", script],
+      signal: ac.signal,
+    });
+    setTimeout(() => {
+      ac.abort();
+      ac.abort(); // double abort should be harmless
+    }, 30);
+    const result = await p;
+    // On Linux, SIGTERM handlers that call process.exit(0) yield an
+    // exit-code=0 path — which runTrack classifies by caller intent:
+    // since the caller aborted, the outcome is "aborted".
+    assert.deepEqual(result, { kind: "aborted" });
+  });
+
+  it("leaves no child behind after the promise resolves", async () => {
+    const ac = new AbortController();
+    const script = `process.exit(0);`;
+    const before = process.listenerCount("exit");
+    await runTrack({
+      ffmpegBin: FAKE_FFMPEG,
+      argv: ["-e", script],
+      signal: ac.signal,
+    });
+    const after = process.listenerCount("exit");
+    assert.equal(after, before, "runTrack must not leak process 'exit' listeners");
+  });
+});

--- a/apps/engine/src/stages/runner.test.ts
+++ b/apps/engine/src/stages/runner.test.ts
@@ -89,16 +89,54 @@ describe("runTrack", () => {
     );
   });
 
-  it("drains all stderr before resolving — no race between exit and readline close", async () => {
-    // Regression: Node can emit 'exit' before readline has delivered
-    // its last stderr 'line' event. Listening on 'close' (not 'exit')
-    // is what guarantees the logger gets the final diagnostic lines.
-    // If the fix regresses, this test sometimes reports 0 lines.
+  it("delivers every stderr line when many lines are written then the child exits naturally", async () => {
+    // Regression: exercises the race between the child 'close' event
+    // and readline's buffered 'line' emission. The runner must gate
+    // resolution on BOTH events. If it resolved on 'close' alone,
+    // lines that were buffered in readline but not yet emitted as
+    // 'line' events would be lost.
+    //
+    // NOTE: process.exit() in the child SKIPS stdio flush, so we use a
+    // natural exit (letting the write callback complete) to isolate
+    // the runner's race from Node's exit-flushing behavior. The race
+    // we care about is on the PARENT (runner) side: given the data
+    // reached the pipe, did the runner wait for readline to surface
+    // it? That is what this test verifies.
+    const ac = new AbortController();
+    const lines: string[] = [];
+    const N = 200;
+    const script = `
+      let pending = ${N};
+      for (let i = 0; i < ${N}; i++) {
+        process.stderr.write('line' + i + '\\n', () => {
+          if (--pending === 0) process.exit(0);
+        });
+      }
+    `;
+    const result = await runTrack({
+      ffmpegBin: FAKE_FFMPEG,
+      argv: ["-e", script],
+      signal: ac.signal,
+      onStderrLine: (l) => lines.push(l),
+    });
+    assert.deepEqual(result, { kind: "ok" });
+    assert.equal(lines.length, N, `got ${lines.length}/${N} lines`);
+    for (let i = 0; i < N; i++) {
+      assert.equal(lines[i], `line${i}`, `line ${i} mismatch`);
+    }
+  });
+
+  it("drains all stderr before resolving — no race between child close and readline close", async () => {
+    // Regression: even after switching to 'close' (from 'exit'),
+    // readline can still have buffered 'line' events in-flight when
+    // the child's 'close' fires. The runner must also gate on
+    // readline's 'close' event before settling. Written as a tight
+    // write-then-exit sequence that uses the write callback to make
+    // sure the byte actually flushed before the child exits.
     const ac = new AbortController();
     const lines: string[] = [];
     const script = `
-      process.stderr.write("final diagnostic\\n");
-      process.exit(1);
+      process.stderr.write("final diagnostic\\n", () => process.exit(1));
     `;
     const result = await runTrack({
       ffmpegBin: FAKE_FFMPEG,
@@ -114,12 +152,15 @@ describe("runTrack", () => {
   });
 
   it("forwards stderr to onStderrLine, split on newlines", async () => {
+    // Uses a write-callback to ensure the last chunk is flushed before
+    // process.exit — otherwise process.exit can race the final write
+    // and drop bytes, masking runner correctness behind a Node-exit
+    // behavior that's unrelated to what this test is checking.
     const ac = new AbortController();
     const lines: string[] = [];
     const script = `
       process.stderr.write("line one\\n");
-      process.stderr.write("line two\\nline three\\n");
-      process.exit(0);
+      process.stderr.write("line two\\nline three\\n", () => process.exit(0));
     `;
     await runTrack({
       ffmpegBin: FAKE_FFMPEG,

--- a/apps/engine/src/stages/runner.test.ts
+++ b/apps/engine/src/stages/runner.test.ts
@@ -84,6 +84,30 @@ describe("runTrack", () => {
     );
   });
 
+  it("drains all stderr before resolving — no race between exit and readline close", async () => {
+    // Regression: Node can emit 'exit' before readline has delivered
+    // its last stderr 'line' event. Listening on 'close' (not 'exit')
+    // is what guarantees the logger gets the final diagnostic lines.
+    // If the fix regresses, this test sometimes reports 0 lines.
+    const ac = new AbortController();
+    const lines: string[] = [];
+    const script = `
+      process.stderr.write("final diagnostic\\n");
+      process.exit(1);
+    `;
+    const result = await runTrack({
+      ffmpegBin: FAKE_FFMPEG,
+      argv: ["-e", script],
+      signal: ac.signal,
+      onStderrLine: (l) => lines.push(l),
+    });
+    assert.deepEqual(result, { kind: "crashed", code: 1, signal: null });
+    assert.ok(
+      lines.includes("final diagnostic"),
+      `final stderr line must be captured; lines=${JSON.stringify(lines)}`,
+    );
+  });
+
   it("forwards stderr to onStderrLine, split on newlines", async () => {
     const ac = new AbortController();
     const lines: string[] = [];

--- a/apps/engine/src/stages/runner.test.ts
+++ b/apps/engine/src/stages/runner.test.ts
@@ -78,8 +78,13 @@ describe("runTrack", () => {
     assert.deepEqual(result, { kind: "aborted" });
     // SIGKILL escalation must have happened within a reasonable window —
     // guards against a regression where the kill timer doesn't fire.
+    // Generous upper bound (2s) to absorb CI scheduler jitter. The
+    // invariant we care about is that SIGKILL fires within a reasonable
+    // window of killTimeoutMs=150 — orders of magnitude below 2s is
+    // plenty of slack. Anything larger would mean the kill timer
+    // didn't fire at all.
     assert.ok(
-      Date.now() - start < 1000,
+      Date.now() - start < 2000,
       `took ${Date.now() - start}ms; SIGKILL timer likely did not fire`,
     );
   });
@@ -174,7 +179,14 @@ describe("runTrack", () => {
     assert.deepEqual(result, { kind: "aborted" });
   });
 
-  it("leaves no child behind after the promise resolves", async () => {
+  it("does not add global process 'exit' listeners per run", async () => {
+    // What this actually verifies: runTrack must not register listeners
+    // on the global `process` object. If it did, looping the supervisor
+    // over hundreds of tracks would eventually hit Node's
+    // MaxListenersExceededWarning. The caller's own AbortSignal is a
+    // separate concern — internal listener removal there is covered by
+    // the "is safe to abort twice (idempotent)" test above (the second
+    // abort being a no-op proves the listener was cleared on exit).
     const ac = new AbortController();
     const script = `process.exit(0);`;
     const before = process.listenerCount("exit");
@@ -184,6 +196,10 @@ describe("runTrack", () => {
       signal: ac.signal,
     });
     const after = process.listenerCount("exit");
-    assert.equal(after, before, "runTrack must not leak process 'exit' listeners");
+    assert.equal(
+      after,
+      before,
+      "runTrack must not add listeners to the global process 'exit' event",
+    );
   });
 });

--- a/apps/engine/src/stages/runner.ts
+++ b/apps/engine/src/stages/runner.ts
@@ -1,0 +1,132 @@
+// Runs a single ffmpeg invocation to completion and reports the outcome.
+//
+// The thin seam between `buildFfmpegArgs()` and the supervisor — pure
+// process lifecycle with no policy. One call == one spawn == one exit.
+//
+// Contract:
+//   - spawn(ffmpegBin, argv) with stdin ignored (matches -nostdin).
+//   - stderr is drained line-by-line to `onStderrLine` so slow consumers
+//     don't backpressure ffmpeg.
+//   - The returned promise resolves (never rejects) to one of:
+//       { kind: "ok" }            — ffmpeg exited 0
+//       { kind: "aborted" }       — caller aborted the AbortSignal
+//       { kind: "crashed", ... }  — anything else (non-zero exit, signal
+//                                   other than our SIGTERM, spawn error)
+//   - When the caller aborts: SIGTERM immediately, then SIGKILL after
+//     `killTimeoutMs` (default 5s) if the child hasn't exited. This is
+//     important for Whatbox's cron watchdog redeploy pattern (Req E):
+//     the engine must stop cleanly within the 5s SIGTERM window.
+
+import { spawn } from "node:child_process";
+import { createInterface } from "node:readline";
+
+export type TrackExit =
+  | { kind: "ok" }
+  | { kind: "aborted" }
+  | { kind: "crashed"; code: number | null; signal: NodeJS.Signals | null };
+
+export interface RunTrackInput {
+  /** Absolute path or bare name resolved on PATH. Defaults to "ffmpeg". */
+  ffmpegBin?: string;
+  /** Full argv AFTER the binary. */
+  argv: string[];
+  /** Caller aborts this to request graceful stop. */
+  signal: AbortSignal;
+  /** Called once per stderr line (CR/LF stripped). Default: no-op. */
+  onStderrLine?: (line: string) => void;
+  /** Grace period between SIGTERM and SIGKILL. Default 5000 ms. */
+  killTimeoutMs?: number;
+}
+
+export function runTrack(input: RunTrackInput): Promise<TrackExit> {
+  const {
+    ffmpegBin = "ffmpeg",
+    argv,
+    signal,
+    onStderrLine = () => {},
+    killTimeoutMs = 5000,
+  } = input;
+
+  if (signal.aborted) {
+    return Promise.resolve<TrackExit>({ kind: "aborted" });
+  }
+
+  return new Promise<TrackExit>((resolve) => {
+    const child = spawn(ffmpegBin, argv, {
+      stdio: ["ignore", "ignore", "pipe"],
+    });
+
+    let settled = false;
+    let abortedByCaller = false;
+    let killTimer: NodeJS.Timeout | null = null;
+
+    const clearKillTimer = () => {
+      if (killTimer) {
+        clearTimeout(killTimer);
+        killTimer = null;
+      }
+    };
+
+    const onAbort = () => {
+      if (abortedByCaller || settled) return;
+      abortedByCaller = true;
+      if (child.exitCode === null && child.signalCode === null) {
+        child.kill("SIGTERM");
+        killTimer = setTimeout(() => {
+          if (child.exitCode === null && child.signalCode === null) {
+            child.kill("SIGKILL");
+          }
+        }, killTimeoutMs);
+        killTimer.unref();
+      }
+    };
+    signal.addEventListener("abort", onAbort, { once: true });
+
+    const settle = (outcome: TrackExit) => {
+      if (settled) return;
+      settled = true;
+      clearKillTimer();
+      signal.removeEventListener("abort", onAbort);
+      resolve(outcome);
+    };
+
+    if (child.stderr) {
+      // Prevent uncaught 'error' from a broken stderr pipe crashing the
+      // process. ffmpeg's stderr rarely errors, but EPIPE is possible
+      // if the child closes it asynchronously.
+      child.stderr.on("error", () => {});
+      const rl = createInterface({ input: child.stderr });
+      rl.on("line", (line) => {
+        try {
+          onStderrLine(line);
+        } catch {
+          // Never let a logger failure propagate into ffmpeg's lifecycle.
+        }
+      });
+      rl.on("error", () => {});
+    }
+
+    child.on("error", (err) => {
+      // Spawn-level failure (binary missing, EACCES). 'exit' may or may
+      // not follow depending on libuv; settle() guards against both.
+      try {
+        onStderrLine(
+          `[runner] spawn error: ${err instanceof Error ? err.message : String(err)}`,
+        );
+      } catch {
+        /* ignore */
+      }
+      settle({ kind: "crashed", code: null, signal: null });
+    });
+
+    child.on("exit", (code, sig) => {
+      if (abortedByCaller) {
+        settle({ kind: "aborted" });
+      } else if (code === 0 && sig === null) {
+        settle({ kind: "ok" });
+      } else {
+        settle({ kind: "crashed", code, signal: sig });
+      }
+    });
+  });
+}

--- a/apps/engine/src/stages/runner.ts
+++ b/apps/engine/src/stages/runner.ts
@@ -107,8 +107,8 @@ export function runTrack(input: RunTrackInput): Promise<TrackExit> {
     }
 
     child.on("error", (err) => {
-      // Spawn-level failure (binary missing, EACCES). 'exit' may or may
-      // not follow depending on libuv; settle() guards against both.
+      // Spawn-level failure (binary missing, EACCES). 'close' still
+      // follows per Node docs; settle() guards against the double fire.
       try {
         onStderrLine(
           `[runner] spawn error: ${err instanceof Error ? err.message : String(err)}`,
@@ -119,7 +119,13 @@ export function runTrack(input: RunTrackInput): Promise<TrackExit> {
       settle({ kind: "crashed", code: null, signal: null });
     });
 
-    child.on("exit", (code, sig) => {
+    // Listen on 'close', NOT 'exit'. 'exit' can fire before stderr has
+    // been fully drained through readline, which loses the final lines
+    // of ffmpeg's stderr diagnostics — exactly the lines that matter
+    // when ffmpeg crashes. 'close' is guaranteed by Node to fire AFTER
+    // the stdio streams have closed. See Node docs for child_process
+    // 'close' vs 'exit'.
+    child.on("close", (code, sig) => {
       if (abortedByCaller) {
         settle({ kind: "aborted" });
       } else if (code === 0 && sig === null) {

--- a/apps/engine/src/stages/runner.ts
+++ b/apps/engine/src/stages/runner.ts
@@ -59,6 +59,12 @@ export function runTrack(input: RunTrackInput): Promise<TrackExit> {
     let settled = false;
     let abortedByCaller = false;
     let killTimer: NodeJS.Timeout | null = null;
+    let childClosed = false;
+    let readlineClosed = false;
+    let pendingExit: {
+      code: number | null;
+      sig: NodeJS.Signals | null;
+    } | null = null;
 
     const clearKillTimer = () => {
       if (killTimer) {
@@ -90,6 +96,27 @@ export function runTrack(input: RunTrackInput): Promise<TrackExit> {
       resolve(outcome);
     };
 
+    // Settle only after BOTH the child process has closed AND the
+    // readline interface has flushed its buffered 'line' events. On
+    // Node 25 the child 'close' event can race with readline's internal
+    // line buffering — if we resolved on 'close' alone, a tightly
+    // written "last diagnostic line + exit" sequence from ffmpeg can
+    // drop the final line. Gating on readline's own 'close' (which
+    // fires AFTER readline has emitted every line it buffered from the
+    // now-ended input stream) makes stderr delivery ordered w.r.t.
+    // resolution.
+    const tryFinish = () => {
+      if (settled || !childClosed || !readlineClosed || !pendingExit) return;
+      const { code, sig } = pendingExit;
+      if (abortedByCaller) {
+        settle({ kind: "aborted" });
+      } else if (code === 0 && sig === null) {
+        settle({ kind: "ok" });
+      } else {
+        settle({ kind: "crashed", code, signal: sig });
+      }
+    };
+
     if (child.stderr) {
       // Prevent uncaught 'error' from a broken stderr pipe crashing the
       // process. ffmpeg's stderr rarely errors, but EPIPE is possible
@@ -104,11 +131,20 @@ export function runTrack(input: RunTrackInput): Promise<TrackExit> {
         }
       });
       rl.on("error", () => {});
+      rl.on("close", () => {
+        readlineClosed = true;
+        tryFinish();
+      });
+    } else {
+      // No stderr to drain (shouldn't happen under our stdio config).
+      readlineClosed = true;
     }
 
     child.on("error", (err) => {
       // Spawn-level failure (binary missing, EACCES). 'close' still
-      // follows per Node docs; settle() guards against the double fire.
+      // follows per Node docs; settle() below guards against the double
+      // fire. On spawn failure we resolve immediately — there's no
+      // meaningful stderr to wait for.
       try {
         onStderrLine(
           `[runner] spawn error: ${err instanceof Error ? err.message : String(err)}`,
@@ -119,20 +155,10 @@ export function runTrack(input: RunTrackInput): Promise<TrackExit> {
       settle({ kind: "crashed", code: null, signal: null });
     });
 
-    // Listen on 'close', NOT 'exit'. 'exit' can fire before stderr has
-    // been fully drained through readline, which loses the final lines
-    // of ffmpeg's stderr diagnostics — exactly the lines that matter
-    // when ffmpeg crashes. 'close' is guaranteed by Node to fire AFTER
-    // the stdio streams have closed. See Node docs for child_process
-    // 'close' vs 'exit'.
     child.on("close", (code, sig) => {
-      if (abortedByCaller) {
-        settle({ kind: "aborted" });
-      } else if (code === 0 && sig === null) {
-        settle({ kind: "ok" });
-      } else {
-        settle({ kind: "crashed", code, signal: sig });
-      }
+      childClosed = true;
+      pendingExit = { code, sig };
+      tryFinish();
     });
   });
 }

--- a/apps/engine/src/stages/supervisor.test.ts
+++ b/apps/engine/src/stages/supervisor.test.ts
@@ -251,6 +251,46 @@ describe("startStage — empty playlist / fallback", () => {
     await rm(work, { recursive: true, force: true });
   });
 
+  it("a clean exit from the -stream_loop fallback is NOT counted as a crash", async () => {
+    // Regression: -stream_loop -1 ffmpeg shouldn't exit cleanly on its
+    // own. If it does (edge case: unreadable file closing immediately),
+    // treat it as an unexpected-but-benign event — restart with backoff
+    // but do not emit { type: "crash" } nor approach the crash cap.
+    const runner = makeControlledRunner();
+    const events: StageEvent[] = [];
+
+    const ctl = startStage({
+      stageId: "fallback-ok",
+      tracks: [],
+      hlsDir: path.join(work, "fallback-ok"),
+      fallbackFile: "/music/curating.aac",
+      onEvent: (e) => events.push(e),
+      runTrackImpl: runner.run,
+      sleep: zeroSleep,
+      maxConsecutiveCrashes: 2,
+    });
+
+    // 3 "ok" exits in a row — strictly more than maxConsecutiveCrashes.
+    // If "ok" were mistakenly counted as a crash, the supervisor would
+    // have bailed out after 2 and never reached the 3rd spawn.
+    await runner.waitForCall(1);
+    runner.complete({ kind: "ok" });
+    await runner.waitForCall(2);
+    runner.complete({ kind: "ok" });
+    await runner.waitForCall(3);
+    runner.complete({ kind: "ok" });
+    await runner.waitForCall(4);
+
+    const crashEvents = events.filter((e) => e.type === "crash");
+    assert.equal(
+      crashEvents.length,
+      0,
+      "ok exit in curating mode must not emit crash events",
+    );
+
+    await ctl.stop();
+  });
+
   it("uses -stream_loop -1 on the fallback file when tracks is empty", async () => {
     const runner = makeControlledRunner();
     const events: StageEvent[] = [];

--- a/apps/engine/src/stages/supervisor.test.ts
+++ b/apps/engine/src/stages/supervisor.test.ts
@@ -507,6 +507,40 @@ describe("startStage — crash handling", () => {
     );
   });
 
+  it("clears currentTrack() before transitioning to the curating fallback", async () => {
+    // Regression: when deadTracks fills up and the supervisor falls
+    // through to runCuratingLoop, the last-failed Track was still
+    // being returned by controller.currentTrack() — which would make
+    // the /api/stages/:id/now endpoint lie about what's playing.
+    const runner = makeControlledRunner();
+    const track = makeTrack({ plexRatingKey: 77, filePath: "/m/dead.opus" });
+
+    const ctl = startStage({
+      stageId: "clear-current",
+      tracks: [track],
+      hlsDir: path.join(work, "clear-current"),
+      fallbackFile: "/music/curating.aac",
+      runTrackImpl: runner.run,
+      sleep: zeroSleep,
+      maxConsecutiveCrashes: 2,
+    });
+
+    // Two crashes → skip → fallback
+    await runner.waitForCall(1);
+    runner.complete({ kind: "crashed", code: 1, signal: null });
+    await runner.waitForCall(2);
+    runner.complete({ kind: "crashed", code: 1, signal: null });
+    // By the time the third (fallback) call is in-flight, currentTrack
+    // must no longer point at the dead real track.
+    await runner.waitForCall(3);
+    assert.equal(
+      ctl.currentTrack(),
+      null,
+      `currentTrack() must be null during curating; got ${JSON.stringify(ctl.currentTrack())}`,
+    );
+    await ctl.stop();
+  });
+
   it("falls back to curating when every track in a multi-track playlist is dead", async () => {
     const runner = makeControlledRunner();
     const events: StageEvent[] = [];

--- a/apps/engine/src/stages/supervisor.test.ts
+++ b/apps/engine/src/stages/supervisor.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, beforeEach, afterEach } from "node:test";
 import assert from "node:assert/strict";
-import { mkdtemp, readdir, rm } from "node:fs/promises";
+import { mkdir, mkdtemp, readdir, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import type { Track } from "@pavoia/shared";
@@ -127,7 +127,6 @@ describe("startStage — happy path", () => {
 
     // Seed stale segments that must be removed.
     const stageDir = path.join(work, "opening");
-    const { mkdir, writeFile } = await import("node:fs/promises");
     await mkdir(stageDir, { recursive: true });
     await writeFile(path.join(stageDir, "seg-00000.ts"), "x");
     await writeFile(path.join(stageDir, "index.m3u8"), "#EXTM3U\n");
@@ -585,7 +584,6 @@ describe("startStage — observer safety", () => {
 
     // Seed a file where the supervisor will try to mkdir → ENOTDIR.
     const file = path.join(work, "not-a-dir");
-    const { writeFile } = await import("node:fs/promises");
     await writeFile(file, "");
 
     const ctl = startStage({

--- a/apps/engine/src/stages/supervisor.test.ts
+++ b/apps/engine/src/stages/supervisor.test.ts
@@ -1,0 +1,559 @@
+import { describe, it, beforeEach, afterEach } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtemp, readdir, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import type { Track } from "@pavoia/shared";
+
+import {
+  startStage,
+  type StageEvent,
+  type RunTrackFn,
+} from "./supervisor.ts";
+import type { TrackExit, RunTrackInput } from "./runner.ts";
+
+// --------------------------------------------------------------------
+// Test helpers
+
+function makeTrack(overrides: Partial<Track> = {}): Track {
+  return {
+    plexRatingKey: 1,
+    fallbackHash: "deadbeef00000000",
+    title: "t",
+    artist: "a",
+    album: "b",
+    albumYear: null,
+    durationSec: 60,
+    filePath: "/music/track.opus",
+    coverUrl: null,
+    ...overrides,
+  };
+}
+
+interface ControlledRunner {
+  run: RunTrackFn;
+  calls: RunTrackInput[];
+  /** Resolve the current in-flight run with the given exit. */
+  complete: (exit: TrackExit) => void;
+  /** Number of currently in-flight runs. */
+  inflight: () => number;
+  /** Wait until `calls.length >= n`, or reject on timeout. */
+  waitForCall: (n: number, timeoutMs?: number) => Promise<void>;
+}
+
+interface Pending {
+  resolve: (v: TrackExit) => void;
+  settled: boolean;
+}
+
+function makeControlledRunner(): ControlledRunner {
+  const calls: RunTrackInput[] = [];
+  const pending: Pending[] = [];
+
+  const run: RunTrackFn = (input) => {
+    calls.push(input);
+    return new Promise<TrackExit>((resolve) => {
+      const entry: Pending = {
+        settled: false,
+        resolve: (v) => {
+          if (entry.settled) return;
+          entry.settled = true;
+          resolve(v);
+        },
+      };
+      pending.push(entry);
+      // Mimic the real runTrack: an aborted signal auto-resolves to
+      // { kind: "aborted" }. Without this, a supervisor stop() in the
+      // middle of a test would hang the run loop.
+      if (input.signal.aborted) {
+        entry.resolve({ kind: "aborted" });
+        return;
+      }
+      input.signal.addEventListener(
+        "abort",
+        () => entry.resolve({ kind: "aborted" }),
+        { once: true },
+      );
+    });
+  };
+
+  const complete = (exit: TrackExit) => {
+    const next = pending.find((p) => !p.settled);
+    if (!next) throw new Error("no in-flight runTrack to complete");
+    next.resolve(exit);
+  };
+
+  const waitForCall = async (n: number, timeoutMs = 2000) => {
+    const start = Date.now();
+    while (calls.length < n) {
+      if (Date.now() - start > timeoutMs) {
+        throw new Error(
+          `timed out waiting for call ${n} (have ${calls.length})`,
+        );
+      }
+      await new Promise((r) => setTimeout(r, 5));
+    }
+  };
+
+  const inflight = () => pending.filter((p) => !p.settled).length;
+  return { run, calls, complete, inflight, waitForCall };
+}
+
+/** Immediate, abort-aware sleep. Tests run in milliseconds this way. */
+const zeroSleep = (_ms: number, signal: AbortSignal) =>
+  new Promise<void>((resolve, reject) => {
+    if (signal.aborted) {
+      reject(new Error("aborted"));
+      return;
+    }
+    queueMicrotask(() => resolve());
+  });
+
+// --------------------------------------------------------------------
+// Tests
+
+describe("startStage — happy path", () => {
+  let work: string;
+  beforeEach(async () => {
+    work = await mkdtemp(path.join(tmpdir(), "pavoia-sup-"));
+  });
+  afterEach(async () => {
+    await rm(work, { recursive: true, force: true });
+  });
+
+  it("prepares + cleans hlsDir before any spawn", async () => {
+    const runner = makeControlledRunner();
+    const events: StageEvent[] = [];
+
+    // Seed stale segments that must be removed.
+    const stageDir = path.join(work, "opening");
+    const { mkdir, writeFile } = await import("node:fs/promises");
+    await mkdir(stageDir, { recursive: true });
+    await writeFile(path.join(stageDir, "seg-00000.ts"), "x");
+    await writeFile(path.join(stageDir, "index.m3u8"), "#EXTM3U\n");
+
+    const ctl = startStage({
+      stageId: "opening",
+      tracks: [makeTrack()],
+      hlsDir: stageDir,
+      fallbackFile: "/tmp/curating.aac",
+      onEvent: (e) => events.push(e),
+      runTrackImpl: runner.run,
+      sleep: zeroSleep,
+    });
+
+    await runner.waitForCall(1);
+    // By the time ffmpeg is called, the dir must be clean.
+    const contents = await readdir(stageDir);
+    assert.deepEqual(contents, []);
+
+    runner.complete({ kind: "ok" });
+    await runner.waitForCall(2);
+    await ctl.stop();
+  });
+
+  it("runs tracks sequentially and wraps around", async () => {
+    const runner = makeControlledRunner();
+    const tracks = [
+      makeTrack({ plexRatingKey: 10, filePath: "/m/1.opus" }),
+      makeTrack({ plexRatingKey: 20, filePath: "/m/2.opus" }),
+      makeTrack({ plexRatingKey: 30, filePath: "/m/3.opus" }),
+    ];
+    const events: StageEvent[] = [];
+
+    const ctl = startStage({
+      stageId: "seq",
+      tracks,
+      hlsDir: path.join(work, "seq"),
+      fallbackFile: "/tmp/curating.aac",
+      onEvent: (e) => events.push(e),
+      runTrackImpl: runner.run,
+      sleep: zeroSleep,
+    });
+
+    await runner.waitForCall(1);
+    runner.complete({ kind: "ok" });
+    await runner.waitForCall(2);
+    runner.complete({ kind: "ok" });
+    await runner.waitForCall(3);
+    runner.complete({ kind: "ok" });
+    await runner.waitForCall(4);
+    // Fourth call must be tracks[0] again (wraparound)
+    assert.ok(runner.calls[3], "fourth call exists");
+    assert.ok(
+      runner.calls[3]!.argv.includes("/m/1.opus"),
+      "wraparound back to tracks[0]",
+    );
+
+    await ctl.stop();
+
+    const started = events.filter((e) => e.type === "track_started");
+    assert.ok(started.length >= 3);
+    assert.equal(
+      (started[0] as Extract<StageEvent, { type: "track_started" }>).track
+        .plexRatingKey,
+      10,
+    );
+    assert.equal(
+      (started[1] as Extract<StageEvent, { type: "track_started" }>).track
+        .plexRatingKey,
+      20,
+    );
+    assert.equal(
+      (started[2] as Extract<StageEvent, { type: "track_started" }>).track
+        .plexRatingKey,
+      30,
+    );
+  });
+
+  it("emits track_started + track_ended pairs with matching track", async () => {
+    const runner = makeControlledRunner();
+    const t = makeTrack({ plexRatingKey: 99 });
+    const events: StageEvent[] = [];
+
+    const ctl = startStage({
+      stageId: "pair",
+      tracks: [t],
+      hlsDir: path.join(work, "pair"),
+      fallbackFile: "/tmp/curating.aac",
+      onEvent: (e) => events.push(e),
+      runTrackImpl: runner.run,
+      sleep: zeroSleep,
+    });
+
+    await runner.waitForCall(1);
+    runner.complete({ kind: "ok" });
+    await runner.waitForCall(2);
+    await ctl.stop();
+
+    const started = events.find(
+      (e): e is Extract<StageEvent, { type: "track_started" }> =>
+        e.type === "track_started",
+    );
+    const ended = events.find(
+      (e): e is Extract<StageEvent, { type: "track_ended" }> =>
+        e.type === "track_ended",
+    );
+    assert.ok(started);
+    assert.ok(ended);
+    assert.equal(started.track.plexRatingKey, 99);
+    assert.equal(ended.track.plexRatingKey, 99);
+    assert.deepEqual(ended.exit, { kind: "ok" });
+  });
+});
+
+describe("startStage — empty playlist / fallback", () => {
+  let work: string;
+  beforeEach(async () => {
+    work = await mkdtemp(path.join(tmpdir(), "pavoia-sup-"));
+  });
+  afterEach(async () => {
+    await rm(work, { recursive: true, force: true });
+  });
+
+  it("uses -stream_loop -1 on the fallback file when tracks is empty", async () => {
+    const runner = makeControlledRunner();
+    const events: StageEvent[] = [];
+
+    const ctl = startStage({
+      stageId: "empty",
+      tracks: [],
+      hlsDir: path.join(work, "empty"),
+      fallbackFile: "/music/curating.aac",
+      onEvent: (e) => events.push(e),
+      runTrackImpl: runner.run,
+      sleep: zeroSleep,
+    });
+
+    await runner.waitForCall(1);
+    assert.ok(runner.calls[0], "first call exists");
+    const argv = runner.calls[0]!.argv;
+    const loopIdx = argv.indexOf("-stream_loop");
+    const iIdx = argv.indexOf("-i");
+    assert.ok(loopIdx >= 0 && argv[loopIdx + 1] === "-1");
+    assert.ok(loopIdx < iIdx);
+    assert.equal(argv[iIdx + 1], "/music/curating.aac");
+
+    // stop() aborts the signal; the mock runner auto-resolves to aborted.
+    await ctl.stop();
+
+    const statuses = events
+      .filter((e): e is Extract<StageEvent, { type: "status" }> => e.type === "status")
+      .map((e) => e.status);
+    assert.ok(statuses.includes("curating"));
+  });
+});
+
+describe("startStage — crash handling", () => {
+  let work: string;
+  beforeEach(async () => {
+    work = await mkdtemp(path.join(tmpdir(), "pavoia-sup-"));
+  });
+  afterEach(async () => {
+    await rm(work, { recursive: true, force: true });
+  });
+
+  it("retries the same track after a crash, with backoff", async () => {
+    const runner = makeControlledRunner();
+    const events: StageEvent[] = [];
+
+    let sleepCalls = 0;
+    const trackedSleep = (ms: number, signal: AbortSignal) => {
+      sleepCalls++;
+      return zeroSleep(ms, signal);
+    };
+
+    const ctl = startStage({
+      stageId: "crashy",
+      tracks: [makeTrack({ plexRatingKey: 1 })],
+      hlsDir: path.join(work, "crashy"),
+      fallbackFile: "/tmp/curating.aac",
+      onEvent: (e) => events.push(e),
+      runTrackImpl: runner.run,
+      sleep: trackedSleep,
+      restartBackoffMs: 17,
+    });
+
+    await runner.waitForCall(1);
+    runner.complete({ kind: "crashed", code: 1, signal: null });
+    await runner.waitForCall(2);
+    // Second spawn must be the SAME track (not advanced)
+    assert.ok(runner.calls[1], "second call exists");
+    assert.ok(runner.calls[1]!.argv.includes("/music/track.opus"));
+    runner.complete({ kind: "ok" });
+    await runner.waitForCall(3);
+    await ctl.stop();
+
+    assert.ok(sleepCalls >= 1, "sleep must be called between crashes");
+
+    const crashes = events.filter(
+      (e): e is Extract<StageEvent, { type: "crash" }> => e.type === "crash",
+    );
+    assert.equal(crashes.length, 1);
+    assert.equal(crashes[0]?.consecutive, 1);
+  });
+
+  it("skips a track after maxConsecutiveCrashes and advances", async () => {
+    const runner = makeControlledRunner();
+    const events: StageEvent[] = [];
+    const tracks = [
+      makeTrack({ plexRatingKey: 1, filePath: "/m/corrupt.opus" }),
+      makeTrack({ plexRatingKey: 2, filePath: "/m/fine.opus" }),
+    ];
+
+    const ctl = startStage({
+      stageId: "skippy",
+      tracks,
+      hlsDir: path.join(work, "skippy"),
+      fallbackFile: "/tmp/curating.aac",
+      onEvent: (e) => events.push(e),
+      runTrackImpl: runner.run,
+      sleep: zeroSleep,
+      maxConsecutiveCrashes: 3,
+    });
+
+    // Crash 3 times on the first track
+    for (let n = 1; n <= 3; n++) {
+      await runner.waitForCall(n);
+      runner.complete({ kind: "crashed", code: 1, signal: null });
+    }
+
+    // Next spawn must be the SECOND track (advanced past the corrupt one)
+    await runner.waitForCall(4);
+    assert.ok(runner.calls[3], "fourth call exists");
+    assert.ok(runner.calls[3]!.argv.includes("/m/fine.opus"));
+
+    await ctl.stop();
+
+    const skipped = events.find(
+      (e): e is Extract<StageEvent, { type: "skipped_after_repeated_crashes" }> =>
+        e.type === "skipped_after_repeated_crashes",
+    );
+    assert.ok(skipped);
+    assert.equal(skipped.track.plexRatingKey, 1);
+  });
+
+  it("resets the consecutive-crash counter on a successful run", async () => {
+    const runner = makeControlledRunner();
+    const events: StageEvent[] = [];
+
+    const ctl = startStage({
+      stageId: "reset",
+      tracks: [makeTrack()],
+      hlsDir: path.join(work, "reset"),
+      fallbackFile: "/tmp/curating.aac",
+      onEvent: (e) => events.push(e),
+      runTrackImpl: runner.run,
+      sleep: zeroSleep,
+      maxConsecutiveCrashes: 3,
+    });
+
+    // Crash twice
+    await runner.waitForCall(1);
+    runner.complete({ kind: "crashed", code: 1, signal: null });
+    await runner.waitForCall(2);
+    runner.complete({ kind: "crashed", code: 1, signal: null });
+    // Succeed on the third
+    await runner.waitForCall(3);
+    runner.complete({ kind: "ok" });
+    await runner.waitForCall(4);
+    // Fourth is the track again (single-track loop wrap). Crash again twice more — must NOT be skipped.
+    runner.complete({ kind: "crashed", code: 1, signal: null });
+    await runner.waitForCall(5);
+    runner.complete({ kind: "crashed", code: 1, signal: null });
+    await runner.waitForCall(6);
+    // Still not skipped (would need 3 consecutive after the success)
+    const skipped = events.find(
+      (e) => e.type === "skipped_after_repeated_crashes",
+    );
+    assert.equal(skipped, undefined);
+    await ctl.stop();
+  });
+});
+
+describe("startStage — graceful stop", () => {
+  let work: string;
+  beforeEach(async () => {
+    work = await mkdtemp(path.join(tmpdir(), "pavoia-sup-"));
+  });
+  afterEach(async () => {
+    await rm(work, { recursive: true, force: true });
+  });
+
+  it("stop() aborts the run loop and resolves once done", async () => {
+    const runner = makeControlledRunner();
+    const ctl = startStage({
+      stageId: "stop",
+      tracks: [makeTrack()],
+      hlsDir: path.join(work, "stop"),
+      fallbackFile: "/tmp/curating.aac",
+      runTrackImpl: runner.run,
+      sleep: zeroSleep,
+    });
+
+    await runner.waitForCall(1);
+    await ctl.stop();
+
+    assert.equal(ctl.status(), "stopped");
+    assert.equal(ctl.currentTrack(), null);
+  });
+
+  it("stop() is idempotent — multiple calls resolve to the same state", async () => {
+    const runner = makeControlledRunner();
+    const ctl = startStage({
+      stageId: "idem",
+      tracks: [makeTrack()],
+      hlsDir: path.join(work, "idem"),
+      fallbackFile: "/tmp/curating.aac",
+      runTrackImpl: runner.run,
+      sleep: zeroSleep,
+    });
+
+    await runner.waitForCall(1);
+    const a = ctl.stop();
+    const b = ctl.stop();
+    const c = ctl.stop();
+    await Promise.all([a, b, c]);
+    assert.equal(ctl.status(), "stopped");
+  });
+
+  it("aborting during backoff exits the loop without another spawn", async () => {
+    const runner = makeControlledRunner();
+    let resolveSleep: (() => void) | null = null;
+    let rejectSleep: ((err: Error) => void) | null = null;
+
+    const heldSleep = (_ms: number, signal: AbortSignal) =>
+      new Promise<void>((resolve, reject) => {
+        if (signal.aborted) {
+          reject(new Error("aborted"));
+          return;
+        }
+        resolveSleep = resolve;
+        rejectSleep = reject;
+        signal.addEventListener(
+          "abort",
+          () => reject(new Error("aborted")),
+          { once: true },
+        );
+      });
+
+    const ctl = startStage({
+      stageId: "bounce",
+      tracks: [makeTrack()],
+      hlsDir: path.join(work, "bounce"),
+      fallbackFile: "/tmp/curating.aac",
+      runTrackImpl: runner.run,
+      sleep: heldSleep,
+    });
+
+    await runner.waitForCall(1);
+    runner.complete({ kind: "crashed", code: 1, signal: null });
+    // Wait for sleep to be engaged
+    const start = Date.now();
+    while (!rejectSleep && Date.now() - start < 1000) {
+      await new Promise((r) => setTimeout(r, 5));
+    }
+    assert.ok(rejectSleep, "supervisor must have entered backoff");
+
+    await ctl.stop();
+    assert.equal(ctl.status(), "stopped");
+    // No additional spawn happened during or after the interrupted sleep
+    assert.equal(runner.calls.length, 1);
+    // Unused to silence the linter about resolveSleep
+    void resolveSleep;
+  });
+
+  it("reports status transitions: starting → playing → stopping → stopped", async () => {
+    const runner = makeControlledRunner();
+    const statuses: string[] = [];
+    const ctl = startStage({
+      stageId: "status",
+      tracks: [makeTrack()],
+      hlsDir: path.join(work, "status"),
+      fallbackFile: "/tmp/curating.aac",
+      onEvent: (e) => {
+        if (e.type === "status") statuses.push(e.status);
+      },
+      runTrackImpl: runner.run,
+      sleep: zeroSleep,
+    });
+
+    await runner.waitForCall(1);
+    await ctl.stop();
+
+    assert.ok(statuses.includes("playing"), `statuses: ${statuses.join(",")}`);
+    assert.ok(statuses.includes("stopping"));
+    assert.equal(statuses.at(-1), "stopped");
+  });
+});
+
+describe("startStage — observer safety", () => {
+  let work: string;
+  beforeEach(async () => {
+    work = await mkdtemp(path.join(tmpdir(), "pavoia-sup-"));
+  });
+  afterEach(async () => {
+    await rm(work, { recursive: true, force: true });
+  });
+
+  it("a throwing onEvent does not take the supervisor down", async () => {
+    const runner = makeControlledRunner();
+    const ctl = startStage({
+      stageId: "boom",
+      tracks: [makeTrack()],
+      hlsDir: path.join(work, "boom"),
+      fallbackFile: "/tmp/curating.aac",
+      onEvent: () => {
+        throw new Error("subscriber down");
+      },
+      runTrackImpl: runner.run,
+      sleep: zeroSleep,
+    });
+
+    await runner.waitForCall(1);
+    runner.complete({ kind: "ok" });
+    await runner.waitForCall(2);
+    await ctl.stop();
+    assert.equal(ctl.status(), "stopped");
+  });
+});

--- a/apps/engine/src/stages/supervisor.test.ts
+++ b/apps/engine/src/stages/supervisor.test.ts
@@ -536,6 +536,36 @@ describe("startStage — observer safety", () => {
     await rm(work, { recursive: true, force: true });
   });
 
+  it("a throwing onStderrLine during HLS setup failure does not reject the run loop", async () => {
+    // Regression: if prepareStageDir / cleanStageDir throw AND the
+    // configured onStderrLine throws, the loop must still stop
+    // cleanly — status === "stopped" and no unhandledRejection.
+    // Root cause: internal log calls bypassed the observer guard.
+    const runner = makeControlledRunner();
+
+    // Seed a file where the supervisor will try to mkdir → ENOTDIR.
+    const file = path.join(work, "not-a-dir");
+    const { writeFile } = await import("node:fs/promises");
+    await writeFile(file, "");
+
+    const ctl = startStage({
+      stageId: "setup-fail",
+      tracks: [makeTrack()],
+      hlsDir: path.join(file, "subdir"), // mkdir under a file → fails
+      fallbackFile: "/tmp/curating.aac",
+      onStderrLine: () => {
+        throw new Error("logger is also down");
+      },
+      runTrackImpl: runner.run,
+      sleep: zeroSleep,
+    });
+
+    await ctl.done;
+    assert.equal(ctl.status(), "stopped");
+    // Nothing was ever spawned because setup failed first.
+    assert.equal(runner.calls.length, 0);
+  });
+
   it("a throwing onEvent does not take the supervisor down", async () => {
     const runner = makeControlledRunner();
     const ctl = startStage({

--- a/apps/engine/src/stages/supervisor.test.ts
+++ b/apps/engine/src/stages/supervisor.test.ts
@@ -412,6 +412,103 @@ describe("startStage — crash handling", () => {
     assert.equal(skipped.track.plexRatingKey, 1);
   });
 
+  it("falls back to curating when the single track has been skipped", async () => {
+    // Regression: without the deadTracks guard, a single-track playlist
+    // with a corrupt file would hit maxConsecutiveCrashes, skip, wrap
+    // around via `i = (i + 1) % 1 = 0`, reset the counter, and re-spawn
+    // the same corrupt track forever. Fix: once all tracks are dead,
+    // transition to the -stream_loop -1 fallback.
+    const runner = makeControlledRunner();
+    const events: StageEvent[] = [];
+    const track = makeTrack({ plexRatingKey: 1, filePath: "/m/dead.opus" });
+
+    const ctl = startStage({
+      stageId: "dead-single",
+      tracks: [track],
+      hlsDir: path.join(work, "dead-single"),
+      fallbackFile: "/music/curating.aac",
+      onEvent: (e) => events.push(e),
+      runTrackImpl: runner.run,
+      sleep: zeroSleep,
+      maxConsecutiveCrashes: 2,
+    });
+
+    // Two consecutive crashes hit the cap → skip → fallback
+    await runner.waitForCall(1);
+    runner.complete({ kind: "crashed", code: 1, signal: null });
+    await runner.waitForCall(2);
+    runner.complete({ kind: "crashed", code: 1, signal: null });
+    await runner.waitForCall(3);
+    // Third call must be the FALLBACK, not the same track again.
+    assert.ok(runner.calls[2], "third call exists");
+    const thirdArgv = runner.calls[2]!.argv;
+    assert.ok(
+      thirdArgv.includes("-stream_loop"),
+      "third spawn must be curating fallback with -stream_loop",
+    );
+    assert.equal(
+      thirdArgv[thirdArgv.indexOf("-i") + 1],
+      "/music/curating.aac",
+      "third spawn must feed the fallback file",
+    );
+
+    await ctl.stop();
+
+    const skipped = events.find(
+      (e) => e.type === "skipped_after_repeated_crashes",
+    );
+    assert.ok(skipped, "skipped_after_repeated_crashes was emitted");
+    const statuses = events
+      .filter((e): e is Extract<StageEvent, { type: "status" }> =>
+        e.type === "status",
+      )
+      .map((e) => e.status);
+    assert.ok(
+      statuses.includes("curating"),
+      `expected curating status after skip; got ${statuses.join(",")}`,
+    );
+  });
+
+  it("falls back to curating when every track in a multi-track playlist is dead", async () => {
+    const runner = makeControlledRunner();
+    const events: StageEvent[] = [];
+    const tracks = [
+      makeTrack({ plexRatingKey: 1, filePath: "/m/a.opus" }),
+      makeTrack({ plexRatingKey: 2, filePath: "/m/b.opus" }),
+    ];
+
+    const ctl = startStage({
+      stageId: "all-dead",
+      tracks,
+      hlsDir: path.join(work, "all-dead"),
+      fallbackFile: "/music/curating.aac",
+      onEvent: (e) => events.push(e),
+      runTrackImpl: runner.run,
+      sleep: zeroSleep,
+      maxConsecutiveCrashes: 2,
+    });
+
+    // Crash twice on track a
+    await runner.waitForCall(1);
+    runner.complete({ kind: "crashed", code: 1, signal: null });
+    await runner.waitForCall(2);
+    runner.complete({ kind: "crashed", code: 1, signal: null });
+    // Crash twice on track b
+    await runner.waitForCall(3);
+    runner.complete({ kind: "crashed", code: 1, signal: null });
+    await runner.waitForCall(4);
+    runner.complete({ kind: "crashed", code: 1, signal: null });
+    // Next spawn must be the fallback
+    await runner.waitForCall(5);
+    assert.ok(runner.calls[4], "fifth call exists");
+    assert.ok(
+      runner.calls[4]!.argv.includes("-stream_loop"),
+      "after all tracks dead, supervisor must switch to fallback",
+    );
+
+    await ctl.stop();
+  });
+
   it("resets the consecutive-crash counter on a successful run", async () => {
     const runner = makeControlledRunner();
     const events: StageEvent[] = [];

--- a/apps/engine/src/stages/supervisor.test.ts
+++ b/apps/engine/src/stages/supervisor.test.ts
@@ -205,6 +205,44 @@ describe("startStage — happy path", () => {
     );
   });
 
+  it("snapshots the tracks array at start — later caller mutation has no effect", async () => {
+    const runner = makeControlledRunner();
+    const t1 = makeTrack({ plexRatingKey: 10, filePath: "/m/1.opus" });
+    const t2 = makeTrack({ plexRatingKey: 20, filePath: "/m/2.opus" });
+    const callerArray = [t1, t2];
+
+    const ctl = startStage({
+      stageId: "snap",
+      tracks: callerArray,
+      hlsDir: path.join(work, "snap"),
+      fallbackFile: "/tmp/curating.aac",
+      runTrackImpl: runner.run,
+      sleep: zeroSleep,
+    });
+
+    // Mutate the caller's array AFTER startStage has returned —
+    // swap both tracks to a poisoned one. If the supervisor didn't
+    // snapshot, the next spawn would pick up the mutation.
+    const poison = makeTrack({ plexRatingKey: 999, filePath: "/poison" });
+    callerArray[0] = poison;
+    callerArray[1] = poison;
+
+    await runner.waitForCall(1);
+    runner.complete({ kind: "ok" });
+    await runner.waitForCall(2);
+
+    assert.ok(runner.calls[0], "first call exists");
+    assert.ok(runner.calls[1], "second call exists");
+    // Spawns must use the ORIGINAL tracks, not the poisoned ones.
+    assert.ok(runner.calls[0]!.argv.includes("/m/1.opus"));
+    assert.ok(runner.calls[1]!.argv.includes("/m/2.opus"));
+    // And definitely not the poison.
+    assert.ok(!runner.calls[0]!.argv.includes("/poison"));
+    assert.ok(!runner.calls[1]!.argv.includes("/poison"));
+
+    await ctl.stop();
+  });
+
   it("emits track_started + track_ended pairs with matching track", async () => {
     const runner = makeControlledRunner();
     const t = makeTrack({ plexRatingKey: 99 });

--- a/apps/engine/src/stages/supervisor.ts
+++ b/apps/engine/src/stages/supervisor.ts
@@ -1,0 +1,312 @@
+// Per-stage ffmpeg supervisor.
+//
+// Owns one stage's HLS output directory and runs a sequential ffmpeg
+// loop inside it:
+//
+//   tracks.length > 0 →  spawn ffmpeg for tracks[0], wait for exit,
+//                        advance, spawn ffmpeg for tracks[1], … wrap
+//                        around at tracks.length (Req K + N).
+//   tracks.length === 0 → spawn ffmpeg -stream_loop -1 on the fallback
+//                        file; only exits when the supervisor aborts
+//                        it (Req O — "curating…").
+//
+// Crash handling (Req: "crash restart with 500 ms backoff"):
+//   - Non-zero exit → log, sleep restartBackoffMs, retry THE SAME track.
+//   - After maxConsecutiveCrashes in a row on the same track, emit
+//     `skipped_after_repeated_crashes` and advance — this is the escape
+//     hatch so a single corrupt file can't hot-loop the supervisor.
+//   - A successful run resets the crash counter.
+//
+// Graceful stop:
+//   - stop() aborts the AbortController, which:
+//       (a) signals the active ffmpeg via runner → SIGTERM → SIGKILL
+//       (b) wakes any in-progress backoff sleep → loop exits
+//   - stop() resolves after the run loop has finished; safe to call
+//     multiple times concurrently.
+//
+// This module intentionally performs NO networking, NO Plex polling,
+// NO /api routing. Wiring lives in Task 5 (engine index.ts).
+
+import type { Track } from "@pavoia/shared";
+
+import { buildFfmpegArgs } from "./ffmpeg-args.ts";
+import { cleanStageDir, prepareStageDir } from "./hls-dir.ts";
+import { runTrack, type RunTrackInput, type TrackExit } from "./runner.ts";
+
+const DEFAULT_RESTART_BACKOFF_MS = 500;
+const DEFAULT_MAX_CONSECUTIVE_CRASHES = 3;
+
+export type StageStatus =
+  | "starting"
+  | "playing"
+  | "curating"
+  | "stopping"
+  | "stopped";
+
+export type StageEvent =
+  | { type: "status"; status: StageStatus }
+  | { type: "track_started"; track: Track; startedAt: number }
+  | { type: "track_ended"; track: Track; exit: TrackExit }
+  | { type: "curating_started"; startedAt: number }
+  | { type: "curating_ended"; exit: TrackExit }
+  | { type: "crash"; track: Track | null; exit: TrackExit; consecutive: number }
+  | { type: "skipped_after_repeated_crashes"; track: Track };
+
+/** Minimal, testable injection surface for the runner. */
+export type RunTrackFn = (input: RunTrackInput) => Promise<TrackExit>;
+
+export interface StartStageConfig {
+  /** Used only for log prefixes + event payloads; no validation. */
+  stageId: string;
+  /** Captured by reference at start; later mutation has no effect. */
+  tracks: readonly Track[];
+  /** Absolute HLS output directory (e.g. /dev/shm/1008/radio-hls/<stage>). */
+  hlsDir: string;
+  /** Absolute path to the curating/silence fallback file (Req O). */
+  fallbackFile: string;
+  /** Defaults to "ffmpeg" on PATH. */
+  ffmpegBin?: string;
+  /** Delay between a crashed ffmpeg and the retry. Default 500 ms. */
+  restartBackoffMs?: number;
+  /** After N consecutive crashes on the same track, advance. Default 3. */
+  maxConsecutiveCrashes?: number;
+  /** Grace period between SIGTERM and SIGKILL on stop. Default 5000 ms. */
+  killTimeoutMs?: number;
+  /** Observer for the supervisor's state machine. Default: no-op. */
+  onEvent?: (event: StageEvent) => void;
+  /** Per-line ffmpeg stderr drain. Default: no-op. */
+  onStderrLine?: (line: string) => void;
+  /** Injectable for tests. Default: real `runTrack`. */
+  runTrackImpl?: RunTrackFn;
+  /** Injectable for tests. Default: real `setTimeout`. */
+  sleep?: (ms: number, signal: AbortSignal) => Promise<void>;
+}
+
+export interface StageController {
+  readonly stageId: string;
+  status(): StageStatus;
+  currentTrack(): Track | null;
+  /** Resolves after the supervisor's run loop has exited. */
+  stop(): Promise<void>;
+  /** Same promise returned from stop(); also resolves on a fatal error. */
+  readonly done: Promise<void>;
+}
+
+export function startStage(config: StartStageConfig): StageController {
+  const {
+    stageId,
+    tracks,
+    hlsDir,
+    fallbackFile,
+    ffmpegBin = "ffmpeg",
+    restartBackoffMs = DEFAULT_RESTART_BACKOFF_MS,
+    maxConsecutiveCrashes = DEFAULT_MAX_CONSECUTIVE_CRASHES,
+    killTimeoutMs = 5000,
+    onEvent = () => {},
+    onStderrLine = () => {},
+    runTrackImpl = runTrack,
+    sleep = defaultSleep,
+  } = config;
+
+  const ac = new AbortController();
+  let status: StageStatus = "starting";
+  let currentTrack: Track | null = null;
+
+  const emit = (ev: StageEvent): void => {
+    try {
+      onEvent(ev);
+    } catch {
+      // Never let an observer bug take the stage down.
+    }
+  };
+  const setStatus = (s: StageStatus): void => {
+    if (status === s) return;
+    status = s;
+    emit({ type: "status", status: s });
+  };
+
+  const runOne = (
+    track: Track,
+    loopInput: boolean,
+  ): Promise<TrackExit> => {
+    const argv = buildFfmpegArgs({
+      trackFilePath: track.filePath,
+      stageHlsDir: hlsDir,
+      loopInput,
+    });
+    return runTrackImpl({
+      ffmpegBin,
+      argv,
+      signal: ac.signal,
+      onStderrLine,
+      killTimeoutMs,
+    });
+  };
+
+  async function runLoop(): Promise<void> {
+    try {
+      await prepareStageDir(hlsDir);
+      await cleanStageDir(hlsDir);
+    } catch (err) {
+      onStderrLine(
+        `[stage:${stageId}] hls dir setup failed: ${
+          err instanceof Error ? err.message : String(err)
+        }`,
+      );
+      return;
+    }
+
+    if (ac.signal.aborted) return;
+
+    if (tracks.length === 0) {
+      await runCuratingLoop();
+      return;
+    }
+
+    let i = 0;
+    while (!ac.signal.aborted) {
+      const track = tracks[i];
+      if (!track) {
+        // Defensive: shouldn't happen given i is bounded, but satisfies
+        // noUncheckedIndexedAccess and guards a future bug.
+        break;
+      }
+      currentTrack = track;
+      setStatus("playing");
+
+      let consecutiveCrashes = 0;
+      while (!ac.signal.aborted) {
+        const startedAt = Date.now();
+        emit({ type: "track_started", track, startedAt });
+
+        const exit = await runOne(track, false);
+
+        emit({ type: "track_ended", track, exit });
+
+        if (exit.kind === "ok") {
+          break; // advance
+        }
+        if (exit.kind === "aborted") {
+          return;
+        }
+        consecutiveCrashes++;
+        emit({ type: "crash", track, exit, consecutive: consecutiveCrashes });
+
+        if (consecutiveCrashes >= maxConsecutiveCrashes) {
+          emit({ type: "skipped_after_repeated_crashes", track });
+          break;
+        }
+        const slept = await sleepOrAbort(restartBackoffMs);
+        if (!slept) return;
+      }
+
+      if (ac.signal.aborted) return;
+      i = (i + 1) % tracks.length;
+    }
+  }
+
+  async function runCuratingLoop(): Promise<void> {
+    // With -stream_loop -1 ffmpeg should only exit when aborted. If it
+    // crashes, restart with backoff — same cap as per-track.
+    const sentinel: Track = {
+      plexRatingKey: 0,
+      fallbackHash: "",
+      title: "Curating",
+      artist: "Pavoia",
+      album: "Fallback",
+      albumYear: null,
+      durationSec: 0,
+      filePath: fallbackFile,
+      coverUrl: null,
+    };
+
+    let consecutiveCrashes = 0;
+    while (!ac.signal.aborted) {
+      const startedAt = Date.now();
+      emit({ type: "curating_started", startedAt });
+      setStatus("curating");
+
+      const exit = await runOne(sentinel, true);
+
+      emit({ type: "curating_ended", exit });
+
+      if (exit.kind === "aborted") return;
+
+      consecutiveCrashes++;
+      emit({
+        type: "crash",
+        track: null,
+        exit,
+        consecutive: consecutiveCrashes,
+      });
+
+      if (consecutiveCrashes >= maxConsecutiveCrashes) {
+        onStderrLine(
+          `[stage:${stageId}] fallback crashed ${consecutiveCrashes} times — stopping`,
+        );
+        return;
+      }
+      const slept = await sleepOrAbort(restartBackoffMs);
+      if (!slept) return;
+    }
+  }
+
+  async function sleepOrAbort(ms: number): Promise<boolean> {
+    try {
+      await sleep(ms, ac.signal);
+      return !ac.signal.aborted;
+    } catch {
+      return false;
+    }
+  }
+
+  const loop = runLoop()
+    .catch((err) => {
+      onStderrLine(
+        `[stage:${stageId}] fatal: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    })
+    .finally(() => {
+      currentTrack = null;
+      setStatus("stopped");
+    });
+
+  async function stop(): Promise<void> {
+    if (status === "stopped") return;
+    if (!ac.signal.aborted) {
+      setStatus("stopping");
+      ac.abort();
+    }
+    await loop;
+  }
+
+  return {
+    stageId,
+    status: () => status,
+    currentTrack: () => currentTrack,
+    stop,
+    done: loop,
+  };
+}
+
+export function defaultSleep(
+  ms: number,
+  signal: AbortSignal,
+): Promise<void> {
+  return new Promise((resolve, reject) => {
+    if (signal.aborted) {
+      reject(new Error("aborted"));
+      return;
+    }
+    let timer: NodeJS.Timeout | null = null;
+    const onAbort = () => {
+      if (timer) clearTimeout(timer);
+      reject(new Error("aborted"));
+    };
+    timer = setTimeout(() => {
+      signal.removeEventListener("abort", onAbort);
+      resolve();
+    }, ms);
+    signal.addEventListener("abort", onAbort, { once: true });
+  });
+}

--- a/apps/engine/src/stages/supervisor.ts
+++ b/apps/engine/src/stages/supervisor.ts
@@ -175,8 +175,19 @@ export function startStage(config: StartStageConfig): StageController {
       return;
     }
 
+    // Tracks that exceeded maxConsecutiveCrashes this session are
+    // marked dead and not re-selected. When all tracks are dead we
+    // transition to the curating fallback — this is what prevents a
+    // single-track playlist with a corrupt file from hot-looping the
+    // crash cap forever.
+    const deadTracks = new Set<number>();
     let i = 0;
     while (!ac.signal.aborted) {
+      if (deadTracks.size >= tracks.length) break; // all dead → curating
+      // Advance past any already-dead track. Safe because the guard
+      // above proves at least one track is alive.
+      while (deadTracks.has(i)) i = (i + 1) % tracks.length;
+
       const track = tracks[i];
       if (!track) {
         // Defensive: shouldn't happen given i is bounded, but satisfies
@@ -206,6 +217,7 @@ export function startStage(config: StartStageConfig): StageController {
 
         if (consecutiveCrashes >= maxConsecutiveCrashes) {
           emit({ type: "skipped_after_repeated_crashes", track });
+          deadTracks.add(i);
           break;
         }
         const slept = await sleepOrAbort(restartBackoffMs);
@@ -214,6 +226,12 @@ export function startStage(config: StartStageConfig): StageController {
 
       if (ac.signal.aborted) return;
       i = (i + 1) % tracks.length;
+    }
+
+    // All tracks exhausted without a successful run — fall through to
+    // the fallback loop so the stage still produces a stream.
+    if (!ac.signal.aborted && deadTracks.size >= tracks.length) {
+      await runCuratingLoop();
     }
   }
 

--- a/apps/engine/src/stages/supervisor.ts
+++ b/apps/engine/src/stages/supervisor.ts
@@ -296,13 +296,18 @@ export function startStage(config: StartStageConfig): StageController {
       setStatus("stopped");
     });
 
-  async function stop(): Promise<void> {
-    if (status === "stopped") return;
+  let stopPromise: Promise<void> | null = null;
+  function stop(): Promise<void> {
+    if (status === "stopped") return Promise.resolve();
+    // Perfect idempotency: concurrent stop() callers share the identical
+    // promise, not separate microtask chains.
+    if (stopPromise) return stopPromise;
     if (!ac.signal.aborted) {
       setStatus("stopping");
       ac.abort();
     }
-    await loop;
+    stopPromise = loop;
+    return stopPromise;
   }
 
   return {

--- a/apps/engine/src/stages/supervisor.ts
+++ b/apps/engine/src/stages/supervisor.ts
@@ -30,11 +30,7 @@
 import type { Track } from "@pavoia/shared";
 
 import { buildFfmpegArgs } from "./ffmpeg-args.ts";
-import {
-  cleanStageDir,
-  prepareStageDir,
-  pruneOrphanSegments,
-} from "./hls-dir.ts";
+import { cleanStageDir, prepareStageDir } from "./hls-dir.ts";
 import { runTrack, type RunTrackInput, type TrackExit } from "./runner.ts";
 
 const DEFAULT_RESTART_BACKOFF_MS = 500;
@@ -235,17 +231,26 @@ export function startStage(config: StartStageConfig): StageController {
       }
 
       if (ac.signal.aborted) return;
-      // Between ffmpeg invocations, sweep any orphan segments that the
-      // just-exited ffmpeg left behind (past its delete_segments
-      // threshold). Safe: only deletes seg-*.ts not referenced by the
-      // current index.m3u8, which listeners won't be fetching.
-      try {
-        await pruneOrphanSegments(hlsDir);
-      } catch (err) {
-        safeLog(
-          `[stage:${stageId}] prune failed: ${err instanceof Error ? err.message : String(err)}`,
-        );
-      }
+      // INTENTIONALLY NO between-track pruning here.
+      //
+      // It is tempting to sweep seg-*.ts files that the just-exited
+      // ffmpeg left behind and that aren't in the current playlist —
+      // see pruneOrphanSegments in hls-dir.ts. But ffmpeg's
+      // `hls_delete_threshold` keeps those unreferenced segments on
+      // disk intentionally as a client safety buffer: listeners that
+      // fetched the playlist right before the track boundary can
+      // legitimately request segments that are no longer in the
+      // newly-written playlist. Pruning them here creates a 404
+      // window and stalls transitions.
+      //
+      // Orphans do accumulate over many track changes, but:
+      //   - Per track: at most `hls_delete_threshold` files (~48 KB each
+      //     at 128 kbps × 3 s), default 1.
+      //   - Stage dir lives in /dev/shm/1008, which Whatbox wipes on
+      //     reboot (Req F), bounding total growth.
+      //
+      // pruneOrphanSegments() is still exported for offline / on-stop
+      // cleanup use; we simply don't run it between tracks.
       i = (i + 1) % tracks.length;
     }
 

--- a/apps/engine/src/stages/supervisor.ts
+++ b/apps/engine/src/stages/supervisor.ts
@@ -58,7 +58,8 @@ export type RunTrackFn = (input: RunTrackInput) => Promise<TrackExit>;
 export interface StartStageConfig {
   /** Used only for log prefixes + event payloads; no validation. */
   stageId: string;
-  /** Captured by reference at start; later mutation has no effect. */
+  /** Shallow-copied at start; later mutation of the caller's array
+   *  has no effect on the supervisor. */
   tracks: readonly Track[];
   /** Absolute HLS output directory (e.g. /dev/shm/1008/radio-hls/<stage>). */
   hlsDir: string;
@@ -95,7 +96,6 @@ export interface StageController {
 export function startStage(config: StartStageConfig): StageController {
   const {
     stageId,
-    tracks,
     hlsDir,
     fallbackFile,
     ffmpegBin = "ffmpeg",
@@ -107,6 +107,12 @@ export function startStage(config: StartStageConfig): StageController {
     runTrackImpl = runTrack,
     sleep = defaultSleep,
   } = config;
+  // Defensive shallow copy so an external mutation of the caller's
+  // array after startStage() has returned cannot change the supervisor's
+  // iteration order or inject/remove tracks mid-run. The `readonly`
+  // TypeScript constraint is a compile-time hint only — a caller could
+  // cast it away.
+  const tracks: readonly Track[] = [...config.tracks];
 
   const ac = new AbortController();
   let status: StageStatus = "starting";

--- a/apps/engine/src/stages/supervisor.ts
+++ b/apps/engine/src/stages/supervisor.ts
@@ -119,6 +119,18 @@ export function startStage(config: StartStageConfig): StageController {
       // Never let an observer bug take the stage down.
     }
   };
+  // Same guard for onStderrLine: a throwing logger must never reject
+  // the run loop or leak as an unhandledRejection. The runner already
+  // wraps its own stderr pipe; this covers the supervisor's own internal
+  // log lines (hls-dir setup failure, repeated fallback crashes, fatal
+  // catch-all, etc.).
+  const safeLog = (line: string): void => {
+    try {
+      onStderrLine(line);
+    } catch {
+      /* ignore */
+    }
+  };
   const setStatus = (s: StageStatus): void => {
     if (status === s) return;
     status = s;
@@ -148,7 +160,7 @@ export function startStage(config: StartStageConfig): StageController {
       await prepareStageDir(hlsDir);
       await cleanStageDir(hlsDir);
     } catch (err) {
-      onStderrLine(
+      safeLog(
         `[stage:${stageId}] hls dir setup failed: ${
           err instanceof Error ? err.message : String(err)
         }`,
@@ -241,7 +253,7 @@ export function startStage(config: StartStageConfig): StageController {
       });
 
       if (consecutiveCrashes >= maxConsecutiveCrashes) {
-        onStderrLine(
+        safeLog(
           `[stage:${stageId}] fallback crashed ${consecutiveCrashes} times — stopping`,
         );
         return;
@@ -262,7 +274,7 @@ export function startStage(config: StartStageConfig): StageController {
 
   const loop = runLoop()
     .catch((err) => {
-      onStderrLine(
+      safeLog(
         `[stage:${stageId}] fatal: ${err instanceof Error ? err.message : String(err)}`,
       );
     })

--- a/apps/engine/src/stages/supervisor.ts
+++ b/apps/engine/src/stages/supervisor.ts
@@ -244,6 +244,19 @@ export function startStage(config: StartStageConfig): StageController {
 
       if (exit.kind === "aborted") return;
 
+      if (exit.kind === "ok") {
+        // With -stream_loop -1 ffmpeg is expected to run until aborted,
+        // not to exit cleanly. A clean exit is unexpected but NOT a
+        // crash — don't emit { type: "crash" } or bump the crash
+        // counter. Back off briefly so we don't hot-loop if whatever
+        // edge case caused the exit (e.g. unreadable fallback file
+        // that ffmpeg just closes) is sticky.
+        consecutiveCrashes = 0;
+        const slept = await sleepOrAbort(restartBackoffMs);
+        if (!slept) return;
+        continue;
+      }
+
       consecutiveCrashes++;
       emit({
         type: "crash",

--- a/apps/engine/src/stages/supervisor.ts
+++ b/apps/engine/src/stages/supervisor.ts
@@ -30,7 +30,11 @@
 import type { Track } from "@pavoia/shared";
 
 import { buildFfmpegArgs } from "./ffmpeg-args.ts";
-import { cleanStageDir, prepareStageDir } from "./hls-dir.ts";
+import {
+  cleanStageDir,
+  prepareStageDir,
+  pruneOrphanSegments,
+} from "./hls-dir.ts";
 import { runTrack, type RunTrackInput, type TrackExit } from "./runner.ts";
 
 const DEFAULT_RESTART_BACKOFF_MS = 500;
@@ -231,12 +235,26 @@ export function startStage(config: StartStageConfig): StageController {
       }
 
       if (ac.signal.aborted) return;
+      // Between ffmpeg invocations, sweep any orphan segments that the
+      // just-exited ffmpeg left behind (past its delete_segments
+      // threshold). Safe: only deletes seg-*.ts not referenced by the
+      // current index.m3u8, which listeners won't be fetching.
+      try {
+        await pruneOrphanSegments(hlsDir);
+      } catch (err) {
+        safeLog(
+          `[stage:${stageId}] prune failed: ${err instanceof Error ? err.message : String(err)}`,
+        );
+      }
       i = (i + 1) % tracks.length;
     }
 
     // All tracks exhausted without a successful run — fall through to
-    // the fallback loop so the stage still produces a stream.
+    // the fallback loop so the stage still produces a stream. Clear
+    // currentTrack so callers querying currentTrack() during curating
+    // mode don't see the last-failed track as "now playing".
     if (!ac.signal.aborted && deadTracks.size >= tracks.length) {
+      currentTrack = null;
       await runCuratingLoop();
     }
   }


### PR DESCRIPTION
## Summary

Implements Week 1 Task 3 per WEEK0_LOG reqs **K–P**: a per-stage supervisor that runs one ffmpeg per track, detects track boundaries via the Node `exit` event (Req N), loops `curating.aac` via `-stream_loop -1` on an empty playlist (Req O), restarts a crashed track with 500 ms backoff, and stops gracefully through an `AbortSignal` (SIGTERM → SIGKILL after 5 s).

Split into five modules, each unit-tested in isolation:

- `ffmpeg-args.ts` — pure argv builder. Locks the HLS flag combo, AAC 128/stereo/44.1 encoding, and real-time pacing (`-re` — the flag that makes *"exit = track boundary"* actually work).
- `runner.ts` — single-spawn lifecycle. `Promise<TrackExit>` discriminated into `ok | aborted | crashed`. `node -e "<script>"` fakes ffmpeg in tests for portability.
- `hls-dir.ts` — mkdir-p on start, targeted cleanup of stale `index.m3u8` + `seg-*.ts`. Non-HLS files preserved.
- `supervisor.ts` — `startStage()` → `StageController`. Sequential track loop + wraparound, fallback loop, consecutive-crash cap so a single corrupt file cannot hot-loop a stage, observer safety.
- `integration.test.ts` — end-to-end against real ffmpeg on a lavfi-generated silence fixture. Auto-skips when ffmpeg is absent.

**CI now installs ffmpeg** so the integration tests execute on every PR. Engine README updated with a full "Stage supervisor" section.

## Why

1. **-re is non-negotiable.** WEEK0_LOG Step 3 explicitly used `-re` for the verified prototype; without it ffmpeg reads the whole file in ~100 ms and exits before the rolling 6-segment window is populated, so the "exit = track boundary" contract silently breaks. My first pass missed this; adding it was the biggest catch of the adversarial self-review.

2. **Track boundary = `exit` event, not stderr parsing.** Req N. The supervisor subscribes to `child.on('exit')` via the runner; there is no ICY-tag parser, no `-progress pipe:1` reader, no stderr regex. Simplest possible mechanism.

3. **Consecutive-crash cap.** WEEK0_LOG only mandates "500 ms backoff on crash". A literal implementation would hot-loop a corrupt file forever. Added `maxConsecutiveCrashes` (default 3) with a `skipped_after_repeated_crashes` event so Task 5 can surface it on `/api/stages/:id/now`.

4. **Segment-number collision across invocations is a non-issue.** WEEK0_LOG Step 3b verified continuity via `+append_list` (seen 5, 6, 7, 8, 9, 10, 11 on disk with 0–4 rolled out). I confirmed this behavior matters here — no `-start_number` plumbing needed.

## Test plan

- [x] `npm run typecheck` — clean on strict mode with `exactOptionalPropertyTypes` and `noUncheckedIndexedAccess`.
- [x] `npm test` — **108/108** pass, including 2 real-ffmpeg integration tests (~4.4 s total).
- [x] CodeRabbit CLI on uncommitted diff — 0 findings.
- [x] Pre-push CodeRabbit gate vs origin/main — "Review completed: No findings ✔".
- [ ] CodeRabbit GitHub App review on this PR — waiting.
- [ ] Codex adversarial review — scheduled.
- [ ] CI green on this PR.
- [ ] Triple-signoff merge gate.

## Out of scope

- Wiring the supervisor into `index.ts` / `/api/stages*` (Task 5).
- 60 s Plex-polling loop for dynamic playlist updates (Task 5).
- WebSocket `track_changed` emission (Task 5).

Refs `docs/WEEK0_LOG.md` reqs K, L, M, N, O, P; `docs/SLIM_V3.md` §"Audio engine".

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Public per-stage supervisor for HLS emission with lifecycle controls, status reporting, crash-restart/backoff, skip-after-repeated-crashes, playlist wraparound, and empty-playlist curating fallback.

* **Tests**
  * Comprehensive unit and integration tests including FFmpeg arg generation, process runner behavior, HLS directory helpers, supervisor logic, and end-to-end FFmpeg smoke tests.

* **Chores**
  * CI now installs and verifies ffmpeg.

* **Documentation**
  * README updated to reflect current supervisor capabilities, running components, and remaining integration work.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->