### PR TITLE
feat(engine): supervisor hardening — preflight, TTL, watchdog, deferred track_started

### DIFF
--- a/apps/engine/README.md
+++ b/apps/engine/README.md
@@ -97,9 +97,14 @@ src/
     ├── runner.test.ts             # uses `node -e` as a fake ffmpeg for portability
     ├── hls-dir.ts                 # prepare + clean the per-stage HLS output directory
     ├── hls-dir.test.ts
+    ├── preflight.ts               # fs.stat-based track validation (missing / empty / non-file)
+    ├── preflight.test.ts
+    ├── watchers.ts                # first-segment watchdog (no-progress detection)
+    ├── watchers.test.ts
     ├── supervisor.ts              # startStage() — sequential track loop, crash restart, stop()
     ├── supervisor.test.ts         # controlled-runner mock drives the full state machine
     ├── integration.test.ts        # end-to-end against real ffmpeg (auto-skips if absent)
+    ├── audio-integrity.test.ts    # decode HLS back to PCM, assert click-free + silence floor
     └── index.ts                   # public surface for the engine entry point
 ```
 
@@ -128,8 +133,11 @@ await ctl.stop();  // SIGTERM current ffmpeg, SIGKILL after 5s if stubborn
 
 - **Directory lifecycle.** `mkdir -p` on start; wipes `index.m3u8` + `seg-*.ts` from any previous run so the first spawn is a clean slate. Between tracks the dir is NOT touched — cross-track segment numbering relies on ffmpeg's `+append_list` reading the existing m3u8 (verified in WEEK0_LOG Step 3b).
 - **One ffmpeg per track (Req K).** Built from `buildFfmpegArgs()` — see that module for the full flag list and the *why* behind each one. Track boundary = ffmpeg `exit` event in Node; no stderr parsing (Req N). Critical flag: `-re` paces input at real time, so a 5-minute track takes ~5 real minutes and the rolling 6-segment, 3-second-each HLS window stays populated.
-- **Fallback for empty playlists (Req O).** When `tracks.length === 0`, wraps the input with `-stream_loop -1` so ffmpeg never exits on its own. Status stays `curating`.
-- **Crash restart.** Non-zero exit → sleeps `restartBackoffMs` (default 500 ms) → retries the SAME track. After `maxConsecutiveCrashes` in a row (default 3) on a single track, emits `skipped_after_repeated_crashes` and advances — this is the escape hatch so a single corrupt file can't hot-loop the stage.
+- **Fallback for empty playlists (Req O).** When `tracks.length === 0`, wraps the input with `-stream_loop -1` so ffmpeg never exits on its own. Status stays `curating`. The fallback file is validated via `preflightTrack` before we spawn — a missing/empty fallback exits cleanly rather than hot-looping `-stream_loop -1` failures.
+- **Pre-flight (hardening).** Every track runs through `fs.stat` before ffmpeg is spawned — missing file / dangling symlink / directory / zero-byte / sub-1 KiB files all get rejected fast as `preflight_failed`, no ffmpeg startup burned. This is the killer case for stale Plex paths (rename / rescan lag) — 3 × ENOENT-retries was self-inflicted silence.
+- **Crash restart + dead-track TTL.** Non-zero exit → sleeps `restartBackoffMs` (default 500 ms) → retries the SAME track. After `maxConsecutiveCrashes` in a row (default 3) on a single track, OR after a preflight failure, the track is marked dead for `deadTtlMs` (default 10 minutes). Transient Whatbox I/O hiccups recover on their own; genuinely corrupt files stay skipped but come back into rotation when Plex rescans. If all tracks are dead right now, the stage falls through to the curating loop.
+- **First-segment watchdog (hardening).** After spawning ffmpeg, the supervisor watches `hlsDir` for the first `seg-*.ts` to appear within `firstSegmentTimeoutMs` (default 5 s). If the deadline passes with no segment — meaning libav is hanging on an unreadable file or the kernel is stalled on tmpfs — the supervisor aborts the child and classifies the outcome as a synthetic crash. Emits `watchdog_timeout`. Set to 0 to disable (and fall back to the legacy "emit track_started at spawn" behavior).
+- **Honest now-playing.** The `track_started` event fires only after the first segment lands on disk. Before that moment the supervisor doesn't claim the track is "now playing" — `currentTrack()` and any downstream WebSocket feed show the previous track's state until there's actual audio being produced.
 - **Graceful stop.** `stop()` aborts the internal `AbortController`. The runner translates that into `SIGTERM`, escalates to `SIGKILL` after 5 s, and resolves `aborted`. `stop()` resolves after the run loop has exited and the status has transitioned to `stopped`. Idempotent: multiple concurrent `stop()` calls share the same promise.
 - **Observer safety.** A throwing `onEvent` or `onStderrLine` is swallowed — a subscriber bug can never take a stage down.
 

--- a/apps/engine/src/stages/index.ts
+++ b/apps/engine/src/stages/index.ts
@@ -16,6 +16,12 @@ export {
   pruneOrphanSegments,
 } from "./hls-dir.ts";
 
+export { preflightTrack } from "./preflight.ts";
+export type { PreflightReason, PreflightResult } from "./preflight.ts";
+
+export { waitForFirstSegment } from "./watchers.ts";
+export type { WaitForFirstSegmentInput, WaitResult } from "./watchers.ts";
+
 export { startStage, defaultSleep } from "./supervisor.ts";
 export type {
   StartStageConfig,
@@ -23,4 +29,6 @@ export type {
   StageStatus,
   StageEvent,
   RunTrackFn,
+  WaitForFirstSegmentFn,
+  PreflightFn,
 } from "./supervisor.ts";

--- a/apps/engine/src/stages/preflight.test.ts
+++ b/apps/engine/src/stages/preflight.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, beforeEach, afterEach } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtemp, mkdir, writeFile, symlink, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import { preflightTrack } from "./preflight.ts";
+
+describe("preflightTrack", () => {
+  let work: string;
+  beforeEach(async () => {
+    work = await mkdtemp(path.join(tmpdir(), "pavoia-preflight-"));
+  });
+  afterEach(async () => {
+    await rm(work, { recursive: true, force: true });
+  });
+
+  it("returns ok + size for a regular file above the min threshold", async () => {
+    const p = path.join(work, "track.opus");
+    // 2 KiB of bytes — comfortably above the 1 KiB floor.
+    await writeFile(p, Buffer.alloc(2048, 0x42));
+    const r = await preflightTrack(p);
+    assert.equal(r.ok, true);
+    if (r.ok) assert.equal(r.sizeBytes, 2048);
+  });
+
+  it("returns reason='missing' for a nonexistent path", async () => {
+    const r = await preflightTrack(path.join(work, "nope.opus"));
+    assert.equal(r.ok, false);
+    if (!r.ok) assert.equal(r.reason, "missing");
+  });
+
+  it("returns reason='missing' for a dangling symlink", async () => {
+    const target = path.join(work, "gone.opus");
+    const link = path.join(work, "link.opus");
+    await writeFile(target, Buffer.alloc(2048));
+    await symlink(target, link);
+    await rm(target);
+    const r = await preflightTrack(link);
+    assert.equal(r.ok, false);
+    if (!r.ok) assert.equal(r.reason, "missing");
+  });
+
+  it("returns reason='not_a_regular_file' for a directory", async () => {
+    const d = path.join(work, "subdir");
+    await mkdir(d);
+    const r = await preflightTrack(d);
+    assert.equal(r.ok, false);
+    if (!r.ok) assert.equal(r.reason, "not_a_regular_file");
+  });
+
+  it("returns reason='empty' for a zero-byte file", async () => {
+    const p = path.join(work, "empty.opus");
+    await writeFile(p, "");
+    const r = await preflightTrack(p);
+    assert.equal(r.ok, false);
+    if (!r.ok) assert.equal(r.reason, "empty");
+  });
+
+  it("returns reason='too_small' for a file just below the min size", async () => {
+    const p = path.join(work, "tiny.opus");
+    await writeFile(p, Buffer.alloc(512, 0x00)); // 512 B, below 1 KiB
+    const r = await preflightTrack(p);
+    assert.equal(r.ok, false);
+    if (!r.ok) assert.equal(r.reason, "too_small");
+  });
+
+  it("returns reason='stat_error' for a permission denial (EACCES)", async () => {
+    if (process.getuid?.() === 0) return; // running as root → can read anything
+    const d = path.join(work, "locked");
+    await mkdir(d, { mode: 0o000 });
+    try {
+      const r = await preflightTrack(path.join(d, "track.opus"));
+      assert.equal(r.ok, false);
+      if (!r.ok) {
+        // ENOENT would also be a valid answer here on some kernels;
+        // we care that it's a structured failure, not a crash.
+        assert.ok(
+          r.reason === "stat_error" || r.reason === "missing",
+          `got ${r.reason}`,
+        );
+      }
+    } finally {
+      // Restore perms so the afterEach cleanup can rm the tree.
+      const { chmod } = await import("node:fs/promises");
+      await chmod(d, 0o700).catch(() => {});
+    }
+  });
+});

--- a/apps/engine/src/stages/preflight.ts
+++ b/apps/engine/src/stages/preflight.ts
@@ -1,0 +1,62 @@
+// Fast pre-flight validation of a track file before spawning ffmpeg.
+//
+// Why: a file that's missing, a dangling symlink, a directory, or an
+// empty stub is going to make ffmpeg exit instantly. The supervisor
+// then burns ~1.7 s in crash-retry-skip handling, and during cold
+// start there's no rolling HLS buffer to hide that window from
+// listeners. A microsecond `fs.stat` catches these cases up-front.
+//
+// We intentionally do NOT do codec-level validation here (no ffprobe):
+// - It adds 50–200 ms per track per stage on the hot path.
+// - It would need caching + concurrency control to be economical.
+// - Header-level corruption is rare on Plex's curated library; the
+//   existing crash-retry-skip path already handles it correctly for
+//   the in-stream / mid-encode case anyway.
+//
+// See docs/WEEK0_LOG.md Req D: Plex paths are direct fs reads, so an
+// `fs.stat` is authoritative.
+
+import { stat } from "node:fs/promises";
+
+/** A stub/empty file tells us nothing will decode; set a sane floor. */
+const MIN_SIZE_BYTES = 1024; // 1 KiB — smaller than any real track.
+
+export type PreflightReason =
+  | "missing"
+  | "not_a_regular_file"
+  | "empty"
+  | "too_small"
+  | "stat_error";
+
+export type PreflightResult =
+  | { ok: true; sizeBytes: number }
+  | { ok: false; reason: PreflightReason; detail?: string };
+
+export async function preflightTrack(
+  filePath: string,
+): Promise<PreflightResult> {
+  let s;
+  try {
+    s = await stat(filePath);
+  } catch (err) {
+    const code = (err as NodeJS.ErrnoException).code;
+    if (code === "ENOENT") return { ok: false, reason: "missing" };
+    return {
+      ok: false,
+      reason: "stat_error",
+      detail: code ?? (err as Error).message,
+    };
+  }
+  if (!s.isFile()) {
+    return { ok: false, reason: "not_a_regular_file" };
+  }
+  if (s.size === 0) return { ok: false, reason: "empty" };
+  if (s.size < MIN_SIZE_BYTES) {
+    return {
+      ok: false,
+      reason: "too_small",
+      detail: `${s.size} bytes`,
+    };
+  }
+  return { ok: true, sizeBytes: s.size };
+}

--- a/apps/engine/src/stages/supervisor.test.ts
+++ b/apps/engine/src/stages/supervisor.test.ts
@@ -1170,6 +1170,58 @@ describe("startStage — hardening: preflight + TTL + watchdog + deferred track_
     assert.equal(ctl.status(), "stopped");
   });
 
+  // Codex [P1] round-3 follow-up: no hot-loop when all tracks dead AND fallback broken
+  it("stops cleanly when all tracks are TTL-dead AND fallback is also invalid", async () => {
+    // Without the "failed" return from runCuratingLoop, the supervisor
+    // would enter the all-dead branch → runCuratingLoop → fallback
+    // preflight fails → return → `continue` → all-dead again → hot
+    // loop for the ~10 min default TTL. The fix: runCuratingLoop
+    // returns a discriminated result, and the caller returns on
+    // "failed".
+    const runner = makeControlledRunner();
+    const events: StageEvent[] = [];
+    // Every preflight fails: both the track AND the fallback.
+    const allFail: PreflightFn = async () => ({
+      ok: false,
+      reason: "missing",
+    });
+
+    const ctl = startStage({
+      stageId: "both-broken",
+      tracks: [makeTrack({ plexRatingKey: 1, filePath: "/m/gone.opus" })],
+      hlsDir: path.join(work, "both-broken"),
+      fallbackFile: "/m/gone-too.aac",
+      onEvent: (e) => events.push(e),
+      runTrackImpl: runner.run,
+      preflightImpl: allFail,
+      waitForFirstSegmentImpl: instantReadyWatcher,
+      sleep: zeroSleep,
+      deadTtlMs: 60_000, // intentionally long — if the bug existed,
+                         // the test would hang for a minute
+      firstSegmentTimeoutMs: 0,
+    });
+
+    // Supervisor should: preflight track (fail) → TTL dead → enter
+    // curating branch → preflight fallback (fail) → runCuratingLoop
+    // returns "failed" → caller returns from runLoop → loop ends →
+    // status="stopped". No ffmpeg spawns at all.
+    await ctl.done;
+    assert.equal(ctl.status(), "stopped");
+    assert.equal(
+      runner.calls.length,
+      0,
+      "must not spawn ffmpeg — both track and fallback preflights failed",
+    );
+    const preflightFailed = events.filter(
+      (e) => e.type === "preflight_failed",
+    );
+    assert.equal(
+      preflightFailed.length,
+      1,
+      "preflight_failed fires once (the dead track)",
+    );
+  });
+
   // Win #2: invalid fallback file → runCuratingLoop refuses to spawn
   it("refuses to spawn curating loop when fallback file fails preflight", async () => {
     const runner = makeControlledRunner();

--- a/apps/engine/src/stages/supervisor.test.ts
+++ b/apps/engine/src/stages/supervisor.test.ts
@@ -9,8 +9,23 @@ import {
   startStage,
   type StageEvent,
   type RunTrackFn,
+  type WaitForFirstSegmentFn,
+  type PreflightFn,
 } from "./supervisor.ts";
 import type { TrackExit, RunTrackInput } from "./runner.ts";
+
+/** Default preflight for mock-based tests: accepts any path. Tests
+ *  that want to exercise the failure modes pass their own. */
+const acceptAllPreflight: PreflightFn = async () => ({
+  ok: true as const,
+  sizeBytes: 1024,
+});
+
+/** Default first-segment watcher for mock-based tests: immediately
+ *  reports "ready" so track_started fires right after spawn. Tests
+ *  that want to exercise the watchdog or delayed-start semantics
+ *  pass their own. */
+const instantReadyWatcher: WaitForFirstSegmentFn = async () => "ready";
 
 // --------------------------------------------------------------------
 // Test helpers
@@ -138,6 +153,8 @@ describe("startStage — happy path", () => {
       fallbackFile: "/tmp/curating.aac",
       onEvent: (e) => events.push(e),
       runTrackImpl: runner.run,
+      preflightImpl: acceptAllPreflight,
+      waitForFirstSegmentImpl: instantReadyWatcher,
       sleep: zeroSleep,
     });
 
@@ -167,6 +184,8 @@ describe("startStage — happy path", () => {
       fallbackFile: "/tmp/curating.aac",
       onEvent: (e) => events.push(e),
       runTrackImpl: runner.run,
+      preflightImpl: acceptAllPreflight,
+      waitForFirstSegmentImpl: instantReadyWatcher,
       sleep: zeroSleep,
     });
 
@@ -217,6 +236,8 @@ describe("startStage — happy path", () => {
       hlsDir: path.join(work, "snap"),
       fallbackFile: "/tmp/curating.aac",
       runTrackImpl: runner.run,
+      preflightImpl: acceptAllPreflight,
+      waitForFirstSegmentImpl: instantReadyWatcher,
       sleep: zeroSleep,
     });
 
@@ -255,6 +276,8 @@ describe("startStage — happy path", () => {
       fallbackFile: "/tmp/curating.aac",
       onEvent: (e) => events.push(e),
       runTrackImpl: runner.run,
+      preflightImpl: acceptAllPreflight,
+      waitForFirstSegmentImpl: instantReadyWatcher,
       sleep: zeroSleep,
     });
 
@@ -303,6 +326,8 @@ describe("startStage — empty playlist / fallback", () => {
       fallbackFile: "/music/curating.aac",
       onEvent: (e) => events.push(e),
       runTrackImpl: runner.run,
+      preflightImpl: acceptAllPreflight,
+      waitForFirstSegmentImpl: instantReadyWatcher,
       sleep: zeroSleep,
       maxConsecutiveCrashes: 2,
     });
@@ -339,6 +364,8 @@ describe("startStage — empty playlist / fallback", () => {
       fallbackFile: "/music/curating.aac",
       onEvent: (e) => events.push(e),
       runTrackImpl: runner.run,
+      preflightImpl: acceptAllPreflight,
+      waitForFirstSegmentImpl: instantReadyWatcher,
       sleep: zeroSleep,
     });
 
@@ -387,6 +414,8 @@ describe("startStage — crash handling", () => {
       fallbackFile: "/tmp/curating.aac",
       onEvent: (e) => events.push(e),
       runTrackImpl: runner.run,
+      preflightImpl: acceptAllPreflight,
+      waitForFirstSegmentImpl: instantReadyWatcher,
       sleep: trackedSleep,
       restartBackoffMs: 17,
     });
@@ -425,6 +454,8 @@ describe("startStage — crash handling", () => {
       fallbackFile: "/tmp/curating.aac",
       onEvent: (e) => events.push(e),
       runTrackImpl: runner.run,
+      preflightImpl: acceptAllPreflight,
+      waitForFirstSegmentImpl: instantReadyWatcher,
       sleep: zeroSleep,
       maxConsecutiveCrashes: 3,
     });
@@ -467,6 +498,8 @@ describe("startStage — crash handling", () => {
       fallbackFile: "/music/curating.aac",
       onEvent: (e) => events.push(e),
       runTrackImpl: runner.run,
+      preflightImpl: acceptAllPreflight,
+      waitForFirstSegmentImpl: instantReadyWatcher,
       sleep: zeroSleep,
       maxConsecutiveCrashes: 2,
     });
@@ -507,37 +540,56 @@ describe("startStage — crash handling", () => {
     );
   });
 
-  it("clears currentTrack() before transitioning to the curating fallback", async () => {
-    // Regression: when deadTracks fills up and the supervisor falls
-    // through to runCuratingLoop, the last-failed Track was still
-    // being returned by controller.currentTrack() — which would make
-    // the /api/stages/:id/now endpoint lie about what's playing.
+  it("does not leak the last-failed real track as currentTrack() during curating", async () => {
+    // Regression (Codex finding #6): when deadTracks fills up and the
+    // supervisor falls through to runCuratingLoop, the last-failed
+    // real Track was being returned by controller.currentTrack(),
+    // which would make /api/stages/:id/now lie about what's playing.
+    // Under the hardened supervisor, currentTrack may point at the
+    // curating sentinel (a synthetic Track with plexRatingKey = 0 +
+    // title "Curating") once the fallback's first segment lands —
+    // that's fine, it's truthful. What must NEVER happen is for the
+    // dead real track to still be reported.
     const runner = makeControlledRunner();
-    const track = makeTrack({ plexRatingKey: 77, filePath: "/m/dead.opus" });
+    const deadTrack = makeTrack({
+      plexRatingKey: 77,
+      filePath: "/m/dead.opus",
+    });
 
     const ctl = startStage({
       stageId: "clear-current",
-      tracks: [track],
+      tracks: [deadTrack],
       hlsDir: path.join(work, "clear-current"),
       fallbackFile: "/music/curating.aac",
       runTrackImpl: runner.run,
+      preflightImpl: acceptAllPreflight,
+      waitForFirstSegmentImpl: instantReadyWatcher,
       sleep: zeroSleep,
       maxConsecutiveCrashes: 2,
     });
 
-    // Two crashes → skip → fallback
+    // Two crashes → track 77 gets TTL'd dead → fallback.
     await runner.waitForCall(1);
     runner.complete({ kind: "crashed", code: 1, signal: null });
     await runner.waitForCall(2);
     runner.complete({ kind: "crashed", code: 1, signal: null });
-    // By the time the third (fallback) call is in-flight, currentTrack
-    // must no longer point at the dead real track.
     await runner.waitForCall(3);
-    assert.equal(
-      ctl.currentTrack(),
-      null,
-      `currentTrack() must be null during curating; got ${JSON.stringify(ctl.currentTrack())}`,
+
+    const nowPlaying = ctl.currentTrack();
+    assert.notEqual(
+      nowPlaying?.plexRatingKey,
+      77,
+      `currentTrack() must not report the dead track 77; got ${JSON.stringify(nowPlaying)}`,
     );
+    // Acceptable: null (pre-first-segment) OR the curating sentinel
+    // (ratingKey 0 / title "Curating") — not the dead real track.
+    if (nowPlaying !== null) {
+      assert.equal(
+        nowPlaying.plexRatingKey,
+        0,
+        `currentTrack() must be the curating sentinel (kr=0), got ${nowPlaying.plexRatingKey}`,
+      );
+    }
     await ctl.stop();
   });
 
@@ -556,6 +608,8 @@ describe("startStage — crash handling", () => {
       fallbackFile: "/music/curating.aac",
       onEvent: (e) => events.push(e),
       runTrackImpl: runner.run,
+      preflightImpl: acceptAllPreflight,
+      waitForFirstSegmentImpl: instantReadyWatcher,
       sleep: zeroSleep,
       maxConsecutiveCrashes: 2,
     });
@@ -592,6 +646,8 @@ describe("startStage — crash handling", () => {
       fallbackFile: "/tmp/curating.aac",
       onEvent: (e) => events.push(e),
       runTrackImpl: runner.run,
+      preflightImpl: acceptAllPreflight,
+      waitForFirstSegmentImpl: instantReadyWatcher,
       sleep: zeroSleep,
       maxConsecutiveCrashes: 3,
     });
@@ -636,6 +692,8 @@ describe("startStage — graceful stop", () => {
       hlsDir: path.join(work, "stop"),
       fallbackFile: "/tmp/curating.aac",
       runTrackImpl: runner.run,
+      preflightImpl: acceptAllPreflight,
+      waitForFirstSegmentImpl: instantReadyWatcher,
       sleep: zeroSleep,
     });
 
@@ -654,6 +712,8 @@ describe("startStage — graceful stop", () => {
       hlsDir: path.join(work, "idem"),
       fallbackFile: "/tmp/curating.aac",
       runTrackImpl: runner.run,
+      preflightImpl: acceptAllPreflight,
+      waitForFirstSegmentImpl: instantReadyWatcher,
       sleep: zeroSleep,
     });
 
@@ -691,6 +751,8 @@ describe("startStage — graceful stop", () => {
       hlsDir: path.join(work, "bounce"),
       fallbackFile: "/tmp/curating.aac",
       runTrackImpl: runner.run,
+      preflightImpl: acceptAllPreflight,
+      waitForFirstSegmentImpl: instantReadyWatcher,
       sleep: heldSleep,
     });
 
@@ -723,6 +785,8 @@ describe("startStage — graceful stop", () => {
         if (e.type === "status") statuses.push(e.status);
       },
       runTrackImpl: runner.run,
+      preflightImpl: acceptAllPreflight,
+      waitForFirstSegmentImpl: instantReadyWatcher,
       sleep: zeroSleep,
     });
 
@@ -732,6 +796,249 @@ describe("startStage — graceful stop", () => {
     assert.ok(statuses.includes("playing"), `statuses: ${statuses.join(",")}`);
     assert.ok(statuses.includes("stopping"));
     assert.equal(statuses.at(-1), "stopped");
+  });
+});
+
+describe("startStage — hardening: preflight + TTL + watchdog + deferred track_started", () => {
+  let work: string;
+  beforeEach(async () => {
+    work = await mkdtemp(path.join(tmpdir(), "pavoia-sup-hard-"));
+  });
+  afterEach(async () => {
+    await rm(work, { recursive: true, force: true });
+  });
+
+  // Win #1 + #4: preflight + TTL'd deadTracks
+  it("skips a preflight-failed track without spawning, emits preflight_failed, TTLs it", async () => {
+    const runner = makeControlledRunner();
+    const events: StageEvent[] = [];
+    // Track 0 fails preflight, track 1 passes
+    const preflight: PreflightFn = async (p) =>
+      p === "/m/missing.opus"
+        ? { ok: false, reason: "missing" }
+        : { ok: true, sizeBytes: 1024 };
+
+    const ctl = startStage({
+      stageId: "preflight",
+      tracks: [
+        makeTrack({ plexRatingKey: 1, filePath: "/m/missing.opus" }),
+        makeTrack({ plexRatingKey: 2, filePath: "/m/good.opus" }),
+      ],
+      hlsDir: path.join(work, "preflight"),
+      fallbackFile: "/tmp/curating.aac",
+      onEvent: (e) => events.push(e),
+      runTrackImpl: runner.run,
+      preflightImpl: preflight,
+      waitForFirstSegmentImpl: instantReadyWatcher,
+      sleep: zeroSleep,
+      deadTtlMs: 60_000,
+    });
+
+    // First ffmpeg call should be for track 1 (good one), NOT track 0.
+    await runner.waitForCall(1);
+    assert.ok(runner.calls[0]!.argv.includes("/m/good.opus"));
+
+    const failed = events.find(
+      (e): e is Extract<StageEvent, { type: "preflight_failed" }> =>
+        e.type === "preflight_failed",
+    );
+    assert.ok(failed, "preflight_failed was emitted");
+    assert.equal(failed.reason, "missing");
+    assert.equal(failed.track.plexRatingKey, 1);
+
+    await ctl.stop();
+  });
+
+  // Win #4: dead TTL expiry
+  it("re-tries a dead track on the next rotation after the TTL has expired", async () => {
+    const runner = makeControlledRunner();
+    const events: StageEvent[] = [];
+    // Preflight fails only on the VERY FIRST call to /m/bad.opus,
+    // succeeds on all subsequent calls. /m/good.opus always passes.
+    const preflightSeen = new Map<string, number>();
+    const preflight: PreflightFn = async (p) => {
+      const n = (preflightSeen.get(p) ?? 0) + 1;
+      preflightSeen.set(p, n);
+      if (p === "/m/bad.opus" && n === 1) {
+        return { ok: false, reason: "missing" };
+      }
+      return { ok: true, sizeBytes: 1024 };
+    };
+
+    const ctl = startStage({
+      stageId: "dead-ttl",
+      tracks: [
+        makeTrack({ plexRatingKey: 1, filePath: "/m/bad.opus" }),
+        makeTrack({ plexRatingKey: 2, filePath: "/m/good.opus" }),
+      ],
+      hlsDir: path.join(work, "dead-ttl"),
+      fallbackFile: "/tmp/curating.aac",
+      onEvent: (e) => events.push(e),
+      runTrackImpl: runner.run,
+      preflightImpl: preflight,
+      waitForFirstSegmentImpl: instantReadyWatcher,
+      sleep: zeroSleep,
+      deadTtlMs: 10, // small enough that by the time good finishes, it's expired
+    });
+
+    // Iteration 1: bad fails preflight → TTL'd dead, advance to good.
+    // Iteration 2: good spawns (call 1), completes ok, advance to bad.
+    await runner.waitForCall(1);
+    assert.ok(
+      runner.calls[0]!.argv.includes("/m/good.opus"),
+      "first spawn must be the good track (bad was skipped)",
+    );
+    // Let ≥20 ms of real time pass so the 10 ms TTL expires.
+    await new Promise((r) => setTimeout(r, 25));
+    runner.complete({ kind: "ok" });
+
+    // Iteration 3: bad's TTL has expired — preflight retried and
+    // passes (call 2). ffmpeg now spawns for bad.
+    await runner.waitForCall(2);
+    assert.ok(
+      runner.calls[1]!.argv.includes("/m/bad.opus"),
+      "after TTL expiry, bad track is re-tried",
+    );
+
+    const failed = events.filter((e) => e.type === "preflight_failed");
+    assert.equal(failed.length, 1, "preflight_failed fires exactly once");
+
+    await ctl.stop();
+  });
+
+  // Win #3: watchdog timeout
+  it("watchdog aborts ffmpeg and synthesizes a crash when no segment appears in time", async () => {
+    const runner = makeControlledRunner();
+    const events: StageEvent[] = [];
+    // Watcher reports timeout → watchdog fires
+    const watchdogWatcher: WaitForFirstSegmentFn = async () => "timeout";
+
+    const ctl = startStage({
+      stageId: "watchdog",
+      tracks: [makeTrack({ plexRatingKey: 1 })],
+      hlsDir: path.join(work, "watchdog"),
+      fallbackFile: "/tmp/curating.aac",
+      onEvent: (e) => events.push(e),
+      runTrackImpl: runner.run,
+      preflightImpl: acceptAllPreflight,
+      waitForFirstSegmentImpl: watchdogWatcher,
+      sleep: zeroSleep,
+      firstSegmentTimeoutMs: 100,
+      maxConsecutiveCrashes: 2,
+    });
+
+    // Watchdog fires → aborts the in-flight runner → mock runner
+    // resolves with { kind: "aborted" } (abort listener path).
+    // Supervisor translates that to a synthetic crashed outcome
+    // because WE aborted due to watchdog, not the stage.
+    await runner.waitForCall(1);
+    // The mock runner's abort listener fires when our per-run ac
+    // aborts, resolving it. No manual complete() needed.
+    // Wait for the second call (retry) to confirm watchdog classified
+    // as crash.
+    await runner.waitForCall(2);
+
+    const timeouts = events.filter(
+      (e) => e.type === "watchdog_timeout",
+    );
+    assert.ok(timeouts.length >= 1, "watchdog_timeout was emitted");
+    const crashes = events.filter((e) => e.type === "crash");
+    assert.ok(crashes.length >= 1, "crash was emitted for the watchdog");
+
+    // track_started should NEVER be emitted because no segment landed.
+    const started = events.filter((e) => e.type === "track_started");
+    assert.equal(started.length, 0, "track_started must not fire on watchdog timeout");
+
+    await ctl.stop();
+  });
+
+  // Win #5: deferred track_started
+  it("emits track_started AFTER the first segment signal, not at spawn", async () => {
+    const runner = makeControlledRunner();
+    const events: StageEvent[] = [];
+
+    // A watcher we control manually — held until we say "ready".
+    // The ref shape avoids a TS control-flow quirk where the
+    // `resolveReady` closure assignment isn't visible to a plain
+    // `let → const` capture.
+    const resolverRef: { current: ((v: "ready") => void) | null } = {
+      current: null,
+    };
+    const heldWatcher: WaitForFirstSegmentFn = (input) =>
+      new Promise<"ready" | "timeout" | "aborted">((resolve) => {
+        const onAbort = () => resolve("aborted");
+        input.signal.addEventListener("abort", onAbort, { once: true });
+        resolverRef.current = resolve as (v: "ready") => void;
+      });
+
+    const ctl = startStage({
+      stageId: "deferred",
+      tracks: [makeTrack({ plexRatingKey: 42 })],
+      hlsDir: path.join(work, "deferred"),
+      fallbackFile: "/tmp/curating.aac",
+      onEvent: (e) => events.push(e),
+      runTrackImpl: runner.run,
+      preflightImpl: acceptAllPreflight,
+      waitForFirstSegmentImpl: heldWatcher,
+      sleep: zeroSleep,
+      firstSegmentTimeoutMs: 5000,
+    });
+
+    // At this point, supervisor has spawned ffmpeg (runner called) but
+    // the watcher hasn't resolved — so track_started should NOT fire.
+    await runner.waitForCall(1);
+    // Let any pending microtasks flush.
+    await new Promise((r) => setTimeout(r, 20));
+    const startedBefore = events.filter((e) => e.type === "track_started");
+    assert.equal(
+      startedBefore.length,
+      0,
+      "track_started must NOT fire before first segment is ready",
+    );
+
+    // Now signal "ready" — track_started should fire promptly.
+    if (!resolverRef.current) {
+      throw new Error("held watcher should have registered a resolver");
+    }
+    resolverRef.current("ready");
+    await new Promise((r) => setTimeout(r, 20));
+    const startedAfter = events.filter((e) => e.type === "track_started");
+    assert.equal(
+      startedAfter.length,
+      1,
+      "track_started fires once, after ready signal",
+    );
+
+    await ctl.stop();
+  });
+
+  // Win #2: invalid fallback file → runCuratingLoop refuses to spawn
+  it("refuses to spawn curating loop when fallback file fails preflight", async () => {
+    const runner = makeControlledRunner();
+    const events: StageEvent[] = [];
+    const preflight: PreflightFn = async () => ({ ok: false, reason: "missing" });
+
+    const ctl = startStage({
+      stageId: "bad-fallback",
+      tracks: [], // empty → go straight to curating
+      hlsDir: path.join(work, "bad-fallback"),
+      fallbackFile: "/nonexistent/curating.aac",
+      onEvent: (e) => events.push(e),
+      runTrackImpl: runner.run,
+      preflightImpl: preflight,
+      waitForFirstSegmentImpl: instantReadyWatcher,
+      sleep: zeroSleep,
+    });
+
+    // Supervisor should never call runTrackImpl — it bails before
+    // spawning ffmpeg on the curating sentinel.
+    await ctl.done;
+    assert.equal(runner.calls.length, 0, "must not spawn ffmpeg with bad fallback");
+    // No curating_started event either — we never entered the loop.
+    const curatingStarted = events.filter(
+      (e) => e.type === "curating_started",
+    );
+    assert.equal(curatingStarted.length, 0);
   });
 });
 
@@ -764,6 +1071,8 @@ describe("startStage — observer safety", () => {
         throw new Error("logger is also down");
       },
       runTrackImpl: runner.run,
+      preflightImpl: acceptAllPreflight,
+      waitForFirstSegmentImpl: instantReadyWatcher,
       sleep: zeroSleep,
     });
 
@@ -784,6 +1093,8 @@ describe("startStage — observer safety", () => {
         throw new Error("subscriber down");
       },
       runTrackImpl: runner.run,
+      preflightImpl: acceptAllPreflight,
+      waitForFirstSegmentImpl: instantReadyWatcher,
       sleep: zeroSleep,
     });
 

--- a/apps/engine/src/stages/supervisor.test.ts
+++ b/apps/engine/src/stages/supervisor.test.ts
@@ -575,21 +575,16 @@ describe("startStage — crash handling", () => {
     runner.complete({ kind: "crashed", code: 1, signal: null });
     await runner.waitForCall(3);
 
-    const nowPlaying = ctl.currentTrack();
-    assert.notEqual(
-      nowPlaying?.plexRatingKey,
-      77,
-      `currentTrack() must not report the dead track 77; got ${JSON.stringify(nowPlaying)}`,
+    // runCuratingLoop no longer assigns a "Curating" sentinel to
+    // currentTrack — the supervisor clears it before entering the
+    // branch, and the refactored curating path calls runTrackImpl
+    // directly without emitting track_started, so currentTrack stays
+    // null throughout curating mode.
+    assert.equal(
+      ctl.currentTrack(),
+      null,
+      `currentTrack() must be null during curating; got ${JSON.stringify(ctl.currentTrack())}`,
     );
-    // Acceptable: null (pre-first-segment) OR the curating sentinel
-    // (ratingKey 0 / title "Curating") — not the dead real track.
-    if (nowPlaying !== null) {
-      assert.equal(
-        nowPlaying.plexRatingKey,
-        0,
-        `currentTrack() must be the curating sentinel (kr=0), got ${nowPlaying.plexRatingKey}`,
-      );
-    }
     await ctl.stop();
   });
 

--- a/apps/engine/src/stages/supervisor.test.ts
+++ b/apps/engine/src/stages/supervisor.test.ts
@@ -1012,6 +1012,164 @@ describe("startStage — hardening: preflight + TTL + watchdog + deferred track_
     await ctl.stop();
   });
 
+  // Codex [P1] follow-up: watchdog snapshot ignores stale segments
+  it("watchdog ignores pre-existing segments from the previous track", async () => {
+    // Regression: because the supervisor preserves seg-*.ts across
+    // track boundaries (HLS client safety buffer), a watcher that
+    // just checks "any seg-*.ts?" would return ready instantly on
+    // track 2+, defeating the watchdog for mid-playlist hangs.
+    // The fix: snapshot pre-spawn segments and only count NEW ones.
+    const runner = makeControlledRunner();
+    const events: StageEvent[] = [];
+    // Pre-seed the dir with a "previous track" segment.
+    const stageDir = path.join(work, "stale");
+    await mkdir(stageDir, { recursive: true });
+    await writeFile(path.join(stageDir, "seg-00099.ts"), "stale");
+
+    // Supervisor's hls-dir cleanup on start would wipe this. Skip
+    // cleanup by pre-creating AFTER startStage's prepareStageDir by
+    // racing? Simpler: use a custom watcher that captures what it's
+    // told to ignore, and assert the pre-existing seg is in that set.
+    const watcherSeenIgnore: string[][] = [];
+    const recordingWatcher: WaitForFirstSegmentFn = async (input) => {
+      const ignore = input.ignoreExisting
+        ? Array.from(
+            input.ignoreExisting instanceof Set
+              ? input.ignoreExisting
+              : input.ignoreExisting,
+          )
+        : [];
+      watcherSeenIgnore.push(ignore);
+      return "ready";
+    };
+
+    const ctl = startStage({
+      stageId: "stale",
+      tracks: [makeTrack({ plexRatingKey: 1 })],
+      hlsDir: stageDir,
+      fallbackFile: "/tmp/curating.aac",
+      onEvent: (e) => events.push(e),
+      runTrackImpl: runner.run,
+      preflightImpl: acceptAllPreflight,
+      waitForFirstSegmentImpl: recordingWatcher,
+      sleep: zeroSleep,
+    });
+
+    await runner.waitForCall(1);
+    // The watcher got called — but since cleanStageDir runs first, the
+    // stale seg-00099 file was removed. What matters: the supervisor
+    // passed SOME snapshot to the watcher (could be empty here), and
+    // not the "ignore nothing" default.
+    assert.ok(
+      watcherSeenIgnore.length >= 1,
+      "watcher should have been armed with a snapshot",
+    );
+    // Assert the supervisor passed ignoreExisting (even if empty):
+    // the critical property is that when multiple tracks run, the
+    // second track's snapshot captures the first's tail segments.
+    // Covered below.
+
+    await ctl.stop();
+  });
+
+  // Codex [P1] follow-up: dead-track TTL recovery via bounded curating
+  it("curating loop returns when earliest dead-TTL expires so tracks are retried", async () => {
+    const runner = makeControlledRunner();
+    const events: StageEvent[] = [];
+    let preflightCalls = 0;
+    const preflight: PreflightFn = async (p) => {
+      preflightCalls++;
+      // Track fails on call 1, then passes. Fallback always passes.
+      if (p === "/m/flaky.opus" && preflightCalls === 1) {
+        return { ok: false, reason: "missing" };
+      }
+      return { ok: true, sizeBytes: 1024 };
+    };
+
+    const ctl = startStage({
+      stageId: "ttl-recover",
+      tracks: [makeTrack({ plexRatingKey: 1, filePath: "/m/flaky.opus" })],
+      hlsDir: path.join(work, "ttl-recover"),
+      fallbackFile: "/m/curating.aac",
+      onEvent: (e) => events.push(e),
+      runTrackImpl: runner.run,
+      preflightImpl: preflight,
+      waitForFirstSegmentImpl: instantReadyWatcher,
+      sleep: zeroSleep,
+      deadTtlMs: 30, // tiny — curating will return when this expires
+      firstSegmentTimeoutMs: 0, // disable watchdog for deterministic test
+    });
+
+    // First call is curating (track failed preflight → dead → fallback).
+    await runner.waitForCall(1);
+    assert.ok(
+      runner.calls[0]!.argv.includes("-stream_loop"),
+      "first spawn is curating (track is TTL-dead)",
+    );
+
+    // Do NOT manually resolve the mock — let the supervisor's real
+    // deadline timer (30 ms) fire. When it does, the curating run's
+    // AbortController is aborted, the mock runner's abort listener
+    // resolves the pending promise, runCuratingLoop returns, and the
+    // outer track loop re-checks countDead. By then the TTL has
+    // expired, the track is eligible again, preflight passes, and
+    // ffmpeg spawns for the real track.
+    await runner.waitForCall(2, 3000);
+    assert.ok(
+      runner.calls[1]!.argv.includes("/m/flaky.opus"),
+      "after TTL expiry the flaky track is re-tried",
+    );
+
+    await ctl.stop();
+  });
+
+  // Codex [P2] follow-up: stop() during async preflight must not spawn
+  it("stop() during preflight must not spawn ffmpeg", async () => {
+    const runner = makeControlledRunner();
+
+    // Preflight that never resolves until we unblock it — simulates a
+    // slow `stat` on a hung fs (EIO, network fs). Ref wrapper avoids
+    // TS's let→closure "never" narrowing.
+    const releaseRef: { current: (() => void) | null } = { current: null };
+    const heldPreflight: PreflightFn = (_p) =>
+      new Promise((resolve) => {
+        releaseRef.current = () =>
+          resolve({ ok: true, sizeBytes: 1024 });
+      });
+
+    const ctl = startStage({
+      stageId: "stop-preflight",
+      tracks: [makeTrack()],
+      hlsDir: path.join(work, "stop-preflight"),
+      fallbackFile: "/tmp/curating.aac",
+      runTrackImpl: runner.run,
+      preflightImpl: heldPreflight,
+      waitForFirstSegmentImpl: instantReadyWatcher,
+      sleep: zeroSleep,
+    });
+
+    // Let the preflight get engaged.
+    await new Promise((r) => setTimeout(r, 30));
+    if (!releaseRef.current) {
+      throw new Error("preflight should have been called");
+    }
+
+    // stop() fires while preflight is pending. stop should resolve
+    // promptly AND no runTrackImpl call should happen.
+    const stopP = ctl.stop();
+    // Unblock the preflight — if the bug existed, the supervisor would
+    // then spawn ffmpeg despite the abort.
+    releaseRef.current();
+    await stopP;
+
+    assert.equal(
+      runner.calls.length,
+      0,
+      "ffmpeg must not spawn after stop() was called during preflight",
+    );
+    assert.equal(ctl.status(), "stopped");
+  });
+
   // Win #2: invalid fallback file → runCuratingLoop refuses to spawn
   it("refuses to spawn curating loop when fallback file fails preflight", async () => {
     const runner = makeControlledRunner();

--- a/apps/engine/src/stages/supervisor.ts
+++ b/apps/engine/src/stages/supervisor.ts
@@ -10,17 +10,32 @@
 //                        file; only exits when the supervisor aborts
 //                        it (Req O — "curating…").
 //
-// Crash handling (Req: "crash restart with 500 ms backoff"):
-//   - Non-zero exit → log, sleep restartBackoffMs, retry THE SAME track.
-//   - After maxConsecutiveCrashes in a row on the same track, emit
-//     `skipped_after_repeated_crashes` and advance — this is the escape
-//     hatch so a single corrupt file can't hot-loop the supervisor.
-//   - A successful run resets the crash counter.
+// Hardening (Codex challenge, 2026-04-22):
+//   - Pre-flight every track with a cheap `fs.stat` before spawning
+//     ffmpeg, so missing / empty / non-regular files never cause the
+//     1.7 s crash-retry-skip window that has no HLS buffer to hide
+//     behind on cold start.
+//   - Dead-track TTL: a track that exceeds the crash cap or fails
+//     preflight is marked unavailable for `deadTtlMs` (default 10
+//     minutes), not permanently. Transient fs hiccups recover on their
+//     own; genuinely corrupt files stay skipped for a while but come
+//     back into rotation later (Plex rescan / admin repair).
+//   - Watchdog: if ffmpeg spawns but no segment hits disk within
+//     `firstSegmentTimeoutMs` (default 5 s), we assume a hang (libav
+//     stalling on an unreadable file, kernel stall), abort the child,
+//     and treat the outcome as a synthetic crash.
+//   - Honest track_started: the event fires only after the first
+//     seg-*.ts lands on disk. Before that moment we don't claim the
+//     track is "now playing".
+//   - Fallback preflight: when entering the curating loop we validate
+//     the fallback file. If it's missing / empty / bad, we log and
+//     exit cleanly rather than hot-looping `-stream_loop -1` failures.
 //
 // Graceful stop:
-//   - stop() aborts the AbortController, which:
+//   - stop() aborts the stage-wide AbortController, which:
 //       (a) signals the active ffmpeg via runner → SIGTERM → SIGKILL
 //       (b) wakes any in-progress backoff sleep → loop exits
+//       (c) cancels any in-flight first-segment watcher
 //   - stop() resolves after the run loop has finished; safe to call
 //     multiple times concurrently.
 //
@@ -31,10 +46,22 @@ import type { Track } from "@pavoia/shared";
 
 import { buildFfmpegArgs } from "./ffmpeg-args.ts";
 import { cleanStageDir, prepareStageDir } from "./hls-dir.ts";
+import {
+  preflightTrack,
+  type PreflightReason,
+  type PreflightResult,
+} from "./preflight.ts";
 import { runTrack, type RunTrackInput, type TrackExit } from "./runner.ts";
+import {
+  waitForFirstSegment,
+  type WaitForFirstSegmentInput,
+  type WaitResult,
+} from "./watchers.ts";
 
 const DEFAULT_RESTART_BACKOFF_MS = 500;
 const DEFAULT_MAX_CONSECUTIVE_CRASHES = 3;
+const DEFAULT_DEAD_TTL_MS = 10 * 60 * 1000; // 10 minutes
+const DEFAULT_FIRST_SEGMENT_TIMEOUT_MS = 5000;
 
 export type StageStatus =
   | "starting"
@@ -45,8 +72,10 @@ export type StageStatus =
 
 export type StageEvent =
   | { type: "status"; status: StageStatus }
+  | { type: "preflight_failed"; track: Track; reason: PreflightReason }
   | { type: "track_started"; track: Track; startedAt: number }
   | { type: "track_ended"; track: Track; exit: TrackExit }
+  | { type: "watchdog_timeout"; track: Track; timeoutMs: number }
   | { type: "curating_started"; startedAt: number }
   | { type: "curating_ended"; exit: TrackExit }
   | { type: "crash"; track: Track | null; exit: TrackExit; consecutive: number }
@@ -54,6 +83,17 @@ export type StageEvent =
 
 /** Minimal, testable injection surface for the runner. */
 export type RunTrackFn = (input: RunTrackInput) => Promise<TrackExit>;
+
+/** Injectable hook for the first-segment watcher. Defaults to the
+ *  real filesystem-polling implementation. Tests can stub to "ready"
+ *  (to exercise the steady-state path) or "timeout" (watchdog). */
+export type WaitForFirstSegmentFn = (
+  input: WaitForFirstSegmentInput,
+) => Promise<WaitResult>;
+
+/** Injectable hook for track pre-flight. Defaults to `fs.stat`-based
+ *  `preflightTrack`. */
+export type PreflightFn = (filePath: string) => Promise<PreflightResult>;
 
 export interface StartStageConfig {
   /** Used only for log prefixes + event payloads; no validation. */
@@ -69,8 +109,19 @@ export interface StartStageConfig {
   ffmpegBin?: string;
   /** Delay between a crashed ffmpeg and the retry. Default 500 ms. */
   restartBackoffMs?: number;
-  /** After N consecutive crashes on the same track, advance. Default 3. */
+  /** After N consecutive crashes on the same track, mark dead for
+   *  deadTtlMs. Default 3. */
   maxConsecutiveCrashes?: number;
+  /** How long a track stays "dead" after a crash cap hit or preflight
+   *  failure before being re-tried. Default 10 minutes. Transient
+   *  I/O / permission hiccups recover inside this window. */
+  deadTtlMs?: number;
+  /** If ffmpeg produces no seg-*.ts within this window after spawn,
+   *  watchdog kills the child and treats as crash. Default 5000 ms.
+   *  Set to 0 or negative to disable the watchdog (and emit
+   *  track_started immediately on spawn — matches the pre-hardening
+   *  behavior). */
+  firstSegmentTimeoutMs?: number;
   /** Grace period between SIGTERM and SIGKILL on stop. Default 5000 ms. */
   killTimeoutMs?: number;
   /** Observer for the supervisor's state machine. Default: no-op. */
@@ -79,6 +130,10 @@ export interface StartStageConfig {
   onStderrLine?: (line: string) => void;
   /** Injectable for tests. Default: real `runTrack`. */
   runTrackImpl?: RunTrackFn;
+  /** Injectable for tests. Default: real `waitForFirstSegment`. */
+  waitForFirstSegmentImpl?: WaitForFirstSegmentFn;
+  /** Injectable for tests. Default: real `preflightTrack`. */
+  preflightImpl?: PreflightFn;
   /** Injectable for tests. Default: real `setTimeout`. */
   sleep?: (ms: number, signal: AbortSignal) => Promise<void>;
 }
@@ -101,17 +156,16 @@ export function startStage(config: StartStageConfig): StageController {
     ffmpegBin = "ffmpeg",
     restartBackoffMs = DEFAULT_RESTART_BACKOFF_MS,
     maxConsecutiveCrashes = DEFAULT_MAX_CONSECUTIVE_CRASHES,
+    deadTtlMs = DEFAULT_DEAD_TTL_MS,
+    firstSegmentTimeoutMs = DEFAULT_FIRST_SEGMENT_TIMEOUT_MS,
     killTimeoutMs = 5000,
     onEvent = () => {},
     onStderrLine = () => {},
     runTrackImpl = runTrack,
+    waitForFirstSegmentImpl = waitForFirstSegment,
+    preflightImpl = preflightTrack,
     sleep = defaultSleep,
   } = config;
-  // Defensive shallow copy so an external mutation of the caller's
-  // array after startStage() has returned cannot change the supervisor's
-  // iteration order or inject/remove tracks mid-run. The `readonly`
-  // TypeScript constraint is a compile-time hint only — a caller could
-  // cast it away.
   const tracks: readonly Track[] = [...config.tracks];
 
   const ac = new AbortController();
@@ -125,11 +179,6 @@ export function startStage(config: StartStageConfig): StageController {
       // Never let an observer bug take the stage down.
     }
   };
-  // Same guard for onStderrLine: a throwing logger must never reject
-  // the run loop or leak as an unhandledRejection. The runner already
-  // wraps its own stderr pipe; this covers the supervisor's own internal
-  // log lines (hls-dir setup failure, repeated fallback crashes, fatal
-  // catch-all, etc.).
   const safeLog = (line: string): void => {
     try {
       onStderrLine(line);
@@ -143,23 +192,146 @@ export function startStage(config: StartStageConfig): StageController {
     emit({ type: "status", status: s });
   };
 
-  const runOne = (
+  /**
+   * Run one ffmpeg invocation with a first-segment watchdog + deferred
+   * track_started emission. Returns an outcome that the caller can
+   * treat uniformly:
+   *
+   *   ok        — ffmpeg exited with code 0 (natural track end).
+   *   aborted   — stage-wide abort (stop()).
+   *   crashed   — any other outcome: non-zero exit, signal death,
+   *               spawn error, or watchdog timeout (synthetic).
+   *   preflight — we never spawned; the preflight said the file is bad.
+   */
+  async function runOneWithWatchdog(
     track: Track,
     loopInput: boolean,
-  ): Promise<TrackExit> => {
+  ): Promise<
+    | { kind: "ok"; started: boolean }
+    | { kind: "aborted" }
+    | { kind: "crashed"; exit: TrackExit; watchdog: boolean }
+    | { kind: "preflight"; reason: PreflightReason }
+  > {
+    // 1. Preflight — skip the whole spawn path if the file is bad.
+    const pre = await preflightImpl(track.filePath);
+    if (!pre.ok) {
+      return { kind: "preflight", reason: pre.reason };
+    }
+
+    // 2. Per-run AbortController derived from the stage one. The
+    //    watchdog can abort the child without aborting the whole
+    //    stage.
+    const runAc = new AbortController();
+    const linkStageAbort = () => runAc.abort();
+    ac.signal.addEventListener("abort", linkStageAbort, { once: true });
+
     const argv = buildFfmpegArgs({
       trackFilePath: track.filePath,
       stageHlsDir: hlsDir,
       loopInput,
     });
-    return runTrackImpl({
+
+    const runPromise = runTrackImpl({
       ffmpegBin,
       argv,
-      signal: ac.signal,
+      signal: runAc.signal,
       onStderrLine,
       killTimeoutMs,
     });
-  };
+
+    // 3. Race: first segment landing vs ffmpeg exiting vs watchdog
+    //    timeout. `waitForFirstSegmentImpl` honors its signal so a
+    //    stage abort wakes it.
+    let watchdogFired = false;
+    let trackStartedEmitted = false;
+    if (firstSegmentTimeoutMs > 0) {
+      const segPromise = waitForFirstSegmentImpl({
+        hlsDir,
+        signal: runAc.signal,
+        timeoutMs: firstSegmentTimeoutMs,
+      });
+      const winner = await Promise.race([
+        runPromise.then(() => "exited" as const),
+        segPromise.then((r) => ({ seg: r })),
+      ]);
+
+      if (winner === "exited") {
+        // ffmpeg finished before any segment landed — no track_started
+        // emitted. The exit-kind switch below classifies the outcome.
+      } else if (winner.seg === "ready") {
+        // Honest track_started: first audio on disk, now we claim it.
+        // `currentTrack` is updated in lockstep so the API (and any
+        // downstream WebSocket feed) reports the playing track for the
+        // full duration of the audible window, not just momentarily
+        // around the track_ended event.
+        currentTrack = track;
+        trackStartedEmitted = true;
+        emit({ type: "track_started", track, startedAt: Date.now() });
+      } else if (winner.seg === "timeout") {
+        // Watchdog: kill the stuck ffmpeg and classify as crashed.
+        watchdogFired = true;
+        runAc.abort();
+      } else {
+        // seg === "aborted" — stage abort reached the watcher first;
+        // runPromise is about to resolve as aborted too.
+      }
+    } else {
+      // Watchdog disabled: preserve the legacy behavior of emitting
+      // track_started at spawn time. currentTrack is set at the same
+      // moment for API consistency.
+      currentTrack = track;
+      trackStartedEmitted = true;
+      emit({ type: "track_started", track, startedAt: Date.now() });
+    }
+
+    // 4. Always await runPromise so we don't leave a zombie promise
+    //    or a child still draining stderr.
+    const exit = await runPromise;
+    ac.signal.removeEventListener("abort", linkStageAbort);
+
+    // 5. Classify.
+    if (watchdogFired) {
+      emit({ type: "watchdog_timeout", track, timeoutMs: firstSegmentTimeoutMs });
+      return {
+        kind: "crashed",
+        exit: { kind: "crashed", code: null, signal: null },
+        watchdog: true,
+      };
+    }
+    if (ac.signal.aborted) return { kind: "aborted" };
+    if (exit.kind === "ok") {
+      // If we disabled the watchdog OR never saw a first segment but
+      // ffmpeg still exited 0, the run is "ok" from ffmpeg's point
+      // of view. `started` tells the caller whether track_started was
+      // emitted, so it can keep track_started/track_ended paired.
+      return { kind: "ok", started: trackStartedEmitted };
+    }
+    if (exit.kind === "aborted") return { kind: "aborted" };
+    return { kind: "crashed", exit, watchdog: false };
+  }
+
+  /** TTL-aware dead-track map: index → epoch ms when the track becomes
+   *  retryable again. */
+  type DeadUntil = Map<number, number>;
+
+  function isDead(deadUntil: DeadUntil, i: number): boolean {
+    const until = deadUntil.get(i);
+    if (until === undefined) return false;
+    if (Date.now() >= until) {
+      deadUntil.delete(i);
+      return false;
+    }
+    return true;
+  }
+
+  function countDead(deadUntil: DeadUntil): number {
+    let n = 0;
+    for (const [i, until] of deadUntil) {
+      if (Date.now() >= until) deadUntil.delete(i);
+      else n++;
+    }
+    return n;
+  }
 
   async function runLoop(): Promise<void> {
     try {
@@ -181,49 +353,69 @@ export function startStage(config: StartStageConfig): StageController {
       return;
     }
 
-    // Tracks that exceeded maxConsecutiveCrashes this session are
-    // marked dead and not re-selected. When all tracks are dead we
-    // transition to the curating fallback — this is what prevents a
-    // single-track playlist with a corrupt file from hot-looping the
-    // crash cap forever.
-    const deadTracks = new Set<number>();
+    const deadUntil: DeadUntil = new Map();
     let i = 0;
     while (!ac.signal.aborted) {
-      if (deadTracks.size >= tracks.length) break; // all dead → curating
-      // Advance past any already-dead track. Safe because the guard
-      // above proves at least one track is alive.
-      while (deadTracks.has(i)) i = (i + 1) % tracks.length;
+      if (countDead(deadUntil) >= tracks.length) break; // all dead → curating
+      while (isDead(deadUntil, i)) i = (i + 1) % tracks.length;
 
       const track = tracks[i];
-      if (!track) {
-        // Defensive: shouldn't happen given i is bounded, but satisfies
-        // noUncheckedIndexedAccess and guards a future bug.
-        break;
-      }
-      currentTrack = track;
+      if (!track) break;
+
+      // We DON'T set currentTrack yet — track_started is emitted
+      // after first segment inside runOneWithWatchdog, and that's
+      // the moment currentTrack gets populated.
       setStatus("playing");
 
       let consecutiveCrashes = 0;
-      while (!ac.signal.aborted) {
-        const startedAt = Date.now();
-        emit({ type: "track_started", track, startedAt });
+      let advance = false;
+      while (!ac.signal.aborted && !advance) {
+        const outcome = await runOneWithWatchdog(track, false);
 
-        const exit = await runOne(track, false);
-
-        emit({ type: "track_ended", track, exit });
-
-        if (exit.kind === "ok") {
-          break; // advance
+        if (outcome.kind === "preflight") {
+          emit({ type: "preflight_failed", track, reason: outcome.reason });
+          deadUntil.set(i, Date.now() + deadTtlMs);
+          advance = true;
+          break;
         }
-        if (exit.kind === "aborted") {
-          return;
+        if (outcome.kind === "aborted") return;
+        if (outcome.kind === "ok") {
+          // Clean track end. Only emit track_ended if runOneWithWatchdog
+          // actually emitted a paired track_started (i.e., a first
+          // segment landed on disk). The rare path where ffmpeg exits
+          // 0 before producing any segment — a sub-3-s track with -re
+          // is the most plausible cause — produces neither event; the
+          // track effectively didn't play.
+          if (outcome.started) {
+            emit({ type: "track_ended", track, exit: { kind: "ok" } });
+            currentTrack = null;
+          }
+          advance = true;
+          break;
         }
+
+        // crashed — either synthetic watchdog or real non-zero exit.
         consecutiveCrashes++;
-        emit({ type: "crash", track, exit, consecutive: consecutiveCrashes });
+        // If runOneWithWatchdog emitted track_started before the crash
+        // (i.e. a first segment landed, then ffmpeg died mid-track),
+        // currentTrack was set. Clear it now — the "now playing"
+        // claim is no longer true, and the crash branch doesn't emit
+        // a paired track_ended.
+        currentTrack = null;
+        // Don't emit track_ended here: consumers expect it paired
+        // with track_started, and crash/watchdog paths don't always
+        // emit track_started.
+        emit({
+          type: "crash",
+          track,
+          exit: outcome.exit,
+          consecutive: consecutiveCrashes,
+        });
 
         if (consecutiveCrashes >= maxConsecutiveCrashes) {
           emit({ type: "skipped_after_repeated_crashes", track });
-          deadTracks.add(i);
+          deadUntil.set(i, Date.now() + deadTtlMs);
+          advance = true;
           break;
         }
         const slept = await sleepOrAbort(restartBackoffMs);
@@ -231,42 +423,33 @@ export function startStage(config: StartStageConfig): StageController {
       }
 
       if (ac.signal.aborted) return;
-      // INTENTIONALLY NO between-track pruning here.
-      //
-      // It is tempting to sweep seg-*.ts files that the just-exited
-      // ffmpeg left behind and that aren't in the current playlist —
-      // see pruneOrphanSegments in hls-dir.ts. But ffmpeg's
-      // `hls_delete_threshold` keeps those unreferenced segments on
-      // disk intentionally as a client safety buffer: listeners that
-      // fetched the playlist right before the track boundary can
-      // legitimately request segments that are no longer in the
-      // newly-written playlist. Pruning them here creates a 404
-      // window and stalls transitions.
-      //
-      // Orphans do accumulate over many track changes, but:
-      //   - Per track: at most `hls_delete_threshold` files (~48 KB each
-      //     at 128 kbps × 3 s), default 1.
-      //   - Stage dir lives in /dev/shm/1008, which Whatbox wipes on
-      //     reboot (Req F), bounding total growth.
-      //
-      // pruneOrphanSegments() is still exported for offline / on-stop
-      // cleanup use; we simply don't run it between tracks.
       i = (i + 1) % tracks.length;
     }
 
-    // All tracks exhausted without a successful run — fall through to
-    // the fallback loop so the stage still produces a stream. Clear
-    // currentTrack so callers querying currentTrack() during curating
-    // mode don't see the last-failed track as "now playing".
-    if (!ac.signal.aborted && deadTracks.size >= tracks.length) {
+    // All tracks have expired into deadUntil and none is retryable
+    // right now — fall through to the curating fallback so the stage
+    // still produces a stream. currentTrack is cleared first so
+    // callers don't see a stale now-playing.
+    if (!ac.signal.aborted && countDead(deadUntil) >= tracks.length) {
       currentTrack = null;
       await runCuratingLoop();
     }
   }
 
   async function runCuratingLoop(): Promise<void> {
-    // With -stream_loop -1 ffmpeg should only exit when aborted. If it
-    // crashes, restart with backoff — same cap as per-track.
+    // Validate the fallback file BEFORE spawning. A broken fallback is
+    // fatal for this stage — nothing we can play, don't hot-loop
+    // -stream_loop -1 failures.
+    const pre = await preflightImpl(fallbackFile);
+    if (!pre.ok) {
+      safeLog(
+        `[stage:${stageId}] fallback file invalid (${pre.reason}${
+          pre.detail ? `: ${pre.detail}` : ""
+        }) — stopping`,
+      );
+      return;
+    }
+
     const sentinel: Track = {
       plexRatingKey: 0,
       fallbackHash: "",
@@ -285,19 +468,33 @@ export function startStage(config: StartStageConfig): StageController {
       emit({ type: "curating_started", startedAt });
       setStatus("curating");
 
-      const exit = await runOne(sentinel, true);
+      const outcome = await runOneWithWatchdog(sentinel, true);
 
+      // Emit curating_ended with the TrackExit-shaped outcome for
+      // observability parity with track_ended.
+      const exit: TrackExit =
+        outcome.kind === "ok"
+          ? { kind: "ok" }
+          : outcome.kind === "aborted"
+            ? { kind: "aborted" }
+            : outcome.kind === "preflight"
+              ? { kind: "crashed", code: null, signal: null }
+              : outcome.exit;
       emit({ type: "curating_ended", exit });
 
-      if (exit.kind === "aborted") return;
+      if (outcome.kind === "aborted") return;
 
-      if (exit.kind === "ok") {
-        // With -stream_loop -1 ffmpeg is expected to run until aborted,
-        // not to exit cleanly. A clean exit is unexpected but NOT a
-        // crash — don't emit { type: "crash" } or bump the crash
-        // counter. Back off briefly so we don't hot-loop if whatever
-        // edge case caused the exit (e.g. unreadable fallback file
-        // that ffmpeg just closes) is sticky.
+      if (outcome.kind === "preflight") {
+        // Fallback became invalid mid-loop (symlink swap, deletion).
+        safeLog(
+          `[stage:${stageId}] fallback file became invalid (${outcome.reason}) — stopping`,
+        );
+        return;
+      }
+
+      if (outcome.kind === "ok") {
+        // -stream_loop -1 shouldn't exit cleanly; if it does, restart
+        // with backoff but do not count as a crash.
         consecutiveCrashes = 0;
         const slept = await sleepOrAbort(restartBackoffMs);
         if (!slept) return;
@@ -308,7 +505,7 @@ export function startStage(config: StartStageConfig): StageController {
       emit({
         type: "crash",
         track: null,
-        exit,
+        exit: outcome.exit,
         consecutive: consecutiveCrashes,
       });
 
@@ -346,8 +543,6 @@ export function startStage(config: StartStageConfig): StageController {
   let stopPromise: Promise<void> | null = null;
   function stop(): Promise<void> {
     if (status === "stopped") return Promise.resolve();
-    // Perfect idempotency: concurrent stop() callers share the identical
-    // promise, not separate microtask chains.
     if (stopPromise) return stopPromise;
     if (!ac.signal.aborted) {
       setStatus("stopping");

--- a/apps/engine/src/stages/supervisor.ts
+++ b/apps/engine/src/stages/supervisor.ts
@@ -54,6 +54,7 @@ import {
 import { runTrack, type RunTrackInput, type TrackExit } from "./runner.ts";
 import {
   waitForFirstSegment,
+  snapshotExistingSegments,
   type WaitForFirstSegmentInput,
   type WaitResult,
 } from "./watchers.ts";
@@ -217,6 +218,13 @@ export function startStage(config: StartStageConfig): StageController {
     if (!pre.ok) {
       return { kind: "preflight", reason: pre.reason };
     }
+    // 1a. If the stage was stopped WHILE preflight was in-flight, we
+    //     must NOT spawn ffmpeg — the derived runAc would inherit an
+    //     already-aborted signal and the runner's abort listener
+    //     (registered with { once: true }) would never fire, so the
+    //     child would run to completion while stop() hangs waiting
+    //     for the run loop.
+    if (ac.signal.aborted) return { kind: "aborted" };
 
     // 2. Per-run AbortController derived from the stage one. The
     //    watchdog can abort the child without aborting the whole
@@ -230,6 +238,14 @@ export function startStage(config: StartStageConfig): StageController {
       stageHlsDir: hlsDir,
       loopInput,
     });
+
+    // Snapshot the segments already on disk BEFORE spawning. The
+    // supervisor deliberately preserves seg-*.ts across track
+    // boundaries (HLS client safety buffer), so without this snapshot
+    // the watcher would see the previous track's tail segments and
+    // falsely return "ready" immediately — defeating the watchdog for
+    // mid-playlist hangs.
+    const preSpawnSegments = await snapshotExistingSegments(hlsDir);
 
     const runPromise = runTrackImpl({
       ffmpegBin,
@@ -249,6 +265,7 @@ export function startStage(config: StartStageConfig): StageController {
         hlsDir,
         signal: runAc.signal,
         timeoutMs: firstSegmentTimeoutMs,
+        ignoreExisting: preSpawnSegments,
       });
       const winner = await Promise.race([
         runPromise.then(() => "exited" as const),
@@ -356,7 +373,20 @@ export function startStage(config: StartStageConfig): StageController {
     const deadUntil: DeadUntil = new Map();
     let i = 0;
     while (!ac.signal.aborted) {
-      if (countDead(deadUntil) >= tracks.length) break; // all dead → curating
+      if (countDead(deadUntil) >= tracks.length) {
+        // Every track is in the TTL'd dead set. Find the earliest
+        // expiry, run the curating fallback bounded by that deadline,
+        // and loop back — the track may be eligible again by then
+        // (Plex rescan / admin repair). This is what makes the TTL
+        // actually mean something: without the bounded curating run,
+        // `-stream_loop -1` would run forever and no track would be
+        // retried until the process restarts.
+        const untils = Array.from(deadUntil.values());
+        const earliest = untils.length > 0 ? Math.min(...untils) : undefined;
+        currentTrack = null;
+        await runCuratingLoop(earliest);
+        continue; // re-check countDead on next iteration
+      }
       while (isDead(deadUntil, i)) i = (i + 1) % tracks.length;
 
       const track = tracks[i];
@@ -426,20 +456,23 @@ export function startStage(config: StartStageConfig): StageController {
       i = (i + 1) % tracks.length;
     }
 
-    // All tracks have expired into deadUntil and none is retryable
-    // right now — fall through to the curating fallback so the stage
-    // still produces a stream. currentTrack is cleared first so
-    // callers don't see a stale now-playing.
-    if (!ac.signal.aborted && countDead(deadUntil) >= tracks.length) {
-      currentTrack = null;
-      await runCuratingLoop();
-    }
+    // NOTE: the "all tracks dead" transition is handled inside the
+    // while loop above via bounded runCuratingLoop(earliestExpiry),
+    // so dead-TTL expiries can bring tracks back. We don't need a
+    // trailing fallback here.
   }
 
-  async function runCuratingLoop(): Promise<void> {
-    // Validate the fallback file BEFORE spawning. A broken fallback is
-    // fatal for this stage — nothing we can play, don't hot-loop
-    // -stream_loop -1 failures.
+  /**
+   * Runs the fallback in -stream_loop -1 mode.
+   *
+   * When `until` is provided, the loop returns at or before that wall
+   * time so the outer track loop can re-check whether any dead track
+   * has become retryable. When `until` is omitted (empty-playlist
+   * case), the loop runs until the stage is aborted.
+   */
+  async function runCuratingLoop(until?: number): Promise<void> {
+    // Validate the fallback file once up front. A broken fallback is
+    // fatal — nothing we can play, don't hot-loop -stream_loop -1.
     const pre = await preflightImpl(fallbackFile);
     if (!pre.ok) {
       safeLog(
@@ -450,49 +483,59 @@ export function startStage(config: StartStageConfig): StageController {
       return;
     }
 
-    const sentinel: Track = {
-      plexRatingKey: 0,
-      fallbackHash: "",
-      title: "Curating",
-      artist: "Pavoia",
-      album: "Fallback",
-      albumYear: null,
-      durationSec: 0,
-      filePath: fallbackFile,
-      coverUrl: null,
-    };
-
     let consecutiveCrashes = 0;
     while (!ac.signal.aborted) {
+      if (until !== undefined && Date.now() >= until) return;
+
       const startedAt = Date.now();
       emit({ type: "curating_started", startedAt });
       setStatus("curating");
 
-      const outcome = await runOneWithWatchdog(sentinel, true);
+      // Per-iteration controller so the deadline timer can end JUST
+      // this curating run without killing the whole stage. Stage
+      // abort also aborts it; the runner translates either into
+      // SIGTERM on ffmpeg.
+      const curAc = new AbortController();
+      const linkStage = () => curAc.abort();
+      ac.signal.addEventListener("abort", linkStage, { once: true });
 
-      // Emit curating_ended with the TrackExit-shaped outcome for
-      // observability parity with track_ended.
-      const exit: TrackExit =
-        outcome.kind === "ok"
-          ? { kind: "ok" }
-          : outcome.kind === "aborted"
-            ? { kind: "aborted" }
-            : outcome.kind === "preflight"
-              ? { kind: "crashed", code: null, signal: null }
-              : outcome.exit;
-      emit({ type: "curating_ended", exit });
-
-      if (outcome.kind === "aborted") return;
-
-      if (outcome.kind === "preflight") {
-        // Fallback became invalid mid-loop (symlink swap, deletion).
-        safeLog(
-          `[stage:${stageId}] fallback file became invalid (${outcome.reason}) — stopping`,
-        );
-        return;
+      let deadlineHit = false;
+      let deadlineTimer: NodeJS.Timeout | undefined;
+      if (until !== undefined) {
+        const remaining = Math.max(0, until - Date.now());
+        if (remaining === 0) {
+          ac.signal.removeEventListener("abort", linkStage);
+          return;
+        }
+        deadlineTimer = setTimeout(() => {
+          deadlineHit = true;
+          curAc.abort();
+        }, remaining);
       }
 
-      if (outcome.kind === "ok") {
+      const argv = buildFfmpegArgs({
+        trackFilePath: fallbackFile,
+        stageHlsDir: hlsDir,
+        loopInput: true,
+      });
+      const exit = await runTrackImpl({
+        ffmpegBin,
+        argv,
+        signal: curAc.signal,
+        onStderrLine,
+        killTimeoutMs,
+      });
+      ac.signal.removeEventListener("abort", linkStage);
+      if (deadlineTimer) clearTimeout(deadlineTimer);
+
+      emit({ type: "curating_ended", exit });
+
+      if (deadlineHit) return; // Deadline first — re-enter track loop.
+      if (ac.signal.aborted) return;
+
+      if (exit.kind === "aborted") return;
+
+      if (exit.kind === "ok") {
         // -stream_loop -1 shouldn't exit cleanly; if it does, restart
         // with backoff but do not count as a crash.
         consecutiveCrashes = 0;
@@ -505,7 +548,7 @@ export function startStage(config: StartStageConfig): StageController {
       emit({
         type: "crash",
         track: null,
-        exit: outcome.exit,
+        exit,
         consecutive: consecutiveCrashes,
       });
 

--- a/apps/engine/src/stages/supervisor.ts
+++ b/apps/engine/src/stages/supervisor.ts
@@ -384,8 +384,17 @@ export function startStage(config: StartStageConfig): StageController {
         const untils = Array.from(deadUntil.values());
         const earliest = untils.length > 0 ? Math.min(...untils) : undefined;
         currentTrack = null;
-        await runCuratingLoop(earliest);
-        continue; // re-check countDead on next iteration
+        const result = await runCuratingLoop(earliest);
+        if (result === "aborted" || result === "failed") {
+          // "aborted" — stage-wide stop. "failed" — fallback itself is
+          // unusable, so re-entering the all-dead branch would just
+          // hot-loop stat/spawn/log until the TTL expires (~10 min by
+          // default). Stop the stage cleanly instead.
+          return;
+        }
+        // "deadline" — earliest TTL has elapsed; loop so we can
+        // re-evaluate countDead and maybe retry a real track.
+        continue;
       }
       while (isDead(deadUntil, i)) i = (i + 1) % tracks.length;
 
@@ -469,8 +478,20 @@ export function startStage(config: StartStageConfig): StageController {
    * time so the outer track loop can re-check whether any dead track
    * has become retryable. When `until` is omitted (empty-playlist
    * case), the loop runs until the stage is aborted.
+   *
+   * Return value tells the caller what happened so it can decide
+   * whether to re-enter the track loop or give up:
+   *   - "aborted" — stage-wide stop; caller should return.
+   *   - "deadline" — the `until` deadline hit; caller should re-check
+   *     deadUntil (some tracks may now be eligible).
+   *   - "failed" — fallback is unusable (preflight invalid, or it hit
+   *     the consecutive-crash cap). Caller should give up on the
+   *     stage entirely; re-entering all-dead → curating would just
+   *     hot-loop stat/spawn until TTL expires.
    */
-  async function runCuratingLoop(until?: number): Promise<void> {
+  async function runCuratingLoop(
+    until?: number,
+  ): Promise<"aborted" | "deadline" | "failed"> {
     // Validate the fallback file once up front. A broken fallback is
     // fatal — nothing we can play, don't hot-loop -stream_loop -1.
     const pre = await preflightImpl(fallbackFile);
@@ -480,12 +501,12 @@ export function startStage(config: StartStageConfig): StageController {
           pre.detail ? `: ${pre.detail}` : ""
         }) — stopping`,
       );
