### PR TITLE
feat(deploy): start-engine.sh — Whatbox launcher (Task 6 slice 1)

### DIFF
--- a/apps/engine/README.md
+++ b/apps/engine/README.md
@@ -137,7 +137,7 @@ Thrown exceptions inside a handler are caught by `app.onError`. Response body ne
 Two axes matter for the watchdog contract (Req J): **connection failure** (HTTP 000) triggers a restart after three consecutive ticks; **5xx** means alive-but-degraded and must *not* trigger a restart (so diagnostic state is preserved).
 
 - **Bind failure** (e.g. `EADDRINUSE`) → `server.on('error')` logs `[engine] server error: …`, `process.exit(1)`. No listener → next watchdog tick sees `HTTP 000`. Three ticks → respawn. ✔ Correct restart.
-- **`SIGTERM` / `SIGINT` / `SIGHUP`** → `server.close()` stops accepting new connections, waits up to **5 s** for in-flight requests to finish, `process.exit(0)`. After 5 s we hard-exit `1`. Idempotent: a second signal while already shutting down is ignored.
+- **`SIGTERM` / `SIGINT` / `SIGHUP`** → `server.close()` stops accepting new connections, every supervisor's `stop()` runs in parallel, then `process.exit(0)`. The whole shutdown is bounded by `SHUTDOWN_TIMEOUT_MS = 15_000` (5 s per-supervisor ffmpeg `SIGTERM → SIGKILL` plus Hono's in-flight drain). If we hit the ceiling, hard-exit `1`. Idempotent: a second signal while already shutting down is ignored.
 - **Thrown exception inside a Hono route handler** → caught by `app.onError`, returns `500 {"error":"internal_server_error"}`. Watchdog sees 2xx-or-5xx (not `000`), does **not** restart. Server stays alive so the next request can succeed and logs retain context. ✔ Matches Req J.
 - **`uncaughtException` / `unhandledRejection`** (bugs outside a route — e.g. in the stage supervisor once it lands) → log and `process.exit(1)`. These signal genuinely unknown state; continuing would be unsafe.
 

--- a/deploy/bin/start-engine.sh
+++ b/deploy/bin/start-engine.sh
@@ -32,6 +32,9 @@ umask 077
 log() { printf '[start-engine] %s\n' "$*" >&2; }
 die() { log "ERROR: $*"; exit 1; }
 is_pid() { [[ "$1" =~ ^[1-9][0-9]*$ ]]; }
+# Accept "node" (Node 22) and any newer-Node thread-named variant such as
+# "node-MainThread" (Node 25+). Anything else is not our engine.
+is_node_comm() { case "$1" in node|node-*) return 0 ;; *) return 1 ;; esac; }
 
 RADIO_HOME="${RADIO_HOME:-$HOME/webradio-v3}"
 ENV_FILE="${RADIO_ENV_FILE:-$HOME/.config/radio/env}"
@@ -74,6 +77,8 @@ esac
 [ -x "$NODE_BIN" ] || die "node binary missing or not executable: $NODE_BIN (deploy must symlink mise Node 22.22.2 here, Req I)"
 [ -f "$ENGINE_ENTRY" ] || die "engine build artifact missing: $ENGINE_ENTRY (run 'npm run build' before starting)"
 command -v curl >/dev/null 2>&1 || die "curl not found on PATH (required for /api/health probes)"
+command -v ss >/dev/null 2>&1 || die "ss not found on PATH (required for orphan-listener pre-spawn check)"
+command -v ps >/dev/null 2>&1 || die "ps not found on PATH (required for PID ownership/identity checks)"
 
 mkdir -p "$LOG_DIR" "$RUN_DIR"
 
@@ -114,14 +119,23 @@ if [ -f "$PID_FILE" ]; then
     log "stale pid file (pid $existing_pid not alive); clearing"
     rm -f "$PID_FILE"
   else
-    # Defend against post-reboot PID reuse — if some unrelated process
-    # happens to hold the recorded PID number, it's not ours and the file
-    # is stale. UID match is good enough for a $HOME-stored pidfile under
-    # the engine's threat model.
+    # Defend against post-reboot PID reuse — same-user PID collisions are
+    # rare but real on a long-lived seedbox account. Two-pronged check:
+    #   1. UID match (cheap rule-out for cross-user reuse).
+    #   2. Process binary is `node` (rules out same-user reuse by other
+    #      long-running processes — shells, other node services, etc.).
+    # Without #2, an unrelated long-running same-user process holding the
+    # recorded PID would force the wrapper through the full drain wait then
+    # exit 1 "wedged," looping every watchdog tick until manual cleanup.
+    # [Codex round-3 P2]
     pid_uid="$(ps -o uid= -p "$existing_pid" 2>/dev/null | tr -d '[:space:]' || true)"
+    pid_comm="$(ps -o comm= -p "$existing_pid" 2>/dev/null | tr -d '[:space:]' || true)"
     our_uid="$(id -u)"
     if [ -z "$pid_uid" ] || [ "$pid_uid" != "$our_uid" ]; then
       log "pid $existing_pid alive but not owned by us (uid=${pid_uid:-?} vs ${our_uid}); treating as stale"
