### PR TITLE
feat(engine): GET /api/stages/:id/now + StageRegistry — Task 5 slice A

### DIFF
--- a/apps/engine/src/app.test.ts
+++ b/apps/engine/src/app.test.ts
@@ -7,7 +7,45 @@ import {
   type HealthBody,
   type StagesBody,
 } from "./app.ts";
-import { STAGES, AUDIO_STAGES } from "@pavoia/shared";
+import {
+  STAGES,
+  AUDIO_STAGES,
+  type NowPlaying,
+  type Track,
+} from "@pavoia/shared";
+import { createStageRegistry } from "./stages/registry.ts";
+import type { StageController } from "./stages/supervisor.ts";
+
+function fakeController(
+  stageId: string,
+  snap: {
+    status: "starting" | "playing" | "curating" | "stopping" | "stopped";
+    track: Track | null;
+    trackStartedAt: number | null;
+  },
+): StageController {
+  return {
+    stageId,
+    status: () => snap.status,
+    currentTrack: () => snap.track,
+    snapshot: () => ({ ...snap }),
+    stop: async () => {},
+    done: Promise.resolve(),
+  };
+}
+
+const SAMPLE_TRACK: Track = {
+  plexRatingKey: 12345,
+  fallbackHash: "deadbeef00000000",
+  title: "Sunset Lift",
+  artist: "Some Artist",
+  album: "Some Album",
+  albumYear: 2024,
+  durationSec: 360,
+  // filePath is engine-internal — must NOT appear in the response.
+  filePath: "/home/yolan/files/plex_music_library/opus/sunset.opus",
+  coverUrl: "/library/metadata/12345/thumb/abc",
+};
 
 describe("resolvePort", () => {
   it("defaults to 3001 when env is undefined", () => {
@@ -210,6 +248,144 @@ describe("createApp() — HTTP contract", () => {
   it("POST /api/stages returns 404 (only GET is defined)", async () => {
     const app = createApp();
     const res = await app.request("/api/stages", { method: "POST" });
+    assert.equal(res.status, 404);
+  });
+});
+
+describe("createApp() — /api/stages/:id/now", () => {
+  it("returns 200 with the projected NowPlaying when the stage has a current track", async () => {
+    const registry = createStageRegistry();
+    registry.register(
+      fakeController("opening", {
+        status: "playing",
+        track: SAMPLE_TRACK,
+        trackStartedAt: 1_700_000_000_000,
+      }),
+    );
+    const app = createApp({ registry });
+    const res = await app.request("/api/stages/opening/now");
+    assert.equal(res.status, 200);
+    const body = (await res.json()) as NowPlaying;
+    assert.equal(body.stageId, "opening");
+    assert.equal(body.status, "playing");
+    assert.equal(body.startedAt, 1_700_000_000_000);
+    assert.equal(body.streamUrl, "/hls/opening/index.m3u8");
+    // The Track must be projected to PublicTrack — `filePath` is
+    // engine-internal and MUST NOT appear in the response.
+    assert.equal(body.track?.title, "Sunset Lift");
+    assert.equal(body.track?.plexRatingKey, 12345);
+    assert.equal(
+      "filePath" in (body.track ?? {}),
+      false,
+      "filePath must never leak through /api/stages/:id/now",
+    );
+  });
+
+  it("returns 200 with track=null and startedAt=null while curating", async () => {
+    const registry = createStageRegistry();
+    registry.register(
+      fakeController("opening", {
+        status: "curating",
+        track: null,
+        trackStartedAt: null,
+      }),
+    );
+    const app = createApp({ registry });
+    const res = await app.request("/api/stages/opening/now");
+    assert.equal(res.status, 200);
+    const body = (await res.json()) as NowPlaying;
+    assert.equal(body.status, "curating");
+    assert.equal(body.track, null);
+    assert.equal(body.startedAt, null);
+  });
+
+  it("returns 404 when the stage id is not in the static catalog", async () => {
+    const registry = createStageRegistry();
+    const app = createApp({ registry });
+    const res = await app.request("/api/stages/no-such-stage/now");
+    assert.equal(res.status, 404);
+    const body = (await res.json()) as { error: string; stageId: string };
+    assert.equal(body.error, "stage_not_found");
+    assert.equal(body.stageId, "no-such-stage");
+  });
+
+  it("returns 410 Gone for the disabled bus stage (no audio by design)", async () => {
+    const registry = createStageRegistry();
+    const app = createApp({ registry });
+    const res = await app.request("/api/stages/bus/now");
+    assert.equal(res.status, 410);
+    const body = (await res.json()) as { error: string; stageId: string };
+    assert.equal(body.error, "stage_has_no_audio");
+    assert.equal(body.stageId, "bus");
+  });
+
+  it("returns 503 when no registry is wired (engine not fully started)", async () => {
+    const app = createApp(); // no deps
+    const res = await app.request("/api/stages/opening/now");
+    assert.equal(res.status, 503);
+    const body = (await res.json()) as { error: string; stageId: string };
+    assert.equal(body.error, "registry_unavailable");
+    assert.equal(body.stageId, "opening");
+  });
+
+  it("returns 503 when the stage is in the catalog but no controller is registered", async () => {
+    const registry = createStageRegistry();
+    // Register a different stage so the registry is non-empty but
+    // the requested one is missing.
+    registry.register(
+      fakeController("closing", {
+        status: "playing",
+        track: SAMPLE_TRACK,
+        trackStartedAt: 1,
+      }),
+    );
+    const app = createApp({ registry });
+    const res = await app.request("/api/stages/opening/now");
+    assert.equal(res.status, 503);
+    const body = (await res.json()) as { error: string; stageId: string };
+    assert.equal(body.error, "stage_not_running");
+  });
+
+  it("snapshots are atomic — same handler call sees consistent track + startedAt", async () => {
+    // Verifies the API uses snapshot() rather than calling currentTrack()
+    // and trackStartedAt() separately (which could race with a track
+    // change mid-handler).
+    let flips = 0;
+    const flippy: StageController = {
+      stageId: "opening",
+      status: () => "playing",
+      currentTrack: () => SAMPLE_TRACK,
+      snapshot: () => {
+        flips++;
+        // If the handler called snapshot() multiple times it would
+        // see different states. Exposing the flip count via track id
+        // lets the assertion catch a regression.
+        return {
+          status: "playing",
+          track: { ...SAMPLE_TRACK, plexRatingKey: flips },
+          trackStartedAt: flips * 1000,
+        };
+      },
+      stop: async () => {},
+      done: Promise.resolve(),
+    };
+    const registry = createStageRegistry();
+    registry.register(flippy);
+    const app = createApp({ registry });
+
+    const res = await app.request("/api/stages/opening/now");
+    const body = (await res.json()) as NowPlaying;
+    assert.equal(flips, 1, "snapshot() must be called exactly once per request");
+    assert.equal(body.track?.plexRatingKey, 1);
+    assert.equal(body.startedAt, 1000);
+  });
+
+  it("POST /api/stages/:id/now returns 404 (only GET is defined)", async () => {
+    const registry = createStageRegistry();
+    const app = createApp({ registry });
+    const res = await app.request("/api/stages/opening/now", {
+      method: "POST",
+    });
     assert.equal(res.status, 404);
   });
 });

--- a/apps/engine/src/app.ts
+++ b/apps/engine/src/app.ts
@@ -5,7 +5,15 @@
 // unit-testable without touching process.env.
 
 import { Hono } from "hono";
-import { STAGES, AUDIO_STAGES, type Stage } from "@pavoia/shared";
+import {
+  STAGES,
+  AUDIO_STAGES,
+  toPublicTrack,
+  type NowPlaying,
+  type Stage,
+} from "@pavoia/shared";
+
+import type { StageRegistry } from "./stages/registry.ts";
 
 export type HealthBody = {
   ok: true;
@@ -21,8 +29,7 @@ export type HealthBody = {
  * Response body for `GET /api/stages`. The static catalog of all 11
  * stages, ordered for the UI sidebar. Live values that can change
  * per Plex playlist (title, summary, current track) are NOT here —
- * those land in `/api/stages/:id/now` once the supervisor registry
- * is wired in (later Task 5 slice).
+ * `/api/stages/:id/now` exposes those.
  *
  * The `Stage` type from @pavoia/shared has no internal-only fields
  * (no filePath, no token, etc.), so we can serialize it directly
@@ -31,6 +38,16 @@ export type HealthBody = {
 export type StagesBody = {
   stages: Stage[];
 };
+
+/**
+ * Optional dependencies for the Hono app. When `registry` is provided,
+ * `/api/stages/:id/now` queries it for live state. When omitted (e.g.
+ * tests of the static surface, or the engine before supervisors have
+ * been wired in `index.ts`), `/now` returns 503.
+ */
+export interface AppDeps {
+  registry?: StageRegistry;
+}
 
 const PORT_PATTERN = /^[1-9]\d{0,4}$/;
 
@@ -50,7 +67,8 @@ export function resolvePort(raw: string | undefined): number {
   return parsed;
 }
 
-export function createApp(): Hono {
+export function createApp(deps: AppDeps = {}): Hono {
+  const { registry } = deps;
   const app = new Hono();
 
   app.get("/api/health", (c) => {
@@ -68,6 +86,57 @@ export function createApp(): Hono {
 
   app.get("/api/stages", (c) => {
     const body: StagesBody = { stages: STAGES };
+    return c.json(body);
+  });
+
+  app.get("/api/stages/:id/now", (c) => {
+    const id = c.req.param("id");
+
+    // Validate the stage id is one of the known catalog ids before
+    // we touch the registry. Returns 404 with the offending id so
+    // clients (and curl debug) get a useful message.
+    const stage = STAGES.find((s) => s.id === id);
+    if (stage === undefined) {
+      return c.json({ error: "stage_not_found", stageId: id }, 404);
+    }
+
+    // Bus is the no-audio easter egg. There's no supervisor and no
+    // HLS stream — the UI handles it as a card-only overlay. Return
+    // 410 Gone so a client that mistakenly requests its now-playing
+    // doesn't think it's a transient error.
+    if (stage.disabled) {
+      return c.json({ error: "stage_has_no_audio", stageId: id }, 410);
+    }
+
+    if (registry === undefined) {
+      // Engine running without a registry yet — `/api/stages` works
+      // (static catalog) but live state isn't available. 503 = "not
+      // ready" so a watchdog/restart doesn't escalate.
+      return c.json(
+        { error: "registry_unavailable", stageId: id },
+        503,
+      );
+    }
+
+    const controller = registry.get(id);
+    if (controller === undefined) {
+      // Catalog says the stage exists, but no supervisor is running
+      // for it. Same not-ready signal — `index.ts` may still be
+      // bringing the stage up.
+      return c.json(
+        { error: "stage_not_running", stageId: id },
+        503,
+      );
+    }
+
+    const snap = controller.snapshot();
+    const body: NowPlaying = {
+      stageId: stage.id,
+      status: snap.status,
+      track: snap.track === null ? null : toPublicTrack(snap.track),
+      startedAt: snap.trackStartedAt,
+      streamUrl: `/hls/${stage.id}/index.m3u8`,
+    };
     return c.json(body);
   });
 

--- a/apps/engine/src/stages/index.ts
+++ b/apps/engine/src/stages/index.ts
@@ -26,9 +26,13 @@ export { startStage, defaultSleep } from "./supervisor.ts";
 export type {
   StartStageConfig,
   StageController,
+  StageSnapshot,
   StageStatus,
   StageEvent,
   RunTrackFn,
   WaitForFirstSegmentFn,
   PreflightFn,
 } from "./supervisor.ts";
+
+export { createStageRegistry } from "./registry.ts";
+export type { StageRegistry } from "./registry.ts";

--- a/apps/engine/src/stages/registry.test.ts
+++ b/apps/engine/src/stages/registry.test.ts
@@ -1,0 +1,96 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+
+import { createStageRegistry } from "./registry.ts";
+import type { StageController, StageSnapshot } from "./supervisor.ts";
+
+function makeFakeController(
+  stageId: string,
+  opts: { stopBehavior?: "ok" | "throw" } = {},
+): StageController {
+  let status: "starting" | "playing" | "stopped" = "starting";
+  const snapshot: StageSnapshot = {
+    status: "starting",
+    track: null,
+    trackStartedAt: null,
+  };
+  return {
+    stageId,
+    status: () => status,
+    currentTrack: () => null,
+    snapshot: () => ({ ...snapshot, status }),
+    stop: async () => {
+      if (opts.stopBehavior === "throw") {
+        throw new Error("stop intentionally failed");
+      }
+      status = "stopped";
+    },
+    done: Promise.resolve(),
+  };
+}
+
+describe("createStageRegistry", () => {
+  it("registers and retrieves a controller by stageId", () => {
+    const r = createStageRegistry();
+    const c = makeFakeController("opening");
+    r.register(c);
+    assert.equal(r.size, 1);
+    assert.equal(r.get("opening"), c);
+  });
+
+  it("returns undefined for an unknown stage", () => {
+    const r = createStageRegistry();
+    assert.equal(r.get("nope"), undefined);
+  });
+
+  it("replaces a controller when registering the same id again", () => {
+    const r = createStageRegistry();
+    const a = makeFakeController("opening");
+    const b = makeFakeController("opening");
+    r.register(a);
+    r.register(b);
+    assert.equal(r.size, 1);
+    assert.equal(r.get("opening"), b);
+  });
+
+  it("all() returns every registered controller", () => {
+    const r = createStageRegistry();
+    const a = makeFakeController("opening");
+    const b = makeFakeController("closing");
+    r.register(a);
+    r.register(b);
+    const all = r.all();
+    assert.equal(all.length, 2);
+    assert.ok(all.includes(a));
+    assert.ok(all.includes(b));
+  });
+
+  it("stopAll() stops every controller", async () => {
+    const r = createStageRegistry();
+    const a = makeFakeController("opening");
+    const b = makeFakeController("closing");
+    r.register(a);
+    r.register(b);
+    await r.stopAll();
+    assert.equal(a.status(), "stopped");
+    assert.equal(b.status(), "stopped");
+  });
+
+  it("stopAll() swallows individual stop errors so others still stop", async () => {
+    const r = createStageRegistry();
+    const ok = makeFakeController("opening");
+    const bad = makeFakeController("broken", { stopBehavior: "throw" });
+    r.register(ok);
+    r.register(bad);
+    // Must not reject — that would leave callers unable to clean up
+    // the rest of the registry on a single misbehaving stage.
+    await r.stopAll();
+    assert.equal(ok.status(), "stopped");
+  });
+
+  it("stopAll() on an empty registry resolves immediately", async () => {
+    const r = createStageRegistry();
+    await r.stopAll();
+    assert.equal(r.size, 0);
+  });
+});

--- a/apps/engine/src/stages/registry.ts
+++ b/apps/engine/src/stages/registry.ts
@@ -1,0 +1,55 @@
+// In-memory registry mapping stageId → StageController.
+//
+// The HTTP layer (/api/stages/:id/now, /hls/* later) needs to look up
+// a controller by stage id. The supervisor itself is wiring-agnostic;
+// this module is the bridge between the per-stage supervisors that
+// `index.ts` will spin up (Slice B) and the request handlers in app.ts
+// that need to read their state.
+//
+// Single-process scope. No persistence — the registry is rebuilt every
+// engine restart from `@pavoia/shared/STAGES`.
+
+import type { StageController } from "./supervisor.ts";
+
+export interface StageRegistry {
+  /**
+   * Insert (or replace) a controller for the given stage id. Replacing
+   * does NOT stop the previous controller — callers must stop it
+   * themselves first if they want clean handoff.
+   */
+  register(controller: StageController): void;
+  get(stageId: string): StageController | undefined;
+  /** Snapshot of all registered controllers in insertion order. */
+  all(): StageController[];
+  /** Stop every registered controller in parallel; resolves when all
+   *  have transitioned to "stopped". Errors from individual stops are
+   *  swallowed so one bad controller doesn't block the others. */
+  stopAll(): Promise<void>;
+  readonly size: number;
+}
+
+export function createStageRegistry(): StageRegistry {
+  const controllers = new Map<string, StageController>();
+
+  return {
+    register(controller) {
+      controllers.set(controller.stageId, controller);
+    },
+    get(stageId) {
+      return controllers.get(stageId);
+    },
+    all() {
+      return Array.from(controllers.values());
+    },
+    async stopAll() {
+      await Promise.all(
+        Array.from(controllers.values()).map((c) =>
+          c.stop().catch(() => {}),
+        ),
+      );
+    },
+    get size() {
+      return controllers.size;
+    },
+  };
+}

--- a/apps/engine/src/stages/supervisor.test.ts
+++ b/apps/engine/src/stages/supervisor.test.ts
@@ -1287,6 +1287,60 @@ describe("startStage — observer safety", () => {
     assert.equal(runner.calls.length, 0);
   });
 
+  it("snapshot() reports null track + startedAt while stopping (public contract)", async () => {
+    // Codex [P2] follow-up: between stop() being called and the run
+    // loop's .finally() running, internal currentTrack stays
+    // populated. The public snapshot must NOT leak that — clients
+    // querying /api/stages/:id/now expect track === null whenever
+    // status isn't "playing" or "curating".
+    const runner = makeControlledRunner();
+    const ctl = startStage({
+      stageId: "stop-snap",
+      tracks: [makeTrack({ plexRatingKey: 7, filePath: "/m/ok.opus" })],
+      hlsDir: path.join(work, "stop-snap"),
+      fallbackFile: "/tmp/curating.aac",
+      runTrackImpl: runner.run,
+      preflightImpl: acceptAllPreflight,
+      waitForFirstSegmentImpl: instantReadyWatcher,
+      sleep: zeroSleep,
+    });
+
+    await runner.waitForCall(1);
+    // Track is now playing (instantReadyWatcher emitted track_started
+    // synchronously after spawn, so currentTrack should be populated
+    // and the snapshot reflects it).
+    let snap = ctl.snapshot();
+    if (snap.status === "playing") {
+      assert.ok(snap.track, "playing snapshot exposes the track");
+    }
+
+    // Trigger stopping. Between this line and the loop returning,
+    // status === "stopping" but currentTrack may still be set.
+    const stopP = ctl.stop();
+
+    // Read the snapshot during the stopping window — it MUST report
+    // null track/startedAt regardless of the internal state.
+    snap = ctl.snapshot();
+    assert.notEqual(snap.status, "playing");
+    if (snap.status === "stopping" || snap.status === "stopped") {
+      assert.equal(
+        snap.track,
+        null,
+        `track must be null while ${snap.status}; got ${JSON.stringify(snap.track)}`,
+      );
+      assert.equal(snap.trackStartedAt, null);
+    }
+
+    await stopP;
+
+    // After stop completes, status is "stopped" and the snapshot
+    // remains consistent.
+    snap = ctl.snapshot();
+    assert.equal(snap.status, "stopped");
+    assert.equal(snap.track, null);
+    assert.equal(snap.trackStartedAt, null);
+  });
+
   it("a throwing onEvent does not take the supervisor down", async () => {
     const runner = makeControlledRunner();
     const ctl = startStage({

--- a/apps/engine/src/stages/supervisor.ts
+++ b/apps/engine/src/stages/supervisor.ts
@@ -42,7 +42,7 @@
 // This module intentionally performs NO networking, NO Plex polling,
 // NO /api routing. Wiring lives in Task 5 (engine index.ts).
 
-import type { Track } from "@pavoia/shared";
+import type { StageStatus, Track } from "@pavoia/shared";
 
 import { buildFfmpegArgs } from "./ffmpeg-args.ts";
 import { cleanStageDir, prepareStageDir } from "./hls-dir.ts";
@@ -69,12 +69,9 @@ const DEFAULT_FIRST_SEGMENT_TIMEOUT_MS = 5000;
  *  timestamp and the outer loop re-enters the all-dead branch). */
 const DEADLINE_GRACE_MS = 5;
 
-export type StageStatus =
-  | "starting"
-  | "playing"
-  | "curating"
-  | "stopping"
-  | "stopped";
+// StageStatus is defined in @pavoia/shared so the web side can use the
+// same type. Re-exported here for engine-internal convenience.
+export type { StageStatus };
 
 export type StageEvent =
   | { type: "status"; status: StageStatus }
@@ -144,10 +141,28 @@ export interface StartStageConfig {
   sleep?: (ms: number, signal: AbortSignal) => Promise<void>;
 }
 
+/**
+ * Atomic snapshot of a stage's now-playing state. Returned by
+ * `StageController.snapshot()` so HTTP handlers can read all related
+ * fields in one go (no race between separate getters).
+ */
+export interface StageSnapshot {
+  status: StageStatus;
+  /** The currently audible track. `null` during curating, before the
+   *  first segment lands, or while stopped/stopping. */
+  track: Track | null;
+  /** Epoch ms when the current track's first segment hit disk. `null`
+   *  whenever `track` is `null`. */
+  trackStartedAt: number | null;
+}
+
 export interface StageController {
   readonly stageId: string;
   status(): StageStatus;
   currentTrack(): Track | null;
+  /** Read-once snapshot of status + track + startedAt. Atomic w.r.t.
+   *  the run-loop's writes. */
+  snapshot(): StageSnapshot;
   /** Resolves after the supervisor's run loop has exited. */
   stop(): Promise<void>;
   /** Same promise returned from stop(); also resolves on a fatal error. */
@@ -177,6 +192,7 @@ export function startStage(config: StartStageConfig): StageController {
   const ac = new AbortController();
   let status: StageStatus = "starting";
   let currentTrack: Track | null = null;
+  let currentTrackStartedAt: number | null = null;
 
   const emit = (ev: StageEvent): void => {
     try {
@@ -282,13 +298,13 @@ export function startStage(config: StartStageConfig): StageController {
         // emitted. The exit-kind switch below classifies the outcome.
       } else if (winner.seg === "ready") {
         // Honest track_started: first audio on disk, now we claim it.
-        // `currentTrack` is updated in lockstep so the API (and any
-        // downstream WebSocket feed) reports the playing track for the
-        // full duration of the audible window, not just momentarily
-        // around the track_ended event.
+        // `currentTrack` + `currentTrackStartedAt` are updated in
+        // lockstep so a snapshot read by the HTTP layer is consistent.
+        const startedAt = Date.now();
         currentTrack = track;
+        currentTrackStartedAt = startedAt;
         trackStartedEmitted = true;
-        emit({ type: "track_started", track, startedAt: Date.now() });
+        emit({ type: "track_started", track, startedAt });
       } else if (winner.seg === "timeout") {
         // Watchdog: kill the stuck ffmpeg and classify as crashed.
         watchdogFired = true;
@@ -299,11 +315,13 @@ export function startStage(config: StartStageConfig): StageController {
       }
     } else {
       // Watchdog disabled: preserve the legacy behavior of emitting
-      // track_started at spawn time. currentTrack is set at the same
-      // moment for API consistency.
+      // track_started at spawn time. currentTrack + startedAt are
+      // set at the same moment for API consistency.
+      const startedAt = Date.now();
       currentTrack = track;
+      currentTrackStartedAt = startedAt;
       trackStartedEmitted = true;
-      emit({ type: "track_started", track, startedAt: Date.now() });
+      emit({ type: "track_started", track, startedAt });
     }
 
     // 4. Always await runPromise so we don't leave a zombie promise
@@ -433,6 +451,7 @@ export function startStage(config: StartStageConfig): StageController {
           if (outcome.started) {
             emit({ type: "track_ended", track, exit: { kind: "ok" } });
             currentTrack = null;
+            currentTrackStartedAt = null;
           }
           advance = true;
           break;
@@ -446,6 +465,7 @@ export function startStage(config: StartStageConfig): StageController {
         // claim is no longer true, and the crash branch doesn't emit
         // a paired track_ended.
         currentTrack = null;
+        currentTrackStartedAt = null;
         // Don't emit track_ended here: consumers expect it paired
         // with track_started, and crash/watchdog paths don't always
         // emit track_started.
@@ -609,6 +629,7 @@ export function startStage(config: StartStageConfig): StageController {
     })
     .finally(() => {
       currentTrack = null;
+      currentTrackStartedAt = null;
       setStatus("stopped");
     });
 
@@ -628,6 +649,11 @@ export function startStage(config: StartStageConfig): StageController {
     stageId,
     status: () => status,
     currentTrack: () => currentTrack,
+    snapshot: () => ({
+      status,
+      track: currentTrack,
+      trackStartedAt: currentTrackStartedAt,
+    }),
     stop,
     done: loop,
   };

--- a/apps/engine/src/stages/supervisor.ts
+++ b/apps/engine/src/stages/supervisor.ts
@@ -649,11 +649,21 @@ export function startStage(config: StartStageConfig): StageController {
     stageId,
     status: () => status,
     currentTrack: () => currentTrack,
-    snapshot: () => ({
-      status,
-      track: currentTrack,
-      trackStartedAt: currentTrackStartedAt,
-    }),
+    snapshot: () => {
+      // Normalize the public snapshot to match the documented contract:
+      // `track` and `trackStartedAt` are null whenever the stage is not
+      // actively producing audio for a real track. The internal vars
+      // stay populated until the run loop's .finally() clears them
+      // (useful for debugging via direct currentTrack() access), but
+      // the public surface used by /api/stages/:id/now is always
+      // truthful.
+      const audible = status === "playing" || status === "curating";
+      return {
+        status,
+        track: audible ? currentTrack : null,
+        trackStartedAt: audible ? currentTrackStartedAt : null,
+      };
+    },
     stop,
     done: loop,
   };

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -93,11 +93,37 @@ export function toPublicTrack(t: Track): PublicTrack {
   };
 }
 
+/**
+ * Lifecycle states of a per-stage ffmpeg supervisor. Mirrored on the
+ * client so the UI can distinguish "playing a real track" from
+ * "curating fallback" from "stopped" without duck-typing the track
+ * field. Re-exported by @pavoia/engine's stages/supervisor.ts to
+ * keep both sides on a single source of truth.
+ */
+export type StageStatus =
+  | "starting"
+  | "playing"
+  | "curating"
+  | "stopping"
+  | "stopped";
+
 export type NowPlaying = {
   stageId: StageId;
+  /** Lifecycle state at the moment of the snapshot. */
+  status: StageStatus;
+  /**
+   * The currently audible track. `null` during `curating` (fallback
+   * loop is playing, not a real track), `starting`, `stopping`, or
+   * `stopped`. Also `null` between a track ending and the next one's
+   * first segment landing on disk.
+   */
   track: PublicTrack | null;
-  /** Wall-clock epoch when the track started encoding. */
-  startedAt: number;
+  /**
+   * Wall-clock epoch ms when the current track's first segment hit
+   * disk (the supervisor's honest "now playing" moment). `null`
+   * whenever `track` is `null`.
+   */
+  startedAt: number | null;
   /** HLS m3u8 URL for this stage. */
   streamUrl: string;
 };


### PR DESCRIPTION
## Summary

Adds the now-playing endpoint and the registry that maps stage ids to running supervisors. Pure infrastructure — \`index.ts\` wiring (Plex client + N supervisors + 60 s poll loop) is **slice B**.

## Pieces

- \`packages/shared/src/types.ts\` — extracts \`StageStatus\` to shared, extends \`NowPlaying\` with \`status\` + nullable \`track\` / \`startedAt\` so curating mode is honestly representable.
- \`apps/engine/src/stages/supervisor.ts\` — adds \`StageSnapshot\` + \`controller.snapshot()\` (atomic read of status + track + trackStartedAt). Tracks \`currentTrackStartedAt\` in lockstep with the track_started / track_ended events.
- \`apps/engine/src/stages/registry.ts\` — new module; in-memory Map with register / get / all / stopAll / size. \`stopAll\` swallows individual errors so one bad controller doesn't block shutdown.
- \`apps/engine/src/app.ts\` — \`createApp({ registry? })\`. New \`GET /api/stages/:id/now\` returns \`NowPlaying\` with status codes:
  - **200** — known stage with running controller
  - **404** — id not in static catalog (\`stage_not_found\`)
  - **410** — \`bus\` stage (no audio by design — \`stage_has_no_audio\`)
  - **503** — no registry wired yet (\`registry_unavailable\`)
  - **503** — stage in catalog but no controller registered (\`stage_not_running\`)

Track is projected via \`toPublicTrack\` so \`filePath\` cannot leak. Atomicity verified by a dedicated test.

## Test plan

- [x] \`npm run typecheck\` clean
- [x] \`npm test\` — **163/163** pass (148 → 163: 7 registry, 8 endpoint)
- [x] Pre-push CR — "Review completed: No findings ✔"
- [ ] Codex review
- [ ] CI + CodeRabbit GitHub App
- [ ] Triple-signoff under v2 (severity gate, 3-round cap)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * New GET /api/stages/:id/now endpoint to fetch live stage playback info: status, startedAt (nullable), track (or null), and HLS stream URL; returns clear error responses for unknown, audio-disabled, or unavailable stages.

* **Tests**
  * Expanded tests covering the new endpoint, registry behavior, snapshot atomicity, lifecycle states, and multiple error scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->