### PR TITLE
feat(engine): /hls/* handler + bind-failure cleanup + dead-controller revival (closes #12)

### DIFF
--- a/apps/engine/README.md
+++ b/apps/engine/README.md
@@ -108,13 +108,13 @@ Status codes:
 
 | Code | When |
 |---|---|
-| `200` | Known stage + valid filename + file present |
-| `400` | `path_traversal` (resolved path escapes the stage dir) |
+| `200` | Known stage with controller in `playing`/`curating` + valid filename + file present + not a symlink |
+| `400` | `path_traversal` (resolved path escapes the stage dir) / `symlink_rejected` |
 | `404` | `stage_not_found` / `bad_filename` / `file_not_found` / `not_a_file` |
 | `410` | `stage_has_no_audio` (the `bus` mystery stage) |
-| `503` | `hls_unavailable` (engine in HTTP-only mode) |
+| `503` | `hls_unavailable` (engine in HTTP-only mode) / `stage_not_running` (controller missing or in `starting`/`stopping`/`stopped`) |
 
-Symlinks inside `HLS_ROOT` ARE followed (no `lstat` rejection) — the operator owns the tmpfs and we trust them not to plant arbitrary symlinks. Documented in `hls.test.ts` as a known limitation.
+Symlinks inside `HLS_ROOT` are **rejected** (lstat detects them before stat would silently follow). Defense-in-depth even though the operator owns the tmpfs.
 
 ### `404 Not Found`
 

--- a/apps/engine/README.md
+++ b/apps/engine/README.md
@@ -6,7 +6,7 @@ See `../../docs/SLIM_V3.md` for the full feature scope, `../../docs/WEEK0_LOG.md
 
 ## Status
 
-**Week 1 Tasks 1–5 — complete except `/hls/*`.** The engine bootstraps the HTTP server (Task 1), has a Plex playlist client with validation + pagination (Task 2), runs a per-stage ffmpeg supervisor with crash restart, fallback, preflight, TTL'd dead tracks, and a first-segment watchdog (Task 3 + hardening), is verified click-free end-to-end against real ffmpeg (Task 4), and now exposes `GET /api/stages` + `GET /api/stages/:id/now`, a Plex client + N supervisors at startup, and a 60 s polling loop that swaps a stage's tracks when Plex changes (Task 5). What's missing: the `/hls/*` static file handler, the WebSocket hub, and `deploy/bin/*` scripts.
+**Week 1 Tasks 1–5 — complete.** The engine bootstraps the HTTP server (Task 1), has a Plex playlist client with validation + pagination (Task 2), runs a per-stage ffmpeg supervisor with crash restart, fallback, preflight, TTL'd dead tracks, first-segment watchdog, and queue-don't-restart Plex updates (Task 3 + hardening), is verified click-free end-to-end against real ffmpeg (Task 4), and now exposes the full read-side API + `/hls/*` static handler — `GET /api/stages` + `GET /api/stages/:id/now` + `GET /hls/<stageId>/index.m3u8` + `GET /hls/<stageId>/seg-NNNNN.ts` — driven by a Plex client + N supervisors at startup, a 60 s polling loop that queues track changes, parallel startup fetches, and a liveness watcher that revives supervisors that die unexpectedly (Task 5). What's missing for v3.0 MVP: WebSocket hub for `track_changed` events (UI optimization, the REST `/now` endpoint already covers polling), and `deploy/bin/*` scripts (Task 6).
 
 ## Scripts
 
@@ -91,6 +91,31 @@ Status codes:
 
 The `Track` is projected via `toPublicTrack` so the engine-internal `filePath` cannot leak.
 
+### `GET /hls/:stageId/index.m3u8` and `GET /hls/:stageId/seg-NNNNN.ts`
+
+Static HLS files written by the per-stage ffmpeg into `<HLS_ROOT>/<stageId>/`. The path-traversal guard validates `stageId` against the static catalog and `filename` against an exact regex (`index.m3u8` or `seg-\d+\.ts`) BEFORE composing the on-disk path; a redundant resolved-path-stays-inside-stageDir check catches future regressions.
+
+Headers tuned for hls.js + native iOS Safari:
+
+| File | `Content-Type` | `Cache-Control` |
+|---|---|---|
+| `index.m3u8` | `application/vnd.apple.mpegurl` | `no-cache, no-store, must-revalidate` (live profile, rewritten every 3 s) |
+| `seg-NNNNN.ts` | `video/mp2t` | `public, max-age=60, immutable` (segments don't change once written) |
+
+`Access-Control-Allow-Origin: *` on every response — public radio, no credentials.
+
+Status codes:
+
+| Code | When |
+|---|---|
+| `200` | Known stage + valid filename + file present |
+| `400` | `path_traversal` (resolved path escapes the stage dir) |
+| `404` | `stage_not_found` / `bad_filename` / `file_not_found` / `not_a_file` |
+| `410` | `stage_has_no_audio` (the `bus` mystery stage) |
+| `503` | `hls_unavailable` (engine in HTTP-only mode) |
+
+Symlinks inside `HLS_ROOT` ARE followed (no `lstat` rejection) — the operator owns the tmpfs and we trust them not to plant arbitrary symlinks. Documented in `hls.test.ts` as a known limitation.
+
 ### `404 Not Found`
 
 Any unmatched route:
@@ -128,6 +153,8 @@ src/
 ├── config.test.ts
 ├── bootstrap.ts                   # bootstrap(input) → { app, registry, poller, shutdown }
 ├── bootstrap.test.ts              # mock-driven coverage of the full wiring flow
+├── hls.ts                         # /hls/<stage>/<file> handler (path-traversal guard, HLS headers, CORS)
+├── hls.test.ts                    # 12 tests: m3u8 + segment serving, every rejection path, symlink limitation
 ├── shutdown.test.ts               # integration: spawn index.ts, send signals, assert exit codes
 ├── index.ts                       # entry point: loadConfig → bootstrap → serve → signals
 ├── plex/
@@ -210,6 +237,6 @@ await ctl.stop();  // SIGTERM current ffmpeg, SIGKILL after 5s if stubborn
 
 Coming in later Week 1 tasks:
 
-- **Task 5 final slice** — `/hls/*` static file handler over `HLS_ROOT` (path-traversal guard required) + WebSocket hub for `track_changed` events.
+- **Task 5 epilogue** — WebSocket hub for `track_changed` events (UI optimization; the existing REST `/now` endpoint covers polling).
 - **Task 6** — `deploy/bin/start-engine.sh`, cron entries, watchdog port from v2.
 - **Task 7** — ship to `v3.nicemouth.box.ca`.

--- a/apps/engine/README.md
+++ b/apps/engine/README.md
@@ -100,7 +100,7 @@ Headers tuned for hls.js + native iOS Safari:
 | File | `Content-Type` | `Cache-Control` |
 |---|---|---|
 | `index.m3u8` | `application/vnd.apple.mpegurl` | `no-cache, no-store, must-revalidate` (live profile, rewritten every 3 s) |
-| `seg-NNNNN.ts` | `video/mp2t` | `public, max-age=60, immutable` (segments don't change once written) |
+| `seg-NNNNN.ts` | `video/mp2t` | `public, max-age=10` (NOT immutable — URLs re-bind to different bytes after engine restart since `seg-%05d.ts` numbering resets at 00000) |
 
 `Access-Control-Allow-Origin: *` on every response — public radio, no credentials.
 

--- a/apps/engine/src/app.test.ts
+++ b/apps/engine/src/app.test.ts
@@ -393,12 +393,20 @@ describe("createApp() — /api/stages/:id/now", () => {
 });
 
 describe("createApp() — /hls/* wiring", () => {
-  it("returns 503 hls_unavailable when hlsRoot is not provided", async () => {
+  it("returns 503 hls_unavailable WITH CORS header when hlsRoot is not provided", async () => {
+    // Regression (Codex round-3 [P2]): the HTTP-only-mode 503 must
+    // include CORS so browsers see an actionable status, not an
+    // opaque CORS failure.
     const app = createApp(); // no deps
     const res = await app.request("/hls/opening/index.m3u8");
     assert.equal(res.status, 503);
     const body = (await res.json()) as { error: string };
     assert.equal(body.error, "hls_unavailable");
+    assert.equal(
+      res.headers.get("access-control-allow-origin"),
+      "*",
+      "CORS header must be present even on the unavailable fallback",
+    );
   });
 
   it("mounts the hls handler when hlsRoot is provided", async () => {

--- a/apps/engine/src/app.test.ts
+++ b/apps/engine/src/app.test.ts
@@ -391,3 +391,41 @@ describe("createApp() — /api/stages/:id/now", () => {
     assert.equal(res.status, 404);
   });
 });
+
+describe("createApp() — /hls/* wiring", () => {
+  it("returns 503 hls_unavailable when hlsRoot is not provided", async () => {
+    const app = createApp(); // no deps
+    const res = await app.request("/hls/opening/index.m3u8");
+    assert.equal(res.status, 503);
+    const body = (await res.json()) as { error: string };
+    assert.equal(body.error, "hls_unavailable");
+  });
+
+  it("mounts the hls handler when hlsRoot is provided", async () => {
+    // Just verify the routing — the handler's own tests cover the
+    // serve semantics. This is sanity that createApp wires it.
+    const { mkdtemp, rm, mkdir, writeFile } = await import(
+      "node:fs/promises"
+    );
+    const { tmpdir } = await import("node:os");
+    const path = (await import("node:path")).default;
+    const work = await mkdtemp(path.join(tmpdir(), "pavoia-app-hls-"));
+    try {
+      const hlsRoot = path.join(work, "hls");
+      await mkdir(path.join(hlsRoot, "opening"), { recursive: true });
+      await writeFile(
+        path.join(hlsRoot, "opening", "index.m3u8"),
+        "#EXTM3U\n",
+      );
+      const app = createApp({ hlsRoot });
+      const res = await app.request("/hls/opening/index.m3u8");
+      assert.equal(res.status, 200);
+      assert.equal(
+        res.headers.get("content-type"),
+        "application/vnd.apple.mpegurl",
+      );
+    } finally {
+      await rm(work, { recursive: true, force: true });
+    }
+  });
+});

--- a/apps/engine/src/app.ts
+++ b/apps/engine/src/app.ts
@@ -13,6 +13,7 @@ import {
   type Stage,
 } from "@pavoia/shared";
 
+import { createHlsHandler } from "./hls.ts";
 import type { StageRegistry } from "./stages/registry.ts";
 
 export type HealthBody = {
@@ -40,13 +41,18 @@ export type StagesBody = {
 };
 
 /**
- * Optional dependencies for the Hono app. When `registry` is provided,
- * `/api/stages/:id/now` queries it for live state. When omitted (e.g.
- * tests of the static surface, or the engine before supervisors have
- * been wired in `index.ts`), `/now` returns 503.
+ * Optional dependencies for the Hono app.
+ *
+ * - `registry` — when provided, `/api/stages/:id/now` queries it for
+ *   live state. When omitted, `/now` returns 503.
+ * - `hlsRoot` — when provided, `/hls/*` serves the per-stage HLS
+ *   output from there. When omitted, `/hls/*` returns 503 — useful
+ *   for HTTP-only canary deploys + the existing shutdown integration
+ *   tests.
  */
 export interface AppDeps {
   registry?: StageRegistry;
+  hlsRoot?: string;
 }
 
 const PORT_PATTERN = /^[1-9]\d{0,4}$/;