+      rm -f "$PID_FILE"
+    elif ! is_node_comm "$pid_comm"; then
+      log "pid $existing_pid alive but not a node process (comm=${pid_comm:-?}); treating as stale"
       rm -f "$PID_FILE"
     elif probe_health; then
       log "engine pid $existing_pid responds healthy on /api/health; nothing to do"
@@ -137,25 +151,36 @@ if [ -f "$PID_FILE" ]; then
       #       spawn over it (would orphan the wedged child) and exit 1 so
       #       the operator/watchdog escalates.
       log "engine pid $existing_pid alive but unresponsive on /api/health; waiting up to ${DRAIN_WAIT_SECS}s for drain"
+      drain_start=$(date +%s)
+      drain_deadline=$((drain_start + DRAIN_WAIT_SECS))
       drained="no"
-      deadline_tenths=$((DRAIN_WAIT_SECS * 2))
-      tenths=0
-      while [ "$tenths" -lt "$deadline_tenths" ]; do
+      while [ "$(date +%s)" -lt "$drain_deadline" ]; do
         if ! kill -0 "$existing_pid" 2>/dev/null; then
           drained="yes"
           break
         fi
         sleep 0.5
-        tenths=$((tenths + 1))
       done
+      drain_elapsed=$(($(date +%s) - drain_start))
       if [ "$drained" = "yes" ]; then
-        log "previous engine pid $existing_pid drained after $((tenths / 2))s; spawning fresh"
+        log "previous engine pid $existing_pid drained after ${drain_elapsed}s; spawning fresh"
         rm -f "$PID_FILE"
       else
-        die "engine pid $existing_pid alive and unresponsive after ${DRAIN_WAIT_SECS}s — wedged; refusing to spawn over it (kill it first, then retry)"
+        die "engine pid $existing_pid alive and unresponsive after ${drain_elapsed}s — wedged; refusing to spawn over it (kill it first, then retry)"
       fi
     fi
   fi
+fi
+
+# Refuse to spawn if anything is already bound to ENGINE_PORT — orphans from
+# a prior crashed wrapper or operator-spawned engines would otherwise let our
+# new child fail EADDRINUSE while probe_health hits the orphan and returns
+# 200, falsely marking startup successful with a dead-PID pointer.
+# [Codex round-3 P2]
+# `ss -ltn` lists TCP listeners; column 4 is the local address. Match the
+# port suffix preceded by ":" to cover both 127.0.0.1:port and [::]:port.
+if ss -ltn 2>/dev/null | awk '{print $4}' | grep -qE ":${ENGINE_PORT}\$"; then
+  die "another process is already bound to port ${ENGINE_PORT} (orphan engine?); refusing to spawn — kill it first"
 fi
 
 log "spawning engine: $NODE_BIN $ENGINE_ENTRY"
@@ -170,10 +195,13 @@ disown "$engine_pid" 2>/dev/null || true
 echo "$engine_pid" >"$PID_FILE"
 log "spawned engine pid $engine_pid; verifying /api/health (up to ${HEALTH_WAIT_SECS}s)"
 
+# Wall-clock deadline (not iteration counting) — each probe_health can block
+# up to curl --max-time 2, so an iteration counter would understate elapsed
+# time by up to 5x. Wall-clock makes the budget honest. [Codex round-3 P3]
+health_start=$(date +%s)
+health_deadline=$((health_start + HEALTH_WAIT_SECS))
 healthy="no"
-deadline_tenths=$((HEALTH_WAIT_SECS * 2))
-tenths=0
-while [ "$tenths" -lt "$deadline_tenths" ]; do
+while [ "$(date +%s)" -lt "$health_deadline" ]; do
   if ! kill -0 "$engine_pid" 2>/dev/null; then
     rm -f "$PID_FILE"
     die "engine pid $engine_pid exited during startup — check $LOG_FILE"
@@ -183,16 +211,16 @@ while [ "$tenths" -lt "$deadline_tenths" ]; do
     break
   fi
   sleep 0.5
-  tenths=$((tenths + 1))
 done
+health_elapsed=$(($(date +%s) - health_start))
 
 if [ "$healthy" != "yes" ]; then
-  log "engine pid $engine_pid did not become healthy within ${HEALTH_WAIT_SECS}s; killing"
+  log "engine pid $engine_pid did not become healthy within ${health_elapsed}s; killing"
   kill -TERM "$engine_pid" 2>/dev/null || true
   sleep 1
   kill -KILL "$engine_pid" 2>/dev/null || true
   rm -f "$PID_FILE"
-  die "engine failed to come up healthy in ${HEALTH_WAIT_SECS}s — check $LOG_FILE"
+  die "engine failed to come up healthy in ${health_elapsed}s — check $LOG_FILE"
 fi
 