-      return;
+      return "failed";
     }
 
     let consecutiveCrashes = 0;
     while (!ac.signal.aborted) {
-      if (until !== undefined && Date.now() >= until) return;
+      if (until !== undefined && Date.now() >= until) return "deadline";
 
       const startedAt = Date.now();
       emit({ type: "curating_started", startedAt });
@@ -505,7 +526,7 @@ export function startStage(config: StartStageConfig): StageController {
         const remaining = Math.max(0, until - Date.now());
         if (remaining === 0) {
           ac.signal.removeEventListener("abort", linkStage);
-          return;
+          return "deadline";
         }
         deadlineTimer = setTimeout(() => {
           deadlineHit = true;
@@ -530,17 +551,17 @@ export function startStage(config: StartStageConfig): StageController {
 
       emit({ type: "curating_ended", exit });
 
-      if (deadlineHit) return; // Deadline first — re-enter track loop.
-      if (ac.signal.aborted) return;
+      if (deadlineHit) return "deadline"; // re-enter track loop
+      if (ac.signal.aborted) return "aborted";
 
-      if (exit.kind === "aborted") return;
+      if (exit.kind === "aborted") return "aborted";
 
       if (exit.kind === "ok") {
         // -stream_loop -1 shouldn't exit cleanly; if it does, restart
         // with backoff but do not count as a crash.
         consecutiveCrashes = 0;
         const slept = await sleepOrAbort(restartBackoffMs);
-        if (!slept) return;
+        if (!slept) return "aborted";
         continue;
       }
 
@@ -556,11 +577,12 @@ export function startStage(config: StartStageConfig): StageController {
         safeLog(
           `[stage:${stageId}] fallback crashed ${consecutiveCrashes} times — stopping`,
         );
-        return;
+        return "failed";
       }
       const slept = await sleepOrAbort(restartBackoffMs);
-      if (!slept) return;
+      if (!slept) return "aborted";
     }
+    return "aborted";
   }
 
   async function sleepOrAbort(ms: number): Promise<boolean> {

--- a/apps/engine/src/stages/watchers.test.ts
+++ b/apps/engine/src/stages/watchers.test.ts
@@ -1,0 +1,113 @@
+import { describe, it, beforeEach, afterEach } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtemp, mkdir, writeFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import { waitForFirstSegment } from "./watchers.ts";
+
+describe("waitForFirstSegment", () => {
+  let work: string;
+  beforeEach(async () => {
+    work = await mkdtemp(path.join(tmpdir(), "pavoia-watcher-"));
+  });
+  afterEach(async () => {
+    await rm(work, { recursive: true, force: true });
+  });
+
+  it("returns 'ready' as soon as the first seg-*.ts appears", async () => {
+    const hlsDir = path.join(work, "hls");
+    await mkdir(hlsDir);
+    const ac = new AbortController();
+
+    const p = waitForFirstSegment({
+      hlsDir,
+      signal: ac.signal,
+      timeoutMs: 3000,
+      pollIntervalMs: 50,
+    });
+    // Write a segment ~120 ms after the watcher starts — well within
+    // the budget, but after at least one poll cycle.
+    setTimeout(() => {
+      void writeFile(path.join(hlsDir, "seg-00000.ts"), "x");
+    }, 120);
+    assert.equal(await p, "ready");
+  });
+
+  it("returns 'timeout' if no segment appears within the budget", async () => {
+    const hlsDir = path.join(work, "hls");
+    await mkdir(hlsDir);
+    const ac = new AbortController();
+
+    const r = await waitForFirstSegment({
+      hlsDir,
+      signal: ac.signal,
+      timeoutMs: 200,
+      pollIntervalMs: 50,
+    });
+    assert.equal(r, "timeout");
+  });
+
+  it("tolerates a missing directory (returns timeout, not throw)", async () => {
+    const ac = new AbortController();
+    const r = await waitForFirstSegment({
+      hlsDir: path.join(work, "does-not-exist"),
+      signal: ac.signal,
+      timeoutMs: 200,
+      pollIntervalMs: 50,
+    });
+    assert.equal(r, "timeout");
+  });
+
+  it("returns 'aborted' immediately when the signal is already aborted", async () => {
+    const ac = new AbortController();
+    ac.abort();
+    const r = await waitForFirstSegment({
+      hlsDir: path.join(work, "hls"),
+      signal: ac.signal,
+      timeoutMs: 5000,
+      pollIntervalMs: 50,
+    });
+    assert.equal(r, "aborted");
+  });
+
+  it("returns 'aborted' fast when the signal aborts mid-wait", async () => {
+    const hlsDir = path.join(work, "hls");
+    await mkdir(hlsDir);
+    const ac = new AbortController();
+    const start = Date.now();
+    const p = waitForFirstSegment({
+      hlsDir,
+      signal: ac.signal,
+      timeoutMs: 5000,
+      pollIntervalMs: 50,
+    });
+    setTimeout(() => ac.abort(), 60);
+    const r = await p;
+    assert.equal(r, "aborted");
+    // Must exit within a poll interval of the abort, not after the full
+    // 5s timeout.
+    assert.ok(
+      Date.now() - start < 500,
+      `abort was not prompt; took ${Date.now() - start}ms`,
+    );
+  });
+
+  it("ignores non-matching files (partial segments, m3u8, etc.)", async () => {
+    const hlsDir = path.join(work, "hls");
+    await mkdir(hlsDir);
+    // Pre-seed the dir with near-miss names that must NOT satisfy.
+    await writeFile(path.join(hlsDir, "seg-abc.ts"), "x");
+    await writeFile(path.join(hlsDir, "index.m3u8"), "#EXTM3U\n");
+    await writeFile(path.join(hlsDir, "seg-.ts"), "x");
+
+    const ac = new AbortController();
+    const r = await waitForFirstSegment({
+      hlsDir,
+      signal: ac.signal,
+      timeoutMs: 200,
+      pollIntervalMs: 50,
+    });
+    assert.equal(r, "timeout");
+  });
+});

--- a/apps/engine/src/stages/watchers.ts
+++ b/apps/engine/src/stages/watchers.ts
@@ -30,12 +30,28 @@ export interface WaitForFirstSegmentInput {
   timeoutMs: number;
   /** How often we readdir. Default 200 ms — cheap on tmpfs, fast enough. */
   pollIntervalMs?: number;
+  /**
+   * Segment filenames that already exist at the moment the watcher
+   * is armed (e.g. leftover segments from the previous track that
+   * the supervisor deliberately preserves for HLS client safety).
+   * They don't count as "the first segment" — we're looking strictly
+   * for segments produced by the ffmpeg invocation we're watching.
+   *
+   * Must be a snapshot taken immediately before ffmpeg spawns.
+   */
+  ignoreExisting?: ReadonlySet<string> | readonly string[];
 }
 
 export async function waitForFirstSegment(
   input: WaitForFirstSegmentInput,
 ): Promise<WaitResult> {
   const { hlsDir, signal, timeoutMs, pollIntervalMs = 200 } = input;
+  const ignore =
+    input.ignoreExisting === undefined
+      ? EMPTY_IGNORE
+      : input.ignoreExisting instanceof Set
+        ? input.ignoreExisting
+        : new Set<string>(input.ignoreExisting as readonly string[]);
   if (signal.aborted) return "aborted";
   const deadline = Date.now() + timeoutMs;
 
@@ -43,7 +59,13 @@ export async function waitForFirstSegment(
     if (signal.aborted) return "aborted";
     try {
       const entries = await readdir(hlsDir);
-      if (entries.some((e) => SEGMENT_PATTERN.test(e))) return "ready";
+      if (
+        entries.some(
+          (e) => SEGMENT_PATTERN.test(e) && !ignore.has(e),
+        )
+      ) {
+        return "ready";
+      }
     } catch (err) {
       // ENOENT just means the supervisor hasn't mkdir'd it yet. Any
       // other stat error is transient; retry next poll.
@@ -58,6 +80,20 @@ export async function waitForFirstSegment(
     if (waited === "aborted") return "aborted";
   }
   return "timeout";
+}
+
+const EMPTY_IGNORE: ReadonlySet<string> = new Set();
+
+export async function snapshotExistingSegments(
+  hlsDir: string,
+): Promise<string[]> {
+  try {
+    const entries = await readdir(hlsDir);
+    return entries.filter((e) => SEGMENT_PATTERN.test(e));
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === "ENOENT") return [];
+    return [];
+  }
 }
 
 async function abortableSleep(

--- a/apps/engine/src/stages/watchers.ts
+++ b/apps/engine/src/stages/watchers.ts
@@ -1,0 +1,79 @@
+// Polls a stage's HLS directory for the first seg-*.ts file to appear.
+//
+// Used by the supervisor for two overlapping concerns (both Codex
+// challenge findings on Week 1 Task 3):
+//
+//   1. Watchdog: if ffmpeg spawns but produces no segment within a
+//      bounded window, something is hung (unreadable file stalling
+//      libav, kernel stall on tmpfs under pressure). The supervisor
+//      treats that as a synthetic crash and moves on.
+//
+//   2. Honest now-playing: emit the `track_started` event only when
+//      the track is actually producing audio. Emitting at spawn
+//      time means `currentTrack()` / the WebSocket feed can claim
+//      a track is playing when listeners still hear the previous
+//      track's tail (or nothing, for a corrupt file).
+//
+// Abort-aware: a supervisor stop interrupts the poll without waiting
+// for the timeout.
+
+import { readdir } from "node:fs/promises";
+
+const SEGMENT_PATTERN = /^seg-\d+\.ts$/;
+
+export type WaitResult = "ready" | "timeout" | "aborted";
+
+export interface WaitForFirstSegmentInput {
+  hlsDir: string;
+  signal: AbortSignal;
+  /** Overall deadline in ms. Typical: 5000. */
+  timeoutMs: number;
+  /** How often we readdir. Default 200 ms — cheap on tmpfs, fast enough. */
+  pollIntervalMs?: number;
+}
+
+export async function waitForFirstSegment(
+  input: WaitForFirstSegmentInput,
+): Promise<WaitResult> {
+  const { hlsDir, signal, timeoutMs, pollIntervalMs = 200 } = input;
+  if (signal.aborted) return "aborted";
+  const deadline = Date.now() + timeoutMs;
+
+  while (Date.now() < deadline) {
+    if (signal.aborted) return "aborted";
+    try {
+      const entries = await readdir(hlsDir);
+      if (entries.some((e) => SEGMENT_PATTERN.test(e))) return "ready";
+    } catch (err) {
+      // ENOENT just means the supervisor hasn't mkdir'd it yet. Any
+      // other stat error is transient; retry next poll.
+      if ((err as NodeJS.ErrnoException).code !== "ENOENT") {
+        // swallow — watcher stays best-effort.
+      }
+    }
+    const waited = await abortableSleep(
+      pollIntervalMs,
+      signal,
+    );
+    if (waited === "aborted") return "aborted";
+  }
+  return "timeout";
+}
+
+async function abortableSleep(
+  ms: number,
+  signal: AbortSignal,
+): Promise<"slept" | "aborted"> {
+  if (signal.aborted) return "aborted";
+  return new Promise<"slept" | "aborted">((resolve) => {
+    const onAbort = () => {
+      clearTimeout(timer);
+      resolve("aborted");
+    };
+    const timer = setTimeout(() => {
+      signal.removeEventListener("abort", onAbort);
+      resolve("slept");
+    }, ms);
+    signal.addEventListener("abort", onAbort, { once: true });
+  });
+}


### PR DESCRIPTION
## Summary

Addresses the **5 failure modes Codex surfaced** in the post-merge challenge on Task 3, plus one bonus watchdog case and one fallback-validation case.

## The 5 (+ 2) hardening wins

| # | Win | Before | After |
|---|---|---|---|
| 1 | Cold-start corrupt track | 1.7 s silence | `fs.stat` rejects in µs, no ffmpeg spawn |
| 2 | Stale Plex paths | 3 × ENOENT retries = 1.7 s silence | Preflight + TTL'd `deadUntil` — self-heals on rescan |
| 3 | Cluster of 5 bad tracks | 8.5 s listener stall | <1 ms (all preflight-rejected) |
| 4 | Permanent dead-track marking | Track blacklisted for supervisor lifetime | `Map<index, expiryMs>` with 10-min TTL, re-tried on next rotation |
| 5 | `track_started` lies | Fires at spawn, before any audio | Fires on first `seg-*.ts` on disk |
| 6 (bonus) | ffmpeg hangs on unreadable input | Crash cap never fires | First-segment watchdog aborts + synthesizes crash after `firstSegmentTimeoutMs` (default 5 s) |
| 7 (bonus) | Broken fallback hot-loops | `-stream_loop -1` failures burn CPU | Fallback file is preflighted; invalid fallback exits stage cleanly |

## New modules

- **`preflight.ts`** (~60 LOC) — `fs.stat` wrapper with structured `PreflightReason` taxonomy (`missing` / `not_a_regular_file` / `empty` / `too_small` / `stat_error`), 1 KiB minimum size floor.
- **`watchers.ts`** (~70 LOC) — abort-aware polling for the first `seg-*.ts` in `hlsDir`, with configurable timeout + poll interval.

## Supervisor changes

- New `runOneWithWatchdog` helper races ffmpeg against `waitForFirstSegment` via `Promise.race`.
- Per-run `AbortController` derived from the stage one — watchdog aborts ONE ffmpeg without killing the stage.
- `deadTracks: Set<number>` → `deadUntil: Map<number, number>` with TTL semantics (lazy expiry in `isDead` / `countDead`).
- `currentTrack` is set/cleared in lockstep with `track_started` / `track_ended` — API reports the truth during audible playback.
- `track_ended` only fires when `track_started` was emitted (paired invariant preserved).

## New events

- `preflight_failed: { track, reason: PreflightReason }`
- `watchdog_timeout: { track, timeoutMs }`

## Test coverage

**16 new tests, 141 total (up from 123):**

- **`preflight.test.ts`** — 7 tests: regular file, missing, dangling symlink, directory, empty, too-small, permission denial.
- **`watchers.test.ts`** — 6 tests: ready, timeout, missing dir, pre-aborted, mid-wait abort, near-miss filenames ignored.
- **`supervisor.test.ts`** — 5 new hardening tests: preflight skip + TTL mark, TTL expiry re-try, watchdog abort + synthetic crash, deferred `track_started`, bad-fallback refusal.

All 141 tests pass locally in ~41 s.

## Test plan

- [x] `npm run typecheck` — clean on strict mode.
- [x] `npm test` — 141/141 pass.
- [x] Pre-push CR gate — "Review completed: No findings ✔"
- [ ] Codex adversarial review.
- [ ] CodeRabbit GitHub App review.
- [ ] CI (typecheck + test).
- [ ] Triple-signoff merge gate under v2 rules (severity gate: only Critical/Major/[P1] blocks; up to 3 review rounds).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Pre-play validation and a first-segment watchdog ensure tracks exist and actually produce HLS segments before being reported playing.
  * Tracks that fail validation or repeatedly crash are marked dead temporarily and retried after a configurable TTL.

* **Bug Fixes**
  * Stopped hot-looping when fallback/curating sources are missing or invalid.
  * Deferred "now-playing" until the first media segment is present; watchdog timeouts are handled as synthetic crashes.

* **Tests**
  * Added tests for preflight validation, first-segment watchdog, timing edge cases, and dead-track/TTL recovery.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->