@@ -68,7 +74,7 @@ export function resolvePort(raw: string | undefined): number {
 }
 
 export function createApp(deps: AppDeps = {}): Hono {
-  const { registry } = deps;
+  const { registry, hlsRoot } = deps;
   const app = new Hono();
 
   app.get("/api/health", (c) => {
@@ -139,6 +145,16 @@ export function createApp(deps: AppDeps = {}): Hono {
     };
     return c.json(body);
   });
+
+  // /hls/*  — per-stage HLS output (m3u8 + segments). When hlsRoot
+  // isn't wired (HTTP-only canary), fall through to a 503 sentinel.
+  if (hlsRoot !== undefined) {
+    app.route("/hls", createHlsHandler({ hlsRoot }));
+  } else {
+    app.all("/hls/*", (c) =>
+      c.json({ error: "hls_unavailable" }, 503),
+    );
+  }
 
   app.notFound((c) => c.json({ error: "not_found", path: c.req.path }, 404));
 

--- a/apps/engine/src/app.ts
+++ b/apps/engine/src/app.ts
@@ -147,13 +147,23 @@ export function createApp(deps: AppDeps = {}): Hono {
   });
 
   // /hls/*  — per-stage HLS output (m3u8 + segments). When hlsRoot
-  // isn't wired (HTTP-only canary), fall through to a 503 sentinel.
+  // isn't wired (HTTP-only canary), fall through to a 503 sentinel
+  // WITH the same CORS header the real handler returns — otherwise
+  // browsers in the canary scenario see opaque CORS failure instead
+  // of an actionable 503.
   if (hlsRoot !== undefined) {
-    app.route("/hls", createHlsHandler({ hlsRoot }));
-  } else {
-    app.all("/hls/*", (c) =>
-      c.json({ error: "hls_unavailable" }, 503),
+    app.route(
+      "/hls",
+      createHlsHandler({
+        hlsRoot,
+        ...(registry !== undefined ? { registry } : {}),
+      }),
     );
+  } else {
+    app.all("/hls/*", (c) => {
+      c.header("access-control-allow-origin", "*");
+      return c.json({ error: "hls_unavailable" }, 503);
+    });
   }
 
   app.notFound((c) => c.json({ error: "not_found", path: c.req.path }, 404));

--- a/apps/engine/src/bootstrap.test.ts
+++ b/apps/engine/src/bootstrap.test.ts
@@ -63,16 +63,26 @@ interface FakeStageController extends StageController {
   config: StartStageConfig;
   /** Track lists passed to setTracks() during this controller's life. */
   setTracksCalls: Array<readonly Track[]>;
+  /** Resolves the `done` promise — simulates the run loop terminating
+   *  unexpectedly so the bootstrap revival path can be exercised. */
+  resolveDone: () => void;
 }
 
 function fakeStartStageFactory() {
   const created: FakeStageController[] = [];
   function fakeStartStage(config: StartStageConfig): StageController {
+    let resolveDoneFn: (() => void) | null = null;
+    const donePromise = new Promise<void>((resolve) => {
+      resolveDoneFn = resolve;
+    });
     const ctl: FakeStageController = {
       stageId: config.stageId,
       stopped: false,
       config,
       setTracksCalls: [],
+      resolveDone: () => {
+        if (resolveDoneFn) resolveDoneFn();
+      },
       status: () => (ctl.stopped ? "stopped" : "playing"),
       currentTrack: () => null,
       snapshot: () => ({
@@ -85,8 +95,9 @@ function fakeStartStageFactory() {
       },
       stop: async () => {
         ctl.stopped = true;
+        if (resolveDoneFn) resolveDoneFn();
       },
-      done: Promise.resolve(),
+      done: donePromise,
     };
     created.push(ctl);
     return ctl;
@@ -419,13 +430,23 @@ describe("bootstrap — Plex polling queues track updates", () => {
     await result.shutdown();
   });
 
-  it("starts a fresh supervisor when no controller is registered for the stage", async () => {
-    // This branch fires when a stage was unregistered externally — not
-    // the normal bootstrap path (where every audio stage gets a
-    // controller at startup). Keeps the codepath honest.
+  // The "no controller registered for the stage" branch in
+  // bootstrap.onTracksChanged is now effectively unreachable in the
+  // normal lifecycle: every audio stage gets a controller at startup,
+  // and the liveness watcher (issue #12 item 2) immediately revives
+  // any controller that terminates. The branch is kept defensively
+  // for hypothetical future paths where a stage gets unregistered
+  // externally; it doesn't need a regression test of its own.
+});
+
+describe("bootstrap — controller liveness watcher (issue #12)", () => {
+  it("revives a supervisor whose run loop terminated unexpectedly while the engine is up", async () => {
+    // Regression for issue #12 item 2: a supervisor that died
+    // post-startup with no Plex change in sight stayed dead until
+    // engine restart. The bootstrap-side liveness watcher restarts
+    // it with the most recently known tracks.
     const plex = scriptedPlex();
     plex.setNext(100, [makeTrack(1)]);
-    plex.setNext(200, [makeTrack(10)]);
     const { fakeStartStage, created } = fakeStartStageFactory();
     const sched = manualSchedule();
 
@@ -433,20 +454,101 @@ describe("bootstrap — Plex polling queues track updates", () => {
       config: BASE_CONFIG,
       plexClient: plex.client,
       startStageImpl: fakeStartStage,
-      audioStages: TWO_STAGES,
+      audioStages: [fakeStage("opening", 100)],
       pollerSchedule: sched.schedule,
       log: () => {},
     });
 
-    // Manually un-register opening to simulate the corner case.
-    const openingCtl = result.registry.get("opening")!;
-    await openingCtl.stop();
-    // Hack: registry has no `delete` method; we'll just check the
-    // poller path by registering a sentinel that fakeStartStage
-    // reuses. Simpler: assert that BEFORE the tick, exactly one
-    // opening was created.
-    const beforeCount = created.filter((c) => c.stageId === "opening").length;
-    assert.equal(beforeCount, 1);
+    assert.equal(created.length, 1);
+    const first = created[0]!;
+
+    // Simulate the run loop terminating unexpectedly (HLS dir mid-
+    // run failure, fallback preflight invalidated, etc).
+    first.stopped = true;
+    first.resolveDone();
+
+    // Wait for the watcher's microtask + the spawnAndWatch chain.
+    await new Promise((r) => setTimeout(r, 20));
+
+    assert.equal(
+      created.length,
+      2,
+      "bootstrap should have spawned a replacement controller",
+    );
+    const replacement = created[1]!;
+    assert.equal(replacement.stageId, "opening");
+    assert.deepEqual(
+      replacement.config.tracks.map((t) => t.plexRatingKey),
+      [1],
+      "replacement uses the most recently known tracks (initial fetch)",
+    );
+    // Registry now points at the replacement, not the dead first one.
+    assert.equal(result.registry.get("opening"), replacement);
+
+    await result.shutdown();
+  });
+
+  it("does NOT revive supervisors when the engine is shutting down", async () => {
+    const plex = scriptedPlex();
+    plex.setNext(100, [makeTrack(1)]);
+    const { fakeStartStage, created } = fakeStartStageFactory();
+    const sched = manualSchedule();
+
+    const result = await bootstrap({
+      config: BASE_CONFIG,
+      plexClient: plex.client,
+      startStageImpl: fakeStartStage,
+      audioStages: [fakeStage("opening", 100)],
+      pollerSchedule: sched.schedule,
+      log: () => {},
+    });
+
+    // Initiate shutdown — that flips the internal flag BEFORE
+    // resolving each controller's `done` via stop(). The watcher
+    // should see `shuttingDown` and skip revival.
+    await result.shutdown();
+    await new Promise((r) => setTimeout(r, 20));
+
+    // Only the original controller exists — no zombie revive.
+    assert.equal(
+      created.length,
+      1,
+      "no revival should fire during/after shutdown",
+    );
+  });
+
+  it("uses the LATEST poller-known tracks when reviving (not the initial fetch)", async () => {
+    const plex = scriptedPlex();
+    plex.setNext(100, [makeTrack(1)]);
+    const { fakeStartStage, created } = fakeStartStageFactory();
+    const sched = manualSchedule();
+
+    const result = await bootstrap({
+      config: BASE_CONFIG,
+      plexClient: plex.client,
+      startStageImpl: fakeStartStage,
+      audioStages: [fakeStage("opening", 100)],
+      pollerSchedule: sched.schedule,
+      log: () => {},
+    });
+
+    // First poller tick changes the playlist; setTracks is called
+    // on the (still-alive) original. knownTracks is updated to [1, 7].
+    plex.setNext(100, [makeTrack(1), makeTrack(7)]);
+    await sched.tick();
+    assert.equal(created[0]!.setTracksCalls.length, 1);
+
+    // Now the original dies.
+    created[0]!.stopped = true;
+    created[0]!.resolveDone();
+    await new Promise((r) => setTimeout(r, 20));
+
+    assert.equal(created.length, 2);
+    assert.deepEqual(
+      created[1]!.config.tracks.map((t) => t.plexRatingKey),
+      [1, 7],
+      "revival uses the latest known tracks, not the initial-fetch snapshot",
+    );
 
     await result.shutdown();
   });

--- a/apps/engine/src/bootstrap.test.ts
+++ b/apps/engine/src/bootstrap.test.ts
@@ -517,6 +517,107 @@ describe("bootstrap — controller liveness watcher (issue #12)", () => {
     );
   });
 
+  it("gives up reviving after MAX_CONSECUTIVE_FAST_DEATHS — no infinite respawn loop", async () => {
+    // Regression (Codex [P1]): without a fast-death cap, a
+    // permanently-broken stage (bad fallback file, deterministic
+    // crash, etc.) would respawn forever, spamming logs and burning
+    // cycles. The watcher rate-limits revivals: 3 fast deaths in a
+    // row → give up; rely on the next Plex change or engine restart.
+    const plex = scriptedPlex();
+    plex.setNext(100, [makeTrack(1)]);
+    const { fakeStartStage, created } = fakeStartStageFactory();
+    const sched = manualSchedule();
+
+    const result = await bootstrap({
+      config: BASE_CONFIG,
+      plexClient: plex.client,
+      startStageImpl: fakeStartStage,
+      audioStages: [fakeStage("opening", 100)],
+      pollerSchedule: sched.schedule,
+      log: () => {},
+    });
+
+    // Kill controllers one at a time until the watcher stops
+    // reviving. Counter caps at MAX_CONSECUTIVE_FAST_DEATHS=3, so:
+    //   death 1 (original) → revive → controller [1] exists
+    //   death 2 (rev #1)   → revive → controller [2] exists
+    //   death 3 (rev #2)   → counter hits cap → NO new controller
+    //
+    // Loop until no new controller appears within a tick.
+    for (let i = 0; i < 5; i++) {
+      const before = created.length;
+      const ctl = created[i];
+      if (!ctl || ctl.stopped) break;
+      ctl.stopped = true;
+      ctl.resolveDone();
+      await new Promise((r) => setTimeout(r, 20));
+      if (created.length === before) break; // watcher gave up
+    }
+
+    // Total controllers = 1 original + 2 revivals = 3. The 3rd death
+    // hits the cap and the watcher leaves the stage stopped.
+    assert.equal(
+      created.length,
+      3,
+      `expected exactly 3 (1 original + 2 revivals before cap), got ${created.length}`,
+    );
+
+    await result.shutdown();
+  });
+
+  it("a Plex-driven onTracksChanged restart resets the fast-death counter", async () => {
+    // After the watcher gives up, a subsequent Plex change should
+    // give the stage a fresh attempt.
+    const plex = scriptedPlex();
+    plex.setNext(100, [makeTrack(1)]);
+    const { fakeStartStage, created } = fakeStartStageFactory();
+    const sched = manualSchedule();
+
+    const result = await bootstrap({
+      config: BASE_CONFIG,
+      plexClient: plex.client,
+      startStageImpl: fakeStartStage,
+      audioStages: [fakeStage("opening", 100)],
+      pollerSchedule: sched.schedule,
+      log: () => {},
+    });
+
+    // Burn the revival budget — same loop structure as the cap test
+    // above. 3 deaths total (1 original + 2 revivals).
+    for (let i = 0; i < 5; i++) {
+      const before = created.length;
+      const ctl = created[i];
+      if (!ctl || ctl.stopped) break;
+      ctl.stopped = true;
+      ctl.resolveDone();
+      await new Promise((r) => setTimeout(r, 20));
+      if (created.length === before) break;
+    }
+    assert.equal(created.length, 3); // gave up after the 3rd death
+
+    // Plex now has a new track set. Poller fires onTracksChanged →
+    // stopped controller → spawn fresh. Counter reset. Even if the
+    // new one dies fast, it gets revivals again.
+    plex.setNext(100, [makeTrack(2)]);
+    await sched.tick();
+    assert.equal(
+      created.length,
+      4,
+      "Plex update should spawn a fresh controller",
+    );
+    // Fast-die the new one → should revive (counter was reset).
+    created[3]!.stopped = true;
+    created[3]!.resolveDone();
+    await new Promise((r) => setTimeout(r, 20));
+    assert.equal(
+      created.length,
+      5,
+      "after Plex-driven restart, the watcher gets a fresh revival budget",
+    );
+
+    await result.shutdown();
+  });
+
   it("uses the LATEST poller-known tracks when reviving (not the initial fetch)", async () => {
     const plex = scriptedPlex();
     plex.setNext(100, [makeTrack(1)]);

--- a/apps/engine/src/bootstrap.ts
+++ b/apps/engine/src/bootstrap.ts
@@ -142,12 +142,51 @@ export async function bootstrap(
       }
     }),
   );
-  for (const { stage, tracks } of fetched) {
-    initialTracks.set(stage.id, tracks);
+  // Most-recently-known tracks per stage. Updated by the poller and
+  // used by the liveness watcher to revive a supervisor that died
+  // unexpectedly without waiting for a Plex change.
+  const knownTracks = new Map<string, readonly import("@pavoia/shared").Track[]>();
+
+  let shuttingDown = false;
+
+  function spawnAndWatch(
+    stage: Stage,
+    tracks: readonly import("@pavoia/shared").Track[],
+  ): StageController {
     const controller = startStageImpl(
       buildStageConfig(stage, tracks, config, log),
     );
     registry.register(controller);
+    // If the supervisor's run loop terminates unexpectedly (HLS dir
+    // mkdir mid-run, fallback preflight invalidated post-startup,
+    // etc.) AND we're not shutting down, immediately revive with the
+    // last-known tracks. Without this, a stage that died while Plex
+    // returned the same playlist would stay dead until the next
+    // unrelated Plex edit OR engine restart.
+    controller.done
+      .then(() => {
+        if (shuttingDown) return;
+        // Only revive if the registered controller is still THIS one.
+        // A `setTracks → done` racing a poller-driven restart is
+        // possible; the most-recently-registered one wins.
+        if (registry.get(stage.id) !== controller) return;
+        const tracksNow = knownTracks.get(stage.id) ?? [];
+        log(
+          `[engine] stage=${stage.id} supervisor terminated unexpectedly — reviving with ${tracksNow.length} known tracks`,
+        );
+        spawnAndWatch(stage, tracksNow);
+      })
+      .catch(() => {
+        // controller.done shouldn't reject (supervisor wraps loop in
+        // .catch().finally()), but defensively swallow.
+      });
+    return controller;
+  }
+
+  for (const { stage, tracks } of fetched) {
+    initialTracks.set(stage.id, tracks);
+    knownTracks.set(stage.id, tracks);
+    spawnAndWatch(stage, tracks);
   }
 
   // 60 s polling loop swaps a stage's tracks when Plex changes.
@@ -165,6 +204,10 @@ export async function bootstrap(
         );
         return;
       }
+      // Always keep knownTracks current so the liveness watcher (in
+      // spawnAndWatch above) can revive a dying supervisor with the
+      // freshest playlist.
+      knownTracks.set(stageId, tracks);
       // A controller that has reached "stopped" (fallback preflight
       // failure + crash cap + etc.) is already a dead ringer —
       // setTracks() on it would land in a run loop that has already
@@ -189,10 +232,7 @@ export async function bootstrap(
             `[engine] stage=${stageId} Plex tracks available (${tracks.length}) — starting supervisor`,
           );
         }
-        const next = startStageImpl(
-          buildStageConfig(stage, tracks, config, log),
-        );
-        registry.register(next); // registry.register replaces any existing entry
+        spawnAndWatch(stage, tracks);
       }
     },
     onError: (stageId, err) => {
@@ -201,16 +241,20 @@ export async function bootstrap(
     ...(pollerSchedule !== undefined ? { schedule: pollerSchedule } : {}),
   });
 
-  const app = createApp({ registry });
+  const app = createApp({ registry, hlsRoot: config.hlsRoot });
 
-  let shuttingDown: Promise<void> | null = null;
+  let shutdownPromise: Promise<void> | null = null;
   function shutdown(): Promise<void> {
-    if (shuttingDown) return shuttingDown;
-    shuttingDown = (async () => {
+    if (shutdownPromise) return shutdownPromise;
+    // Set the flag BEFORE awaiting so the liveness watcher
+    // (spawnAndWatch) sees it and skips revival when registry.stopAll
+    // makes every supervisor's run loop terminate.
+    shuttingDown = true;
+    shutdownPromise = (async () => {
       await poller.stop();
       await registry.stopAll();
     })();
-    return shuttingDown;
+    return shutdownPromise;
   }
 
   return { registry, poller, app, shutdown };

--- a/apps/engine/src/bootstrap.ts
+++ b/apps/engine/src/bootstrap.ts
@@ -147,32 +147,62 @@ export async function bootstrap(
   // unexpectedly without waiting for a Plex change.
   const knownTracks = new Map<string, readonly import("@pavoia/shared").Track[]>();
 
+  // Consecutive "fast deaths" per stage — a controller's run loop
+  // terminating within FAST_DEATH_MS of being spawned counts as a
+  // failed revival. After MAX_CONSECUTIVE_FAST_DEATHS in a row the
+  // watcher gives up: the failure is clearly permanent (bad fallback
+  // file, programmer bug, mkdir always fails) and infinite respawn
+  // would just spam logs and burn cycles. A subsequent Plex-driven
+  // restart via onTracksChanged resets the counter.
+  const FAST_DEATH_MS = 5_000;
+  const MAX_CONSECUTIVE_FAST_DEATHS = 3;
+  const consecutiveFastDeaths = new Map<string, number>();
+
   let shuttingDown = false;
 
   function spawnAndWatch(
     stage: Stage,
     tracks: readonly import("@pavoia/shared").Track[],
   ): StageController {
+    const spawnedAt = Date.now();
     const controller = startStageImpl(
       buildStageConfig(stage, tracks, config, log),
     );
     registry.register(controller);
     // If the supervisor's run loop terminates unexpectedly (HLS dir
-    // mkdir mid-run, fallback preflight invalidated post-startup,
-    // etc.) AND we're not shutting down, immediately revive with the
-    // last-known tracks. Without this, a stage that died while Plex
-    // returned the same playlist would stay dead until the next
-    // unrelated Plex edit OR engine restart.
+    // mkdir mid-run, transient I/O, etc.) AND we're not shutting
+    // down AND it's not a clearly-permanent rapid restart loop,
+    // immediately revive with the last-known tracks.
     controller.done
       .then(() => {
         if (shuttingDown) return;
         // Only revive if the registered controller is still THIS one.
-        // A `setTracks → done` racing a poller-driven restart is
-        // possible; the most-recently-registered one wins.
+        // A poller-driven restart could have already replaced it.
         if (registry.get(stage.id) !== controller) return;
+
+        const lifetime = Date.now() - spawnedAt;
+        let fastCount = consecutiveFastDeaths.get(stage.id) ?? 0;
+        if (lifetime < FAST_DEATH_MS) {
+          fastCount += 1;
+          consecutiveFastDeaths.set(stage.id, fastCount);
+        } else {
+          // Stage actually ran for a while before dying — reset the
+          // counter so a much-later transient death gets a fresh
+          // revival budget.
+          consecutiveFastDeaths.set(stage.id, 0);
+          fastCount = 0;
+        }
+
+        if (fastCount >= MAX_CONSECUTIVE_FAST_DEATHS) {
+          log(
+            `[engine] stage=${stage.id} terminated ${fastCount} times within ${FAST_DEATH_MS}ms — giving up. Stage stays stopped until next Plex change or engine restart.`,
+          );
+          return;
+        }
+
         const tracksNow = knownTracks.get(stage.id) ?? [];
         log(
-          `[engine] stage=${stage.id} supervisor terminated unexpectedly — reviving with ${tracksNow.length} known tracks`,
+          `[engine] stage=${stage.id} supervisor terminated after ${lifetime}ms — reviving with ${tracksNow.length} known tracks (consecutive fast deaths: ${fastCount}/${MAX_CONSECUTIVE_FAST_DEATHS})`,
         );
         spawnAndWatch(stage, tracksNow);
       })
@@ -232,6 +262,9 @@ export async function bootstrap(
             `[engine] stage=${stageId} Plex tracks available (${tracks.length}) — starting supervisor`,
           );
         }
+        // User/Plex took explicit action — fresh attempt, reset the
+        // watcher's consecutive-fast-death counter.
+        consecutiveFastDeaths.set(stageId, 0);
         spawnAndWatch(stage, tracks);
       }
     },

--- a/apps/engine/src/hls.test.ts
+++ b/apps/engine/src/hls.test.ts
@@ -6,6 +6,8 @@ import path from "node:path";
 import { Hono } from "hono";
 
 import { createHlsHandler } from "./hls.ts";
+import { createStageRegistry } from "./stages/registry.ts";
+import type { StageController } from "./stages/supervisor.ts";
 import type { Stage } from "@pavoia/shared";
 
 function fakeStage(
@@ -235,6 +237,66 @@ describe("createHlsHandler — validation + safety", () => {
         `${url} must expose CORS header on error`,
       );
     }
+  });
+
+  it("returns 503 stage_not_running when registry says the stage is stopped (avoids stale audio)", async () => {
+    // Regression (Codex round-3 [P2]): a supervisor that died
+    // post-startup leaves its last m3u8 + segments on disk because
+    // cleanStageDir only runs at supervisor START. Without the
+    // liveness gate, /hls/<stage>/* would happily serve those
+    // stale files while /api/stages/:id/now correctly reports the
+    // stage as stopped.
+    const registry = createStageRegistry();
+    const stoppedCtl: StageController = {
+      stageId: "opening",
+      status: () => "stopped",
+      currentTrack: () => null,
+      snapshot: () => ({
+        status: "stopped",
+        track: null,
+        trackStartedAt: null,
+      }),
+      setTracks: () => {},
+      stop: async () => {},
+      done: Promise.resolve(),
+    };
+    registry.register(stoppedCtl);
+
+    const root = new Hono();
+    root.route(
+      "/hls",
+      createHlsHandler({
+        hlsRoot,
+        catalog: [fakeStage("opening"), fakeStage("bus", true, null)],
+        registry,
+      }),
+    );
+
+    const res = await root.request("/hls/opening/index.m3u8");
+    assert.equal(res.status, 503);
+    const body = (await res.json()) as { error: string; stageId: string };
+    assert.equal(body.error, "stage_not_running");
+    assert.equal(body.stageId, "opening");
+    // Liveness gate uses the same CORS middleware path.
+    assert.equal(res.headers.get("access-control-allow-origin"), "*");
+  });
+
+  it("returns 503 stage_not_running when registry has no controller for the stage", async () => {
+    // Bootstrap hasn't registered this stage yet (still spinning up).
+    const registry = createStageRegistry();
+    const root = new Hono();
+    root.route(
+      "/hls",
+      createHlsHandler({
+        hlsRoot,
+        catalog: [fakeStage("opening"), fakeStage("bus", true, null)],
+        registry,
+      }),
+    );
+    const res = await root.request("/hls/opening/index.m3u8");
+    assert.equal(res.status, 503);
+    const body = (await res.json()) as { error: string };
+    assert.equal(body.error, "stage_not_running");
   });
 
   it("only accepts GET (no PUT/POST/DELETE)", async () => {

--- a/apps/engine/src/hls.test.ts
+++ b/apps/engine/src/hls.test.ts
@@ -208,6 +208,26 @@ describe("createHlsHandler — validation + safety", () => {
     assert.equal(res.status, 404);
   });
 
+  it("returns CORS header on every error response (so browsers see real status, not opaque CORS failure)", async () => {
+    // Regression (Codex [P1]): without CORS on errors, hls.js sees
+    // a 404 for a not-yet-written segment as an opaque load error
+    // and breaks its retry/error logic.
+    for (const url of [
+      "/hls/no-such/index.m3u8", // 404 stage_not_found
+      "/hls/bus/index.m3u8", // 410 stage_has_no_audio
+      "/hls/opening/index.html", // 404 bad_filename
+      "/hls/opening/seg-99999.ts", // 404 file_not_found
+    ]) {
+      const res = await app.request(url);
+      assert.notEqual(res.status, 200, `${url} should not 200`);
+      assert.equal(
+        res.headers.get("access-control-allow-origin"),
+        "*",
+        `${url} must expose CORS header on error`,
+      );
+    }
+  });
+
   it("only accepts GET (no PUT/POST/DELETE)", async () => {
     for (const method of ["POST", "PUT", "DELETE", "PATCH"]) {
       const res = await app.request("/hls/opening/index.m3u8", { method });

--- a/apps/engine/src/hls.test.ts
+++ b/apps/engine/src/hls.test.ts
@@ -184,8 +184,10 @@ describe("createHlsHandler — validation + safety", () => {
     assert.equal(body.error, "not_a_file");
   });
 
-  it("does not follow a symlink that points outside the stage dir", async () => {
-    if (process.getuid?.() === 0) return; // root: skip permission semantics
+  it("rejects a symlink even when it points to a regular file outside the stage dir", async () => {
+    // Defense-in-depth: even though the operator owns hlsRoot, we
+    // refuse to follow symlinks. lstat detects the link before stat
+    // would silently follow it.
     const outside = path.join(work, "secret.txt");
     await writeFile(outside, "ssssh");
     const symlinkPath = path.join(hlsRoot, "opening", "seg-00007.ts");
@@ -195,18 +197,29 @@ describe("createHlsHandler — validation + safety", () => {
       return; // some FS don't support symlinks (rare); skip silently
     }
     const res = await app.request("/hls/opening/seg-00007.ts");
-    // The catalog + filename pass; the stat shows it's a regular
-    // file (because Node follows symlinks by default). We DO end up
-    // serving the contents — this test documents that the current
-    // safety model relies on the operator NOT planting symlinks
-    // inside hlsRoot. If we ever need to harden against this, switch
-    // stat → lstat and reject symlinks. For now this is captured as
-    // a known limitation, NOT an exploit (the operator owns hlsRoot).
-    assert.equal(
-      res.status,
-      200,
-      "current model trusts hlsRoot — operator-owned tmpfs",
-    );
+    assert.equal(res.status, 400);
+    const body = (await res.json()) as { error: string };
+    assert.equal(body.error, "symlink_rejected");
+  });
+
+  it("rejects a symlink even when it points to a regular file INSIDE the stage dir", async () => {
+    // The lstat check is unconditional — any symlink is refused, not
+    // just outside-pointing ones. Keeps the policy unambiguous.
+    const realFile = path.join(hlsRoot, "opening", "seg-00009.ts");
+    await writeFile(realFile, Buffer.alloc(2048));
+    const symlinkPath = path.join(hlsRoot, "opening", "seg-00010.ts");
+    try {
+      await symlink(realFile, symlinkPath);
+    } catch {
+      return;
+    }
+    const res = await app.request("/hls/opening/seg-00010.ts");
+    assert.equal(res.status, 400);
+    const body = (await res.json()) as { error: string };
+    assert.equal(body.error, "symlink_rejected");
+    // The original (non-symlinked) file STILL serves fine.
+    const real = await app.request("/hls/opening/seg-00009.ts");
+    assert.equal(real.status, 200);
   });
 
   it("returns 404 for /hls (no stage path)", async () => {

--- a/apps/engine/src/hls.test.ts
+++ b/apps/engine/src/hls.test.ts
@@ -70,11 +70,20 @@ describe("createHlsHandler — happy path", () => {
     assert.match(body, /#EXTM3U/);
   });
 
-  it("serves a segment with mp2t content-type and immutable cache", async () => {
+  it("serves a segment with mp2t content-type and a SHORT max-age (NOT immutable)", async () => {
+    // Regression: segments WERE marked immutable, which caused stale
+    // audio after engine restarts (cleanStageDir + ffmpeg restarts
+    // numbering at 00000, so the same URL maps to different bytes).
     const res = await app.request("/hls/opening/seg-00000.ts");
     assert.equal(res.status, 200);
     assert.equal(res.headers.get("content-type"), "video/mp2t");
-    assert.match(res.headers.get("cache-control") ?? "", /immutable/);
+    const cc = res.headers.get("cache-control") ?? "";
+    assert.match(cc, /max-age=\d+/);
+    assert.doesNotMatch(
+      cc,
+      /immutable/,
+      "segments must not be immutable — URLs re-bind after restart",
+    );
     assert.equal(res.headers.get("content-length"), "2048");
     const buf = new Uint8Array(await res.arrayBuffer());
     assert.equal(buf.length, 2048);

--- a/apps/engine/src/hls.test.ts
+++ b/apps/engine/src/hls.test.ts
@@ -202,6 +202,33 @@ describe("createHlsHandler — validation + safety", () => {
     assert.equal(body.error, "symlink_rejected");
   });
 
+  it("rejects requests when the stage DIRECTORY itself is a symlink (containment escape)", async () => {
+    // Codex round-5 [P2]: realpath(fullPath) and realpath(stageDir)
+    // both resolve through a symlinked stage dir, so a relative
+    // check between them passes — but the served file is OUTSIDE
+    // the configured hlsRoot. Fix: lstat stageDir AND verify
+    // realpath(fullPath) is inside the configured hlsRoot.
+    const evilDir = path.join(work, "outside");
+    await mkdir(evilDir, { recursive: true });
+    await writeFile(path.join(evilDir, "seg-00000.ts"), Buffer.alloc(2048));
+    // Replace opening's stage dir with a symlink to the evil dir.
+    await rm(path.join(hlsRoot, "opening"), { recursive: true });
+    try {
+      await symlink(evilDir, path.join(hlsRoot, "opening"));
+    } catch {
+      return; // FS doesn't support symlinks; skip
+    }
+    const res = await app.request("/hls/opening/seg-00000.ts");
+    assert.equal(res.status, 400);
+    const body = (await res.json()) as { error: string };
+    // Either symlink_rejected (lstat path) or path_traversal
+    // (realpath containment path). Both are valid rejections.
+    assert.ok(
+      body.error === "symlink_rejected" || body.error === "path_traversal",
+      `expected rejection; got ${body.error}`,
+    );
+  });
+
   it("rejects a symlink even when it points to a regular file INSIDE the stage dir", async () => {
     // The lstat check is unconditional — any symlink is refused, not
     // just outside-pointing ones. Keeps the policy unambiguous.

--- a/apps/engine/src/hls.test.ts
+++ b/apps/engine/src/hls.test.ts
@@ -1,0 +1,220 @@
+import { describe, it, beforeEach, afterEach } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtemp, mkdir, writeFile, rm, symlink } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { Hono } from "hono";
+
+import { createHlsHandler } from "./hls.ts";
+import type { Stage } from "@pavoia/shared";
+
+function fakeStage(
+  id: string,
+  disabled = false,
+  plexPlaylistId: number | null = 100,
+): Stage {
+  return {
+    id: id as Stage["id"],
+    order: 0,
+    plexPlaylistId,
+    icon: "🎵",
+    fallbackTitle: id,
+    fallbackDescription: "",
+    gradient: { from: "#000", via: "#000", to: "#000" },
+    accent: "#fff",
+    disabled,
+  };
+}
+
+describe("createHlsHandler — happy path", () => {
+  let work: string;
+  let hlsRoot: string;
+  let app: Hono;
+
+  beforeEach(async () => {
+    work = await mkdtemp(path.join(tmpdir(), "pavoia-hls-handler-"));
+    hlsRoot = path.join(work, "hls");
+    await mkdir(path.join(hlsRoot, "opening"), { recursive: true });
+    await writeFile(
+      path.join(hlsRoot, "opening", "index.m3u8"),
+      "#EXTM3U\n#EXT-X-VERSION:3\n#EXTINF:3.000,\nseg-00000.ts\n",
+    );
+    await writeFile(
+      path.join(hlsRoot, "opening", "seg-00000.ts"),
+      Buffer.alloc(2048, 0xab),
+    );
+    const root = new Hono();
+    root.route(
+      "/hls",
+      createHlsHandler({
+        hlsRoot,
+        catalog: [fakeStage("opening"), fakeStage("bus", true, null)],
+      }),
+    );
+    app = root;
+  });
+  afterEach(async () => {
+    await rm(work, { recursive: true, force: true });
+  });
+
+  it("serves the m3u8 with HLS content-type and no-cache", async () => {
+    const res = await app.request("/hls/opening/index.m3u8");
+    assert.equal(res.status, 200);
+    assert.equal(
+      res.headers.get("content-type"),
+      "application/vnd.apple.mpegurl",
+    );
+    assert.match(res.headers.get("cache-control") ?? "", /no-cache/);
+    assert.equal(res.headers.get("access-control-allow-origin"), "*");
+    const body = await res.text();
+    assert.match(body, /#EXTM3U/);
+  });
+
+  it("serves a segment with mp2t content-type and immutable cache", async () => {
+    const res = await app.request("/hls/opening/seg-00000.ts");
+    assert.equal(res.status, 200);
+    assert.equal(res.headers.get("content-type"), "video/mp2t");
+    assert.match(res.headers.get("cache-control") ?? "", /immutable/);
+    assert.equal(res.headers.get("content-length"), "2048");
+    const buf = new Uint8Array(await res.arrayBuffer());
+    assert.equal(buf.length, 2048);
+    assert.equal(buf[0], 0xab);
+  });
+});
+
+describe("createHlsHandler — validation + safety", () => {
+  let work: string;
+  let hlsRoot: string;
+  let app: Hono;
+
+  beforeEach(async () => {
+    work = await mkdtemp(path.join(tmpdir(), "pavoia-hls-handler-"));
+    hlsRoot = path.join(work, "hls");
+    await mkdir(path.join(hlsRoot, "opening"), { recursive: true });
+    await writeFile(
+      path.join(hlsRoot, "opening", "index.m3u8"),
+      "#EXTM3U\n",
+    );
+    const root = new Hono();
+    root.route(
+      "/hls",
+      createHlsHandler({
+        hlsRoot,
+        catalog: [fakeStage("opening"), fakeStage("bus", true, null)],
+      }),
+    );
+    app = root;
+  });
+  afterEach(async () => {
+    await rm(work, { recursive: true, force: true });
+  });
+
+  it("returns 404 stage_not_found for a stage not in the catalog", async () => {
+    const res = await app.request("/hls/no-such-stage/index.m3u8");
+    assert.equal(res.status, 404);
+    const body = (await res.json()) as { error: string; stageId: string };
+    assert.equal(body.error, "stage_not_found");
+    assert.equal(body.stageId, "no-such-stage");
+  });
+
+  it("returns 410 stage_has_no_audio for the disabled bus stage", async () => {
+    const res = await app.request("/hls/bus/index.m3u8");
+    assert.equal(res.status, 410);
+    const body = (await res.json()) as { error: string };
+    assert.equal(body.error, "stage_has_no_audio");
+  });
+
+  it("returns 404 bad_filename for unexpected file names", async () => {
+    for (const f of [
+      "index.html",
+      "seg-abc.ts",
+      "seg-.ts",
+      "config.json",
+      ".env",
+      "seg-00000.ts.bak",
+    ]) {
+      const res = await app.request(`/hls/opening/${f}`);
+      assert.equal(res.status, 404, `${f} must be rejected`);
+      const body = (await res.json()) as { error: string };
+      assert.equal(body.error, "bad_filename", `${f} reason mismatch`);
+    }
+  });
+
+  it("rejects path-traversal attempts in the URL", async () => {
+    // Hono normalizes URL segments before they hit the route param,
+    // so the engine sees no `..` ever — but the redundant guard
+    // still rejects anything weird on the resolved-path side.
+    for (const url of [
+      "/hls/opening/%2E%2E%2Fother",
+      "/hls/opening/.bashrc",
+    ]) {
+      const res = await app.request(url);
+      // bad_filename or stage_not_found — either way NEVER 200, never
+      // serves arbitrary content.
+      assert.notEqual(res.status, 200, `${url} must not be served`);
+    }
+  });
+
+  it("returns 404 file_not_found when the file is missing on disk", async () => {
+    const res = await app.request("/hls/opening/seg-99999.ts");
+    assert.equal(res.status, 404);
+    const body = (await res.json()) as { error: string };
+    assert.equal(body.error, "file_not_found");
+  });
+
+  it("returns 404 not_a_file when the path resolves to a directory", async () => {
+    // Edge case: someone created a "seg-12345.ts" DIRECTORY (e.g.
+    // by `mkdir` typo). The catalog + filename validation pass; the
+    // stat check refuses to serve a directory as a segment.
+    await mkdir(path.join(hlsRoot, "opening", "seg-12345.ts"));
+    const res = await app.request("/hls/opening/seg-12345.ts");
+    assert.equal(res.status, 404);
+    const body = (await res.json()) as { error: string };
+    assert.equal(body.error, "not_a_file");
+  });
+
+  it("does not follow a symlink that points outside the stage dir", async () => {
+    if (process.getuid?.() === 0) return; // root: skip permission semantics
+    const outside = path.join(work, "secret.txt");
+    await writeFile(outside, "ssssh");
+    const symlinkPath = path.join(hlsRoot, "opening", "seg-00007.ts");
+    try {
+      await symlink(outside, symlinkPath);
+    } catch {
+      return; // some FS don't support symlinks (rare); skip silently
+    }
+    const res = await app.request("/hls/opening/seg-00007.ts");
+    // The catalog + filename pass; the stat shows it's a regular
+    // file (because Node follows symlinks by default). We DO end up
+    // serving the contents — this test documents that the current
+    // safety model relies on the operator NOT planting symlinks
+    // inside hlsRoot. If we ever need to harden against this, switch
+    // stat → lstat and reject symlinks. For now this is captured as
+    // a known limitation, NOT an exploit (the operator owns hlsRoot).
+    assert.equal(
+      res.status,
+      200,
+      "current model trusts hlsRoot — operator-owned tmpfs",
+    );
+  });
+
+  it("returns 404 for /hls (no stage path)", async () => {
+    const res = await app.request("/hls");
+    assert.equal(res.status, 404);
+  });
+
+  it("returns 404 for /hls/opening (no filename path)", async () => {
+    const res = await app.request("/hls/opening");
+    assert.equal(res.status, 404);
+  });
+
+  it("only accepts GET (no PUT/POST/DELETE)", async () => {
+    for (const method of ["POST", "PUT", "DELETE", "PATCH"]) {
+      const res = await app.request("/hls/opening/index.m3u8", { method });
+      // Hono returns 404 for unmatched method+path combos; either way
+      // it MUST NOT be 200/204.
+      assert.notEqual(res.status, 200, `${method} should not succeed`);
+      assert.notEqual(res.status, 204, `${method} should not succeed`);
+    }
+  });
+});

--- a/apps/engine/src/hls.test.ts
+++ b/apps/engine/src/hls.test.ts
@@ -202,6 +202,38 @@ describe("createHlsHandler — validation + safety", () => {
     assert.equal(body.error, "symlink_rejected");
   });
 
+  it("works correctly when HLS_ROOT itself is reached through a symlink (Linux mount points)", async () => {
+    // Codex round-6 [P2]: comparing path.resolve(hlsRoot) (preserves
+    // symlinks) against realpath(fullPath) (resolves them) made
+    // every legit request look like a path traversal when HLS_ROOT
+    // (or any of its parents) was a symlink — common on Linux for
+    // /var/run/... /run/... /tmp -> /private/tmp on macOS, etc.
+    const realRoot = path.join(work, "real-hls-root");
+    await mkdir(path.join(realRoot, "opening"), { recursive: true });
+    await writeFile(
+      path.join(realRoot, "opening", "index.m3u8"),
+      "#EXTM3U\n#sym-rooted\n",
+    );
+    const linkedRoot = path.join(work, "linked-hls-root");
+    try {
+      await symlink(realRoot, linkedRoot);
+    } catch {
+      return; // FS doesn't support symlinks; skip
+    }
+
+    const root = new Hono();
+    root.route(
+      "/hls",
+      createHlsHandler({
+        hlsRoot: linkedRoot, // symlinked path
+        catalog: [fakeStage("opening"), fakeStage("bus", true, null)],
+      }),
+    );
+    const res = await root.request("/hls/opening/index.m3u8");
+    assert.equal(res.status, 200, "valid request through symlinked root");
+    assert.match(await res.text(), /sym-rooted/);
+  });
+
   it("rejects requests when the stage DIRECTORY itself is a symlink (containment escape)", async () => {
     // Codex round-5 [P2]: realpath(fullPath) and realpath(stageDir)
     // both resolve through a symlinked stage dir, so a relative

--- a/apps/engine/src/hls.ts
+++ b/apps/engine/src/hls.ts
@@ -1,0 +1,145 @@
+// HTTP handler for the /hls/<stageId>/<file> static surface.
+//
+// Serves the per-stage HLS output the supervisor writes into
+// /dev/shm/1008/radio-hls/<stageId>/. The path-traversal guard is
+// the security-critical part: the request never directly indexes
+// into the filesystem; we validate stageId against the static catalog
+// and the filename against an exact regex BEFORE composing the path.
+//
+// Headers chosen to match what hls.js expects in a browser:
+//   - .m3u8 → application/vnd.apple.mpegurl, Cache-Control: no-cache
+//             (live profile, the playlist is rewritten every 3 s).
+//   - .ts   → video/mp2t, Cache-Control: public, max-age=60
+//             (segments are immutable; once written they don't change).
+// CORS is wide-open (*) — this is a public radio served to whichever
+// origin the web UI is hosted on, no credentials, no cookies.
+
+import { stat, readFile } from "node:fs/promises";
+import path from "node:path";
+import { Hono, type Context, type Handler } from "hono";
+
+import { STAGES, type Stage } from "@pavoia/shared";
+
+const SEGMENT_PATTERN = /^seg-\d+\.ts$/;
+const PLAYLIST_NAME = "index.m3u8";
+
+export interface CreateHlsHandlerInput {
+  /** Absolute root dir under which each stage owns a subdir. */
+  hlsRoot: string;
+  /**
+   * Override the catalog. Defaults to @pavoia/shared STAGES. Tests
+   * can pass a smaller list — handler's behavior is identical, just
+   * with fewer valid ids.
+   */
+  catalog?: readonly Stage[];
+}
+
+/**
+ * Returns a Hono app that mounts the /hls/* surface under whatever
+ * path the parent app uses to .route() it.
+ */
+export function createHlsHandler(input: CreateHlsHandlerInput): Hono {
+  const { hlsRoot, catalog = STAGES } = input;
+  const hlsRootResolved = path.resolve(hlsRoot);
+  // O(1) lookup for the stage validation hot path.
+  const audioStageIds = new Set(
+    catalog.filter((s) => !s.disabled).map((s) => s.id),
+  );
+  const disabledStageIds = new Set(
+    catalog.filter((s) => s.disabled).map((s) => s.id),
+  );
+
+  const app = new Hono();
+
+  // /hls/<stageId>/<filename> — index.m3u8 or seg-<digits>.ts only.
+  app.get("/:stageId/:filename", (c) =>
+    serveStageFile(c, {
+      hlsRootResolved,
+      audioStageIds,
+      disabledStageIds,
+    }),
+  );
+
+  // Anything else under /hls/* (eg /hls or /hls/<stage>/) is 404.
+  app.all("/*", (c) => c.json({ error: "not_found" }, 404));
+
+  return app;
+}
+
+interface ServeContext {
+  hlsRootResolved: string;
+  audioStageIds: ReadonlySet<string>;
+  disabledStageIds: ReadonlySet<string>;
+}
+
+async function serveStageFile(
+  c: Context,
+  ctx: ServeContext,
+): Promise<Response> {
+  const stageId = c.req.param("stageId") ?? "";
+  const filename = c.req.param("filename") ?? "";
+
+  // 1. Validate stage id against the catalog. Returning a structured
+  //    error makes curl-debugging this surface tractable.
+  if (ctx.disabledStageIds.has(stageId)) {
+    return c.json({ error: "stage_has_no_audio", stageId }, 410);
+  }
+  if (!ctx.audioStageIds.has(stageId)) {
+    return c.json({ error: "stage_not_found", stageId }, 404);
+  }
+
+  // 2. Validate filename. Only the playlist or numeric segments — no
+  //    dotfiles, no traversal sequences, no unexpected extensions.
+  //    The regex anchor is what makes the safety claim tight.
+  const isPlaylist = filename === PLAYLIST_NAME;
+  const isSegment = SEGMENT_PATTERN.test(filename);
+  if (!isPlaylist && !isSegment) {
+    return c.json({ error: "bad_filename" }, 404);
+  }
+
+  // 3. Compose + verify the resolved path is INSIDE hlsRoot/stageId/.
+  //    With (1) and (2) already validated this is belt-and-suspenders,
+  //    but cheap, and protects against future relaxations of the
+  //    catalog or filename rules.
+  const stageDir = path.join(ctx.hlsRootResolved, stageId);
+  const fullPath = path.join(stageDir, filename);
+  const rel = path.relative(stageDir, fullPath);
+  if (rel === "" || rel.startsWith("..") || path.isAbsolute(rel)) {
+    return c.json({ error: "path_traversal" }, 400);
+  }
+
+  // 4. Read the file. Sub-100 KB segments + tiny m3u8 — full-buffer
+  //    reads are simpler than streaming and don't measurably hurt
+  //    throughput for HLS.
+  let bytes: Buffer;
+  let size: number;
+  try {
+    const s = await stat(fullPath);
+    if (!s.isFile()) {
+      return c.json({ error: "not_a_file" }, 404);
+    }
+    size = s.size;
+    bytes = await readFile(fullPath);
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === "ENOENT") {
+      return c.json({ error: "file_not_found" }, 404);
+    }
+    throw err;
+  }
+
+  // 5. Headers. Tuned for hls.js + native Safari/iOS:
+  //    - .m3u8 must not cache (live playlist rewritten every 3 s)
+  //    - .ts segments are immutable for their HLS-window lifetime
+  //    - CORS open, no credentials — public radio
+  const headers: Record<string, string> = {
+    "content-type": isPlaylist
+      ? "application/vnd.apple.mpegurl"
+      : "video/mp2t",
+    "content-length": String(size),
+    "cache-control": isPlaylist
+      ? "no-cache, no-store, must-revalidate"
+      : "public, max-age=60, immutable",
+    "access-control-allow-origin": "*",
+  };
+  return new Response(new Uint8Array(bytes), { status: 200, headers });
+}

--- a/apps/engine/src/hls.ts
+++ b/apps/engine/src/hls.ts
@@ -159,31 +159,40 @@ async function serveStageFile(
     return c.json({ error: "path_traversal" }, 400);
   }
 
-  // 4. Symlink rejection + read. The path-text checks at (3) are
-  //    necessary but not sufficient — `stat()` and `readFile()`
-  //    follow symlinks, so a symlinked seg-*.ts inside the stage
-  //    dir could resolve outside the root. Defense in depth even
-  //    though the operator owns hlsRoot:
-  //      a. lstat the requested path; reject any symlink outright.
-  //      b. realpath both stageDir and fullPath, then re-verify
-  //         the resolved fullPath is still inside the resolved
-  //         stageDir (catches indirect symlinks within stageDir
-  //         that lstat alone wouldn't see).
+  // 4. Symlink rejection + containment + read. The path-text checks
+  //    at (3) are necessary but not sufficient — `stat()` and
+  //    `readFile()` follow symlinks, so multiple kinds of symlink
+  //    can escape the stage dir:
+  //      - a symlinked seg-*.ts inside the stage dir
+  //      - the stageDir ITSELF being a symlink to /tmp/evil
+  //    Both must be rejected. Layered defense:
+  //      a. lstat stageDir + the requested file; reject either if
+  //         it's a symbolic link. Catches the obvious cases up
+  //         front before we touch realpath.
+  //      b. realpath the requested file, then verify it's still
+  //         under ctx.hlsRootResolved (the operator-configured root,
+  //         resolved at handler creation). Catches indirect
+  //         symlinks at any intermediate path component, no matter
+  //         how creative.
   //    Then read. Sub-100 KB segments + tiny m3u8 — full-buffer
   //    reads are simpler than streaming and don't measurably hurt
   //    throughput for HLS.
   let bytes: Buffer;
   try {
-    const linkInfo = await lstat(fullPath);
-    if (linkInfo.isSymbolicLink()) {
+    const [stageDirInfo, fileInfo] = await Promise.all([
+      lstat(stageDir),
+      lstat(fullPath),
+    ]);
+    if (stageDirInfo.isSymbolicLink() || fileInfo.isSymbolicLink()) {
       return c.json({ error: "symlink_rejected" }, 400);
     }
-    const [stageDirReal, fullPathReal] = await Promise.all([
-      realpath(stageDir),
-      realpath(fullPath),
-    ]);
-    const relReal = path.relative(stageDirReal, fullPathReal);
-    if (relReal === "" || relReal.startsWith("..") || path.isAbsolute(relReal)) {
+    const fullPathReal = await realpath(fullPath);
+    const relToRoot = path.relative(ctx.hlsRootResolved, fullPathReal);
+    if (
+      relToRoot === "" ||
+      relToRoot.startsWith("..") ||
+      path.isAbsolute(relToRoot)
+    ) {
       return c.json({ error: "path_traversal" }, 400);
     }
     const s = await stat(fullPathReal);

--- a/apps/engine/src/hls.ts
+++ b/apps/engine/src/hls.ts
@@ -56,6 +56,25 @@ export interface CreateHlsHandlerInput {
 export function createHlsHandler(input: CreateHlsHandlerInput): Hono {
   const { hlsRoot, catalog = STAGES, registry } = input;
   const hlsRootResolved = path.resolve(hlsRoot);
+  // Memoized realpath of hlsRoot — required for the containment
+  // comparison in serveStageFile because realpath(fullPath) resolves
+  // through any symlinks. If we compared against path.resolve()
+  // alone, a symlinked HLS_ROOT (or any of its parents — common on
+  // Linux mount points like /var/run/...) would make every legit
+  // request look like a path traversal. Computed lazily on first
+  // request so the handler factory can stay sync, retried on
+  // failure (the supervisor may not have mkdir'd the parent yet).
+  let hlsRootRealCached: Promise<string> | null = null;
+  const getHlsRootReal = (): Promise<string> => {
+    if (hlsRootRealCached) return hlsRootRealCached;
+    hlsRootRealCached = realpath(hlsRootResolved).catch((err) => {
+      // Allow retry on the next request (e.g. ENOENT during a brief
+      // window where the operator is rotating the mount).
+      hlsRootRealCached = null;
+      throw err;
+    });
+    return hlsRootRealCached;
+  };
   // O(1) lookup for the stage validation hot path.
   const audioStageIds = new Set(
     catalog.filter((s) => !s.disabled).map((s) => s.id),
@@ -81,6 +100,7 @@ export function createHlsHandler(input: CreateHlsHandlerInput): Hono {
   app.get("/:stageId/:filename", (c) => {
     const ctx: ServeContext = {
       hlsRootResolved,
+      getHlsRootReal,
       audioStageIds,
       disabledStageIds,
       ...(registry !== undefined ? { registry } : {}),
@@ -96,6 +116,8 @@ export function createHlsHandler(input: CreateHlsHandlerInput): Hono {
 
 interface ServeContext {
   hlsRootResolved: string;
+  /** Memoized realpath of hlsRootResolved — see createHlsHandler. */
+  getHlsRootReal: () => Promise<string>;
   audioStageIds: ReadonlySet<string>;
   disabledStageIds: ReadonlySet<string>;
   registry?: StageRegistry;
@@ -186,8 +208,15 @@ async function serveStageFile(
     if (stageDirInfo.isSymbolicLink() || fileInfo.isSymbolicLink()) {
       return c.json({ error: "symlink_rejected" }, 400);
     }
-    const fullPathReal = await realpath(fullPath);
-    const relToRoot = path.relative(ctx.hlsRootResolved, fullPathReal);
+    const [fullPathReal, hlsRootReal] = await Promise.all([
+      realpath(fullPath),
+      ctx.getHlsRootReal(),
+    ]);
+    // Compare BOTH sides through realpath — using path.resolve() on
+    // hlsRootResolved would preserve symlinks, so a symlinked
+    // HLS_ROOT (e.g. /var/run/... on Linux) would make every
+    // legitimate request look like a path traversal.
+    const relToRoot = path.relative(hlsRootReal, fullPathReal);
     if (
       relToRoot === "" ||
       relToRoot.startsWith("..") ||

--- a/apps/engine/src/hls.ts
+++ b/apps/engine/src/hls.ts
@@ -51,6 +51,17 @@ export function createHlsHandler(input: CreateHlsHandlerInput): Hono {
 
   const app = new Hono();
 
+  // CORS on every response, including errors. hls.js + native iOS
+  // surface non-CORS-friendly 4xx as opaque "load error" instead of
+  // the actual status, which breaks normal HLS retry logic. The
+  // success path also re-asserts these headers but it's cheap.
+  app.use("/*", async (c, next) => {
+    await next();
+    if (!c.res.headers.has("access-control-allow-origin")) {
+      c.res.headers.set("access-control-allow-origin", "*");
+    }
+  });
+
   // /hls/<stageId>/<filename> — index.m3u8 or seg-<digits>.ts only.
   app.get("/:stageId/:filename", (c) =>
     serveStageFile(c, {
@@ -112,13 +123,11 @@ async function serveStageFile(
   //    reads are simpler than streaming and don't measurably hurt
   //    throughput for HLS.
   let bytes: Buffer;
-  let size: number;
   try {
     const s = await stat(fullPath);
     if (!s.isFile()) {
       return c.json({ error: "not_a_file" }, 404);
     }
-    size = s.size;
     bytes = await readFile(fullPath);
   } catch (err) {
     if ((err as NodeJS.ErrnoException).code === "ENOENT") {
@@ -128,14 +137,18 @@ async function serveStageFile(
   }
 
   // 5. Headers. Tuned for hls.js + native Safari/iOS:
-  //    - .m3u8 must not cache (live playlist rewritten every 3 s)
-  //    - .ts segments are immutable for their HLS-window lifetime
-  //    - CORS open, no credentials — public radio
+  //    - .m3u8 must not cache (live playlist rewritten every 3 s).
+  //    - .ts segments are immutable for their HLS-window lifetime.
+  //    - CORS open, no credentials — public radio.
+  //    - content-length comes from the BUFFER WE'RE SENDING, not the
+  //      stat result, so a m3u8 rewrite between stat() and readFile()
+  //      can't make us advertise a stale size that some HLS clients
+  //      treat as a truncated playlist reload.
   const headers: Record<string, string> = {
     "content-type": isPlaylist
       ? "application/vnd.apple.mpegurl"
       : "video/mp2t",
-    "content-length": String(size),
+    "content-length": String(bytes.length),
     "cache-control": isPlaylist
       ? "no-cache, no-store, must-revalidate"
       : "public, max-age=60, immutable",

--- a/apps/engine/src/hls.ts
+++ b/apps/engine/src/hls.ts
@@ -20,6 +20,8 @@ import { Hono, type Context, type Handler } from "hono";
 
 import { STAGES, type Stage } from "@pavoia/shared";
 
+import type { StageRegistry } from "./stages/registry.ts";
+
 const SEGMENT_PATTERN = /^seg-\d+\.ts$/;
 const PLAYLIST_NAME = "index.m3u8";
 
@@ -32,6 +34,19 @@ export interface CreateHlsHandlerInput {
    * with fewer valid ids.
    */
   catalog?: readonly Stage[];
+  /**
+   * Optional registry. When provided, the handler refuses to serve
+   * a stage whose controller is missing OR has reached the
+   * "stopped" terminal state — the stage's last `index.m3u8` and
+   * segment files would otherwise stick around on tmpfs and serve
+   * stale audio (cleanStageDir only runs on supervisor START, not
+   * on its termination). Returns 503 stage_not_running.
+   *
+   * When omitted (e.g. unit tests of the static surface), the
+   * liveness gate is skipped and the handler trusts the catalog +
+   * filename validation.
+   */
+  registry?: StageRegistry;
 }
 
 /**
@@ -39,7 +54,7 @@ export interface CreateHlsHandlerInput {
  * path the parent app uses to .route() it.
  */
 export function createHlsHandler(input: CreateHlsHandlerInput): Hono {
-  const { hlsRoot, catalog = STAGES } = input;
+  const { hlsRoot, catalog = STAGES, registry } = input;
   const hlsRootResolved = path.resolve(hlsRoot);
   // O(1) lookup for the stage validation hot path.
   const audioStageIds = new Set(
@@ -63,13 +78,15 @@ export function createHlsHandler(input: CreateHlsHandlerInput): Hono {
   });
 
   // /hls/<stageId>/<filename> — index.m3u8 or seg-<digits>.ts only.
-  app.get("/:stageId/:filename", (c) =>
-    serveStageFile(c, {
+  app.get("/:stageId/:filename", (c) => {
+    const ctx: ServeContext = {
       hlsRootResolved,
       audioStageIds,
       disabledStageIds,
-    }),
-  );
+      ...(registry !== undefined ? { registry } : {}),
+    };
+    return serveStageFile(c, ctx);
+  });
 
   // Anything else under /hls/* (eg /hls or /hls/<stage>/) is 404.
   app.all("/*", (c) => c.json({ error: "not_found" }, 404));
@@ -81,6 +98,7 @@ interface ServeContext {
   hlsRootResolved: string;
   audioStageIds: ReadonlySet<string>;
   disabledStageIds: ReadonlySet<string>;
+  registry?: StageRegistry;
 }
 
 async function serveStageFile(
@@ -106,6 +124,20 @@ async function serveStageFile(
   const isSegment = SEGMENT_PATTERN.test(filename);
   if (!isPlaylist && !isSegment) {
     return c.json({ error: "bad_filename" }, 404);
+  }
+
+  // 2a. Liveness gate. cleanStageDir only runs at supervisor START,
+  //     so if a supervisor terminated (fast-death cap, fallback
+  //     failure, etc.) the last m3u8 + segments would still be on
+  //     disk and we'd happily serve them — stale audio while
+  //     /api/stages/:id/now correctly reports the stage as stopped.
+  //     When a registry is wired, refuse to serve a stage whose
+  //     controller is missing or in the "stopped" state.
+  if (ctx.registry !== undefined) {
+    const controller = ctx.registry.get(stageId);
+    if (controller === undefined || controller.status() === "stopped") {
+      return c.json({ error: "stage_not_running", stageId }, 503);
+    }
   }
 
   // 3. Compose + verify the resolved path is INSIDE hlsRoot/stageId/.

--- a/apps/engine/src/hls.ts
+++ b/apps/engine/src/hls.ts
@@ -14,7 +14,7 @@
 // CORS is wide-open (*) — this is a public radio served to whichever
 // origin the web UI is hosted on, no credentials, no cookies.
 
-import { stat, readFile } from "node:fs/promises";
+import { stat, lstat, readFile, realpath } from "node:fs/promises";
 import path from "node:path";
 import { Hono, type Context, type Handler } from "hono";
 
@@ -131,11 +131,19 @@ async function serveStageFile(
   //     failure, etc.) the last m3u8 + segments would still be on
   //     disk and we'd happily serve them — stale audio while
   //     /api/stages/:id/now correctly reports the stage as stopped.
-  //     When a registry is wired, refuse to serve a stage whose
-  //     controller is missing or in the "stopped" state.
+  //     We only allow `playing` / `curating` — the states where the
+  //     supervisor is actively producing audio.
+  //
+  //     `starting` and `stopping` are deliberately rejected too:
+  //     spawnAndWatch registers a replacement controller BEFORE
+  //     startStage runs cleanStageDir, so requests in that window
+  //     could read the previous run's stale files. Returning 503
+  //     during the transition gives clients a retriable signal
+  //     instead of stale audio.
   if (ctx.registry !== undefined) {
     const controller = ctx.registry.get(stageId);
-    if (controller === undefined || controller.status() === "stopped") {
+    const status = controller?.status();
+    if (status !== "playing" && status !== "curating") {
       return c.json({ error: "stage_not_running", stageId }, 503);
     }
   }
@@ -151,16 +159,38 @@ async function serveStageFile(
     return c.json({ error: "path_traversal" }, 400);
   }
 
-  // 4. Read the file. Sub-100 KB segments + tiny m3u8 — full-buffer
+  // 4. Symlink rejection + read. The path-text checks at (3) are
+  //    necessary but not sufficient — `stat()` and `readFile()`
+  //    follow symlinks, so a symlinked seg-*.ts inside the stage
+  //    dir could resolve outside the root. Defense in depth even
+  //    though the operator owns hlsRoot:
+  //      a. lstat the requested path; reject any symlink outright.
+  //      b. realpath both stageDir and fullPath, then re-verify
+  //         the resolved fullPath is still inside the resolved
+  //         stageDir (catches indirect symlinks within stageDir
+  //         that lstat alone wouldn't see).
+  //    Then read. Sub-100 KB segments + tiny m3u8 — full-buffer
   //    reads are simpler than streaming and don't measurably hurt
   //    throughput for HLS.
   let bytes: Buffer;
   try {
-    const s = await stat(fullPath);
+    const linkInfo = await lstat(fullPath);
+    if (linkInfo.isSymbolicLink()) {
+      return c.json({ error: "symlink_rejected" }, 400);
+    }
+    const [stageDirReal, fullPathReal] = await Promise.all([
+      realpath(stageDir),
+      realpath(fullPath),
+    ]);
+    const relReal = path.relative(stageDirReal, fullPathReal);
+    if (relReal === "" || relReal.startsWith("..") || path.isAbsolute(relReal)) {
+      return c.json({ error: "path_traversal" }, 400);
+    }
+    const s = await stat(fullPathReal);
     if (!s.isFile()) {
       return c.json({ error: "not_a_file" }, 404);
     }
-    bytes = await readFile(fullPath);
+    bytes = await readFile(fullPathReal);
   } catch (err) {
     if ((err as NodeJS.ErrnoException).code === "ENOENT") {
       return c.json({ error: "file_not_found" }, 404);

--- a/apps/engine/src/hls.ts
+++ b/apps/engine/src/hls.ts
@@ -138,7 +138,17 @@ async function serveStageFile(
 
   // 5. Headers. Tuned for hls.js + native Safari/iOS:
   //    - .m3u8 must not cache (live playlist rewritten every 3 s).
-  //    - .ts segments are immutable for their HLS-window lifetime.
+  //    - .ts segments use a short max-age but are NOT marked
+  //      immutable. Reason: each supervisor start runs cleanStageDir
+  //      and ffmpeg's seg-%05d.ts numbering restarts at 00000, so
+  //      `/hls/<stage>/seg-00000.ts` refers to different bytes after
+  //      a deploy / watchdog restart. With `immutable`, browsers
+  //      and shared caches would replay stale audio for the full
+  //      max-age window after a restart. max-age=10 is enough for a
+  //      single listener to fetch each segment exactly once during
+  //      its rolling-window lifetime (~18 s on the server) without
+  //      a re-request, and short enough to bound the stale-audio
+  //      window after restart.
   //    - CORS open, no credentials — public radio.
   //    - content-length comes from the BUFFER WE'RE SENDING, not the
   //      stat result, so a m3u8 rewrite between stat() and readFile()
@@ -151,7 +161,7 @@ async function serveStageFile(
     "content-length": String(bytes.length),
     "cache-control": isPlaylist
       ? "no-cache, no-store, must-revalidate"
-      : "public, max-age=60, immutable",
+      : "public, max-age=10",
     "access-control-allow-origin": "*",
   };
   return new Response(new Uint8Array(bytes), { status: 200, headers });

--- a/apps/engine/src/index.ts
+++ b/apps/engine/src/index.ts
@@ -63,7 +63,14 @@ const server = serve(
 
 server.on("error", (err) => {
   console.error(`[engine] server error:`, err);
-  process.exit(1);
+  // EADDRINUSE / EPERM after a full bootstrap leaves supervisors +
+  // poller already running. Tear them down gracefully before exit
+  // so we don't leak ffmpeg processes through OS pipe teardown.
+  // Bounded by a hard timer so a hung shutdown can't trap the
+  // process — the watchdog will see the dead pid and respawn anyway.
+  const force = setTimeout(() => process.exit(1), SHUTDOWN_TIMEOUT_MS);
+  force.unref();
+  shutdownEngine().catch(() => {}).finally(() => process.exit(1));
 });
 
 let shuttingDown = false;


### PR DESCRIPTION
Final read-side slice of Task 5 plus closes both items in #12.

## Three concurrent slices

### 1. \`/hls/*\` static file handler

Mounts under createApp's \`/hls\` route when \`hlsRoot\` is provided; returns 503 \`hls_unavailable\` otherwise (HTTP-only canary mode).

**Path-traversal guard:** validates \`stageId\` against the static catalog and \`filename\` against an exact regex (\`index.m3u8\` or \`seg-\\d+\\.ts\`) BEFORE composing the on-disk path. A redundant resolved-path-stays-inside-stageDir check catches future regressions.

**HLS-tuned headers:**
| File | Content-Type | Cache-Control |
|---|---|---|
| \`index.m3u8\` | \`application/vnd.apple.mpegurl\` | \`no-cache, no-store, must-revalidate\` |
| \`seg-NNNNN.ts\` | \`video/mp2t\` | \`public, max-age=60, immutable\` |

\`Access-Control-Allow-Origin: *\` everywhere — public radio.

**Status codes:** \`200\` / \`400\` path_traversal / \`404\` (stage_not_found, bad_filename, file_not_found, not_a_file) / \`410\` stage_has_no_audio / \`503\` hls_unavailable.

### 2. Bind-failure cleanup (closes #12 item 1)

\`server.on(\"error\")\` now calls \`shutdownEngine()\` before \`process.exit(1)\`, bounded by a hard timer. Without this, EADDRINUSE after a full bootstrap leaks supervisors + poller through OS pipe teardown.

### 3. Dead-controller liveness revival (closes #12 item 2)

Bootstrap watches each controller's \`done\` promise. If a run loop terminates unexpectedly while the engine is up AND the registered controller is still that one, spawn a replacement with the most-recently-known tracks. \`knownTracks\` is updated on every poller-driven \`onTracksChanged\` so revival picks up the freshest playlist, not the initial-fetch snapshot.

## Test coverage

**+15 net tests, 222/222 pass.**

- \`hls.test.ts\` (12): happy path, every validation branch, traversal attempts, file-missing, directory-as-segment, symlink-follows documented limitation, no-stage / no-filename, only-GET.
- \`app.test.ts\` (2): \`/hls/*\` returns 503 without hlsRoot, mounts when provided.
- \`bootstrap.test.ts\` (3): revival on unexpected termination, no revival during shutdown, revival uses LATEST poller-known tracks.
- \`bootstrap.test.ts\` (-1): obsolete \"no controller registered\" branch is now effectively unreachable post-revival.

## Test plan

- [x] \`npm run typecheck\` clean
- [x] \`npm test\` — 222/222 pass
- [x] Pre-push CR — \"No findings ✔\"
- [ ] Codex review
- [ ] CI + CodeRabbit GitHub App
- [ ] Triple-signoff under v2 (severity gate, 3-round cap)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Per-stage HLS serving for playlists and segments with strict filename/stage validation, traversal containment checks, tuned cache headers, permissive CORS, and a 503 JSON sentinel when HLS is unavailable.

* **Bug Fixes**
  * Graceful shutdown on server errors with timeout fallback.
  * Supervisor liveness: automatic, rate-limited revival of failed controllers; no revival during shutdown.

* **Documentation**
  * Expanded HLS contract, error/status taxonomy, and documented symlink behavior.

* **Tests**
  * End-to-end HLS and liveness tests covering success and failure modes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->