-log "engine healthy in $((tenths / 2))s (pid $engine_pid); logs: $LOG_FILE"
+log "engine healthy in ${health_elapsed}s (pid $engine_pid); logs: $LOG_FILE"

--- a/deploy/bin/start-engine.sh
+++ b/deploy/bin/start-engine.sh
@@ -32,9 +32,13 @@ umask 077
 log() { printf '[start-engine] %s\n' "$*" >&2; }
 die() { log "ERROR: $*"; exit 1; }
 is_pid() { [[ "$1" =~ ^[1-9][0-9]*$ ]]; }
-# Accept "node" (Node 22) and any newer-Node thread-named variant such as
-# "node-MainThread" (Node 25+). Anything else is not our engine.
-is_node_comm() { case "$1" in node|node-*) return 0 ;; *) return 1 ;; esac; }
+# Read /proc/$pid/cmdline as a space-joined string. Returns empty if the
+# pid no longer exists or proc isn't available.
+pid_cmdline() {
+  if [ -r "/proc/$1/cmdline" ]; then
+    tr '\0' ' ' <"/proc/$1/cmdline" 2>/dev/null
+  fi
+}
 
 RADIO_HOME="${RADIO_HOME:-$HOME/webradio-v3}"
 ENV_FILE="${RADIO_ENV_FILE:-$HOME/.config/radio/env}"
@@ -119,26 +123,35 @@ if [ -f "$PID_FILE" ]; then
     log "stale pid file (pid $existing_pid not alive); clearing"
     rm -f "$PID_FILE"
   else
-    # Defend against post-reboot PID reuse — same-user PID collisions are
-    # rare but real on a long-lived seedbox account. Two-pronged check:
+    # Defend against post-reboot PID reuse and same-user node confusion.
+    # Two-pronged check:
     #   1. UID match (cheap rule-out for cross-user reuse).
-    #   2. Process binary is `node` (rules out same-user reuse by other
-    #      long-running processes — shells, other node services, etc.).
-    # Without #2, an unrelated long-running same-user process holding the
-    # recorded PID would force the wrapper through the full drain wait then
-    # exit 1 "wedged," looping every watchdog tick until manual cleanup.
-    # [Codex round-3 P2]
+    #   2. /proc/$pid/cmdline includes our exact ENGINE_ENTRY path. Just
+    #      checking comm=node was ambiguous on a host running multiple
+    #      same-user node processes (e.g. apps/web alongside the engine);
+    #      the cmdline check pins the recorded PID specifically to our
+    #      engine entry point. [Codex round-4 P2-A]
+    # Without these, a stale PID held by an unrelated process would force
+    # the wrapper through the full drain wait then exit 1 "wedged," looping
+    # every watchdog tick until manual cleanup. [Codex round-3 P2]
     pid_uid="$(ps -o uid= -p "$existing_pid" 2>/dev/null | tr -d '[:space:]' || true)"
-    pid_comm="$(ps -o comm= -p "$existing_pid" 2>/dev/null | tr -d '[:space:]' || true)"
+    cmdline="$(pid_cmdline "$existing_pid")"
     our_uid="$(id -u)"
     if [ -z "$pid_uid" ] || [ "$pid_uid" != "$our_uid" ]; then
       log "pid $existing_pid alive but not owned by us (uid=${pid_uid:-?} vs ${our_uid}); treating as stale"
       rm -f "$PID_FILE"
-    elif ! is_node_comm "$pid_comm"; then
-      log "pid $existing_pid alive but not a node process (comm=${pid_comm:-?}); treating as stale"
+    elif ! [[ " $cmdline " == *" $ENGINE_ENTRY "* ]]; then
+      log "pid $existing_pid alive but cmdline does not include $ENGINE_ENTRY (probably another node service); treating as stale"
       rm -f "$PID_FILE"
-    elif probe_health; then
-      log "engine pid $existing_pid responds healthy on /api/health; nothing to do"
+    elif probe_health && { sleep 0.25; probe_health; }; then
+      # Two probes 250 ms apart confirm the engine isn't just a few
+      # milliseconds away from processing an in-flight SIGTERM. The
+      # documented deploy/watchdog flow is `kill && start-engine.sh`,
+      # and Node's signal handler can take 1–100 ms to run before
+      # server.close() actually stops accepting connections — a single
+      # probe in that window false-positives "healthy" then the engine
+      # dies behind us. [Codex round-4 P2-B]
+      log "engine pid $existing_pid responds healthy on /api/health (confirmed); nothing to do"
       exit 0
     else
       # Alive, ours, but not responding. Two situations collapse here:
@@ -177,9 +190,9 @@ fi
 # new child fail EADDRINUSE while probe_health hits the orphan and returns
 # 200, falsely marking startup successful with a dead-PID pointer.
 # [Codex round-3 P2]
-# `ss -ltn` lists TCP listeners; column 4 is the local address. Match the
-# port suffix preceded by ":" to cover both 127.0.0.1:port and [::]:port.
-if ss -ltn 2>/dev/null | awk '{print $4}' | grep -qE ":${ENGINE_PORT}\$"; then
+# `ss -ltnH "sport = :PORT"` filters by source port directly — robust against
+# ss column-ordering variations across versions; -H suppresses the header.
+if [ -n "$(ss -ltnH "sport = :${ENGINE_PORT}" 2>/dev/null)" ]; then
   die "another process is already bound to port ${ENGINE_PORT} (orphan engine?); refusing to spawn — kill it first"
 fi
 

--- a/deploy/bin/start-engine.sh
+++ b/deploy/bin/start-engine.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+# start-engine.sh — Whatbox launcher for the Pavoia v3 audio engine.
+#
+# Invoked from cron @reboot (initial start) and from watchdog.sh (respawn after
+# 3 consecutive HTTP 000 — see WEEK0_LOG.md Req J). Idempotent: a second
+# invocation while the engine is already healthy exits 0 without action.
+#
+# Layout assumed under $RADIO_HOME (default ~/webradio-v3):
+#   bin/node                  symlink to mise-managed Node 22.22.2 (Req I)
+#   apps/engine/dist/index.js compiled engine entry point (npm run build)
+#   logs/engine.log           append-only stdout+stderr (Req H)
+#   run/engine.pid            current engine PID (consumed by watchdog.sh)
+#
+# Engine env (Plex token, HLS_ROOT, etc.) lives in ~/.config/radio/env (Req G)
+# and is sourced by this wrapper, not validated — apps/engine/src/config.ts
+# does the validation and exits 1 on bad input, which the watchdog detects as
+# HTTP 000 and respawns from.
+
+set -euo pipefail
+umask 077
+
+log() { printf '[start-engine] %s\n' "$*" >&2; }
+die() { log "ERROR: $*"; exit 1; }
+
+RADIO_HOME="${RADIO_HOME:-$HOME/webradio-v3}"
+ENV_FILE="${RADIO_ENV_FILE:-$HOME/.config/radio/env}"
+
+NODE_BIN="$RADIO_HOME/bin/node"
+ENGINE_ENTRY="$RADIO_HOME/apps/engine/dist/index.js"
+LOG_DIR="$RADIO_HOME/logs"
+RUN_DIR="$RADIO_HOME/run"
+PID_FILE="$RUN_DIR/engine.pid"
+LOG_FILE="$LOG_DIR/engine.log"
+
+[ -f "$ENV_FILE" ] || die "env file not found: $ENV_FILE (see WEEK0_LOG.md Req G)"
+# Auto-export every assignment in the env file so PLEX_TOKEN, HLS_ROOT, etc.
+# reach the engine child via the inherited environment. Operator may write
+# `KEY=value` (no `export`) and it still propagates correctly.
+set -a
+# shellcheck disable=SC1090  # path resolved at runtime, not lintable here
+. "$ENV_FILE"
+set +a
+
+[ -x "$NODE_BIN" ] || die "node binary missing or not executable: $NODE_BIN (deploy must symlink mise Node 22.22.2 here, Req I)"
+[ -f "$ENGINE_ENTRY" ] || die "engine build artifact missing: $ENGINE_ENTRY (run 'npm run build' before starting)"
+
+mkdir -p "$LOG_DIR" "$RUN_DIR"
+
+if [ -f "$PID_FILE" ]; then
+  existing_pid="$(cat "$PID_FILE" 2>/dev/null || true)"
+  if [ -n "$existing_pid" ] && kill -0 "$existing_pid" 2>/dev/null; then
+    log "engine already running (pid $existing_pid); nothing to do"
+    exit 0
+  fi
+  log "stale pid file (pid '$existing_pid' not alive); clearing"
+  rm -f "$PID_FILE"
+fi
+
+log "spawning engine: $NODE_BIN $ENGINE_ENTRY"
+nohup "$NODE_BIN" "$ENGINE_ENTRY" >>"$LOG_FILE" 2>&1 &
+engine_pid=$!
+disown "$engine_pid" 2>/dev/null || true
+echo "$engine_pid" >"$PID_FILE"
+log "engine started (pid $engine_pid); logs: $LOG_FILE"

--- a/deploy/bin/start-engine.sh
+++ b/deploy/bin/start-engine.sh
@@ -10,24 +10,38 @@
 #   apps/engine/dist/index.js compiled engine entry point (npm run build)
 #   logs/engine.log           append-only stdout+stderr (Req H)
 #   run/engine.pid            current engine PID (consumed by watchdog.sh)
+#   run/engine.lock           flock target (one start-engine.sh at a time)
 #
 # Engine env (Plex token, HLS_ROOT, etc.) lives in ~/.config/radio/env (Req G)
 # and is sourced by this wrapper, not validated — apps/engine/src/config.ts
-# does the validation and exits 1 on bad input, which the watchdog detects as
-# HTTP 000 and respawns from.
+# does the validation and exits 1 on bad input, which the wrapper then catches
+# via the post-spawn /api/health probe and reports as a startup failure.
+#
+# Exit-code contract (matters for deploy scripts and operator workflows):
+#   0  — engine is running AND healthy (responds 2xx on /api/health), OR
+#        another start-engine.sh holds the lock (idempotent no-op).
+#   1  — failed to start a healthy engine (bad env, port bind failure, child
+#        crash during bootstrap, /api/health didn't become responsive in time,
+#        or an existing engine is wedged and we refuse to spawn over it).
+#
+# Cron @reboot can ignore the exit code; deploys and operators should not.
 
 set -euo pipefail
 umask 077
 
 log() { printf '[start-engine] %s\n' "$*" >&2; }
 die() { log "ERROR: $*"; exit 1; }
+is_pid() { [[ "$1" =~ ^[1-9][0-9]*$ ]]; }
 
 RADIO_HOME="${RADIO_HOME:-$HOME/webradio-v3}"
 ENV_FILE="${RADIO_ENV_FILE:-$HOME/.config/radio/env}"
-# Wait budget for an in-flight engine to drain before we declare it healthy.
-# The engine has a 15 s graceful-shutdown budget (apps/engine/README.md), so we
-# need a strictly larger window. Override via env for fast smoke tests.
+# Wait budget for an in-flight engine to drain (graceful shutdown) before we
+# treat it as wedged. Engine's SHUTDOWN_TIMEOUT_MS is 15 s
+# (apps/engine/src/index.ts), so the default 20 s gives a small buffer.
 DRAIN_WAIT_SECS="${ENGINE_DRAIN_WAIT_SECS:-20}"
+# Wait budget for a freshly-spawned engine to start responding 2xx on
+# /api/health. Real bootstrap is ~1–5 s on Whatbox; 15 s is generous.
+HEALTH_WAIT_SECS="${ENGINE_HEALTH_WAIT_SECS:-15}"
 
 NODE_BIN="$RADIO_HOME/bin/node"
 ENGINE_ENTRY="$RADIO_HOME/apps/engine/dist/index.js"
@@ -35,6 +49,7 @@ LOG_DIR="$RADIO_HOME/logs"
 RUN_DIR="$RADIO_HOME/run"
 PID_FILE="$RUN_DIR/engine.pid"
 LOG_FILE="$LOG_DIR/engine.log"
+LOCK_FILE="$RUN_DIR/engine.lock"
 
 [ -f "$ENV_FILE" ] || die "env file not found: $ENV_FILE (see WEEK0_LOG.md Req G)"
 # Auto-export every assignment in the env file so PLEX_TOKEN, HLS_ROOT, etc.
@@ -45,39 +60,83 @@ set -a
 . "$ENV_FILE"
 set +a
 
+# Validate the wait knobs before any arithmetic — a non-numeric value would
+# crash the script under `set -e` mid-loop, leaving an unclear failure state.
+case "$DRAIN_WAIT_SECS" in
+  ''|*[!0-9]*) die "ENGINE_DRAIN_WAIT_SECS must be a non-negative integer, got '$DRAIN_WAIT_SECS'" ;;
+esac
+[ "$DRAIN_WAIT_SECS" -le 600 ] || die "ENGINE_DRAIN_WAIT_SECS too large (>600s), got $DRAIN_WAIT_SECS"
+case "$HEALTH_WAIT_SECS" in
+  ''|*[!0-9]*) die "ENGINE_HEALTH_WAIT_SECS must be a non-negative integer, got '$HEALTH_WAIT_SECS'" ;;
+esac
+[ "$HEALTH_WAIT_SECS" -le 600 ] || die "ENGINE_HEALTH_WAIT_SECS too large (>600s), got $HEALTH_WAIT_SECS"
+
 [ -x "$NODE_BIN" ] || die "node binary missing or not executable: $NODE_BIN (deploy must symlink mise Node 22.22.2 here, Req I)"
 [ -f "$ENGINE_ENTRY" ] || die "engine build artifact missing: $ENGINE_ENTRY (run 'npm run build' before starting)"
+command -v curl >/dev/null 2>&1 || die "curl not found on PATH (required for /api/health probes)"
 
 mkdir -p "$LOG_DIR" "$RUN_DIR"
 
+# Hold a non-blocking exclusive lock for the wrapper's lifetime. Two
+# concurrent start-engine.sh invocations no longer both spawn — the loser
+# exits 0 idempotently because the winner is doing the work. fd 9 is
+# explicitly closed in the engine child (`9>&-` on the nohup line below),
+# so the lock releases as soon as this wrapper exits, even though the
+# engine is still alive. That keeps the real lock semantics tight on
+# "wrapper in flight" instead of accidentally widening to "engine alive."
+exec 9>"$LOCK_FILE"
+if ! flock -n 9; then
+  log "another start-engine.sh holds the lock ($LOCK_FILE); nothing to do"
+  exit 0
+fi
+
+ENGINE_PORT="${ENGINE_PORT:-3001}"
+HEALTH_URL="http://127.0.0.1:${ENGINE_PORT}/api/health"
+
+# Returns 0 iff /api/health responds with a 2xx within 2 s. curl writes the
+# HTTP code to stdout; on connection refused / timeout it writes "000" so we
+# never need to interpret curl's exit code separately.
+probe_health() {
+  local code
+  code="$(curl --silent --max-time 2 --output /dev/null --write-out '%{http_code}' "$HEALTH_URL" 2>/dev/null || echo 000)"
+  case "$code" in
+    2*) return 0 ;;
+    *)  return 1 ;;
+  esac
+}
+
 if [ -f "$PID_FILE" ]; then
-  existing_pid="$(cat "$PID_FILE" 2>/dev/null || true)"
-  if [ -z "$existing_pid" ]; then
-    log "empty pid file; clearing"
+  existing_pid="$(tr -d '[:space:]' <"$PID_FILE" 2>/dev/null || true)"
+  if ! is_pid "$existing_pid"; then
+    log "invalid pid file content ('$existing_pid'); clearing"
     rm -f "$PID_FILE"
   elif ! kill -0 "$existing_pid" 2>/dev/null; then
     log "stale pid file (pid $existing_pid not alive); clearing"
     rm -f "$PID_FILE"
   else
-    # PID is alive. Confirm it's owned by us — defends against post-reboot PID
-    # reuse where the recorded number now belongs to some unrelated process.
+    # Defend against post-reboot PID reuse — if some unrelated process
+    # happens to hold the recorded PID number, it's not ours and the file
+    # is stale. UID match is good enough for a $HOME-stored pidfile under
+    # the engine's threat model.
     pid_uid="$(ps -o uid= -p "$existing_pid" 2>/dev/null | tr -d '[:space:]' || true)"
     our_uid="$(id -u)"
     if [ -z "$pid_uid" ] || [ "$pid_uid" != "$our_uid" ]; then
       log "pid $existing_pid alive but not owned by us (uid=${pid_uid:-?} vs ${our_uid}); treating as stale"
       rm -f "$PID_FILE"
+    elif probe_health; then
+      log "engine pid $existing_pid responds healthy on /api/health; nothing to do"
+      exit 0
     else
-      # Genuinely an alive process we own. Two cases collapse here:
-      #   (a) Healthy engine called via @reboot or watchdog-against-healthy.
-      #       Should leave it alone.
-      #   (b) Engine in graceful-shutdown drain — deploy/watchdog flow is
-      #       `kill && start-engine.sh` per WEEK0_LOG.md Step 2, and the
-      #       engine takes up to 15 s to flush in-flight requests.
-      #       Without waiting we'd false-positive (b) as (a), see the old
-      #       engine exit moments later, and leave nothing running until
-      #       the next watchdog tick (≥3 minutes of dead air). [Codex P1]
-      # Wait up to DRAIN_WAIT_SECS for it to exit, polling every 0.5 s.
-      log "found alive engine pid $existing_pid; waiting up to ${DRAIN_WAIT_SECS}s for drain"
+      # Alive, ours, but not responding. Two situations collapse here:
+      #   (a) Engine in graceful-shutdown drain — deploy/watchdog flow is
+      #       `kill && start-engine.sh` per WEEK0_LOG.md Step 2 / Req J.
+      #       Engine's SHUTDOWN_TIMEOUT_MS is 15 s. Wait it out, then spawn.
+      #   (b) Engine wedged — bootstrap stalled, Plex hang holding the event
+      #       loop, etc. start-engine.sh is not the health authority; if a
+      #       wedged engine is still alive after the drain wait, refuse to
+      #       spawn over it (would orphan the wedged child) and exit 1 so
+      #       the operator/watchdog escalates.
+      log "engine pid $existing_pid alive but unresponsive on /api/health; waiting up to ${DRAIN_WAIT_SECS}s for drain"
       drained="no"
       deadline_tenths=$((DRAIN_WAIT_SECS * 2))
       tenths=0
@@ -93,16 +152,47 @@ if [ -f "$PID_FILE" ]; then
         log "previous engine pid $existing_pid drained after $((tenths / 2))s; spawning fresh"
         rm -f "$PID_FILE"
       else
-        log "engine still healthy after ${DRAIN_WAIT_SECS}s wait (pid $existing_pid); nothing to do"
-        exit 0
+        die "engine pid $existing_pid alive and unresponsive after ${DRAIN_WAIT_SECS}s — wedged; refusing to spawn over it (kill it first, then retry)"
       fi
     fi
   fi
 fi
 
 log "spawning engine: $NODE_BIN $ENGINE_ENTRY"
-nohup "$NODE_BIN" "$ENGINE_ENTRY" >>"$LOG_FILE" 2>&1 &
+# 9>&- explicitly closes the flock fd in the child so the lock releases
+# when this wrapper exits, not when the engine exits (see the exec 9> block).
+nohup "$NODE_BIN" "$ENGINE_ENTRY" >>"$LOG_FILE" 2>&1 9>&- &
 engine_pid=$!
 disown "$engine_pid" 2>/dev/null || true
+# Write the pidfile immediately so operators / watchdog can see the child
+# during its bootstrap window. If health verification fails below we'll
+# clean it up.
 echo "$engine_pid" >"$PID_FILE"
-log "engine started (pid $engine_pid); logs: $LOG_FILE"
+log "spawned engine pid $engine_pid; verifying /api/health (up to ${HEALTH_WAIT_SECS}s)"
+
+healthy="no"
+deadline_tenths=$((HEALTH_WAIT_SECS * 2))
+tenths=0
+while [ "$tenths" -lt "$deadline_tenths" ]; do
+  if ! kill -0 "$engine_pid" 2>/dev/null; then
+    rm -f "$PID_FILE"
+    die "engine pid $engine_pid exited during startup — check $LOG_FILE"
+  fi
+  if probe_health; then
+    healthy="yes"
+    break
+  fi
+  sleep 0.5
+  tenths=$((tenths + 1))
+done
+
+if [ "$healthy" != "yes" ]; then
+  log "engine pid $engine_pid did not become healthy within ${HEALTH_WAIT_SECS}s; killing"
+  kill -TERM "$engine_pid" 2>/dev/null || true
+  sleep 1
+  kill -KILL "$engine_pid" 2>/dev/null || true
+  rm -f "$PID_FILE"
+  die "engine failed to come up healthy in ${HEALTH_WAIT_SECS}s — check $LOG_FILE"
+fi
+
+log "engine healthy in $((tenths / 2))s (pid $engine_pid); logs: $LOG_FILE"

--- a/deploy/bin/start-engine.sh
+++ b/deploy/bin/start-engine.sh
@@ -24,6 +24,10 @@ die() { log "ERROR: $*"; exit 1; }
 
 RADIO_HOME="${RADIO_HOME:-$HOME/webradio-v3}"
 ENV_FILE="${RADIO_ENV_FILE:-$HOME/.config/radio/env}"
+# Wait budget for an in-flight engine to drain before we declare it healthy.
+# The engine has a 15 s graceful-shutdown budget (apps/engine/README.md), so we
+# need a strictly larger window. Override via env for fast smoke tests.
+DRAIN_WAIT_SECS="${ENGINE_DRAIN_WAIT_SECS:-20}"
 
 NODE_BIN="$RADIO_HOME/bin/node"
 ENGINE_ENTRY="$RADIO_HOME/apps/engine/dist/index.js"
@@ -48,12 +52,52 @@ mkdir -p "$LOG_DIR" "$RUN_DIR"
 
 if [ -f "$PID_FILE" ]; then
   existing_pid="$(cat "$PID_FILE" 2>/dev/null || true)"
-  if [ -n "$existing_pid" ] && kill -0 "$existing_pid" 2>/dev/null; then
-    log "engine already running (pid $existing_pid); nothing to do"
-    exit 0
+  if [ -z "$existing_pid" ]; then
+    log "empty pid file; clearing"
+    rm -f "$PID_FILE"
+  elif ! kill -0 "$existing_pid" 2>/dev/null; then
+    log "stale pid file (pid $existing_pid not alive); clearing"
+    rm -f "$PID_FILE"
+  else
+    # PID is alive. Confirm it's owned by us — defends against post-reboot PID
+    # reuse where the recorded number now belongs to some unrelated process.
+    pid_uid="$(ps -o uid= -p "$existing_pid" 2>/dev/null | tr -d '[:space:]' || true)"
+    our_uid="$(id -u)"
+    if [ -z "$pid_uid" ] || [ "$pid_uid" != "$our_uid" ]; then
+      log "pid $existing_pid alive but not owned by us (uid=${pid_uid:-?} vs ${our_uid}); treating as stale"
+      rm -f "$PID_FILE"
+    else
+      # Genuinely an alive process we own. Two cases collapse here:
+      #   (a) Healthy engine called via @reboot or watchdog-against-healthy.
+      #       Should leave it alone.
+      #   (b) Engine in graceful-shutdown drain — deploy/watchdog flow is
+      #       `kill && start-engine.sh` per WEEK0_LOG.md Step 2, and the
+      #       engine takes up to 15 s to flush in-flight requests.
+      #       Without waiting we'd false-positive (b) as (a), see the old
+      #       engine exit moments later, and leave nothing running until
+      #       the next watchdog tick (≥3 minutes of dead air). [Codex P1]
+      # Wait up to DRAIN_WAIT_SECS for it to exit, polling every 0.5 s.
+      log "found alive engine pid $existing_pid; waiting up to ${DRAIN_WAIT_SECS}s for drain"
+      drained="no"
+      deadline_tenths=$((DRAIN_WAIT_SECS * 2))
+      tenths=0
+      while [ "$tenths" -lt "$deadline_tenths" ]; do
+        if ! kill -0 "$existing_pid" 2>/dev/null; then
+          drained="yes"
+          break
+        fi
+        sleep 0.5
+        tenths=$((tenths + 1))
+      done
+      if [ "$drained" = "yes" ]; then
+        log "previous engine pid $existing_pid drained after $((tenths / 2))s; spawning fresh"
+        rm -f "$PID_FILE"
+      else
+        log "engine still healthy after ${DRAIN_WAIT_SECS}s wait (pid $existing_pid); nothing to do"
+        exit 0
+      fi
+    fi
   fi
-  log "stale pid file (pid '$existing_pid' not alive); clearing"
-  rm -f "$PID_FILE"
 fi
 
 log "spawning engine: $NODE_BIN $ENGINE_ENTRY"


### PR DESCRIPTION
## What

First slice of Week 1 Task 6 (deploy scripts). A pure-bash wrapper, `deploy/bin/start-engine.sh` (~60 LOC), invoked from cron `@reboot` and from the forthcoming `watchdog.sh` to launch the audio engine on Whatbox.

## Why this slice, this shape

Task 6 is the deploy story that lets the engine survive on a no-systemd seedbox (per `WEEK0_LOG.md` Step 2 + Reqs E–J). It's also the gate for shipping to `v3.nicemouth.box.ca`. Splitting Task 6 into atomic slices (one wrapper, then the watchdog, then the env template, then crontab) lets each piece land independently reviewable instead of dropping a 4-script tarball at once. Per `CLAUDE.md` §3 cadence rules.

## Design choices (the "why" behind each non-obvious decision)

- **Pure bash, no Node/TS dependency.** The wrapper has to run before any Node-side work — including failed builds. A Node helper would add a chicken-and-egg dependency exactly when the operator most needs the launcher to "just work."
- **Stable `${RADIO_HOME}/bin/node` symlink, not a hardcoded mise path.** Req I lists both options; the symlink lets us bump Node versions with a single `ln -sf`, and keeps mise install paths (per-user, brittle) out of a checked-in script.
- **Runs `dist/index.js`, not `--experimental-strip-types src/index.ts`.** Aligns with `apps/engine/package.json`'s declared `npm start` ("production entry point"). Compiled JS = faster cold start under the watchdog respawn loop, no exposure to experimental-flag drift between Node patches. Trade-off: deploy must run `npm ci && npm run build` first — that's a separate slice's concern.
- **`set -a` around the env source.** Without it, `KEY=value` lines in `~/.config/radio/env` populate the wrapper's shell scope but never reach `nohup`'s child — the engine would boot with `process.env.PLEX_TOKEN === undefined` and exit 1. Smoke-test caught this; fixed before this slice was committed.
- **Idempotent PID-file guard with stale recovery.** `@reboot` cron *and* `watchdog.sh` both call this script. If the engine is alive, second invocation is a no-op. If the PID file lingers from a crashed engine, it gets cleared and a fresh spawn proceeds. Without stale recovery, a single crash would lock the wrapper into "already running" forever.
- **`umask 077`.** Whatbox is a shared seedbox. Logs (which can contain Plex API responses) and PID files land 0600 instead of the default 0644.
- **Wrapper does NOT validate env contents.** `apps/engine/src/config.ts` already collects every error in one pass and exits 1 on bad input. Duplicating that in bash would be drift-prone and lower-fidelity. The wrapper just sources the file; the engine is the source of truth for what's required.

## Verification

Smoke test (manual, against tmpdir `RADIO_HOME` with stub `node` + stub `dist/index.js`) covers 6 cases — all green:

1. Clean start: PID written, log written, env propagates to child, file modes 600.
2. Idempotent re-invocation: same PID stays in file, no respawn.
3. Stale-PID recovery: kill child → re-invoke → fresh PID written, new process alive.
4. Missing env file → non-zero exit + clear error.
5. Missing `dist/index.js` → non-zero exit + clear error.
6. Missing node binary → non-zero exit + clear error.

Pre-push CodeRabbit review against `origin/main`: **No findings ✔**.

Pre-commit hook ran the full 230-test engine suite (no source changes, but checked anyway): all green.

`shellcheck` not installed locally; can wire it as an npm devDep or `pacman -S shellcheck` if desired before the next bash-script slice.

## What's NOT in this slice (deliberate)

- `deploy/bin/watchdog.sh` (Req J — restart on 3 consecutive HTTP 000, never on 5xx).
- crontab entries (`@reboot` + `* * * * *`).
- env file template at `~/.config/radio/env`.
- Deploy pipeline that builds `dist/` and refreshes the `bin/node` symlink.

Each lands as its own slice once this one is approved.

## Test plan

- [x] Local smoke test (tmpdir, 6 cases)
- [x] Pre-push CodeRabbit clean
- [x] 230/230 engine tests still green
- [ ] Codex `/codex review --base main` clean
- [ ] CodeRabbit GitHub App clean
- [ ] Triple-signoff merge gate satisfied

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a secure, idempotent engine startup utility with automatic environment loading, dependency checks, duplicate-instance and port-bind prevention, health-based readiness probes, graceful spawn/termination logic, and integrated logging/status reporting.

* **Documentation**
  * Clarified shutdown lifecycle: stop accepting new connections, supervisors stop in parallel, 15s hard timeout, and idempotent signal handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->