### PR TITLE
feat(deploy): watchdog.sh — Whatbox cron-minute restart watchdog (Task 6 slice 2)

### DIFF
--- a/deploy/bin/start-engine.sh
+++ b/deploy/bin/start-engine.sh
@@ -108,12 +108,14 @@ ENGINE_PORT="${ENGINE_PORT:-3001}"
 HEALTH_URL="http://127.0.0.1:${ENGINE_PORT}/api/health"
 
 # Returns 0 iff /api/health responds with a 2xx within 2 s. curl writes the
-# HTTP code to stdout; on connection refused / timeout it writes "000" so we
-# never need to interpret curl's exit code separately.
+# HTTP code via --write-out (including "000" on connection refused/timeout).
+# `|| true` keeps set -e from killing us on curl's non-zero exit. The fallback
+# is via parameter default, NOT `|| echo 000` after the pipe — that form
+# concatenates curl's "000" with the echo's "000" producing "000000".
 probe_health() {
   local code
-  code="$(curl --silent --max-time 2 --output /dev/null --write-out '%{http_code}' "$HEALTH_URL" 2>/dev/null || echo 000)"
-  case "$code" in
+  code="$(curl --silent --max-time 2 --output /dev/null --write-out '%{http_code}' "$HEALTH_URL" 2>/dev/null || true)"
+  case "${code:-000}" in
     2*) return 0 ;;
     *)  return 1 ;;
   esac

--- a/deploy/bin/start-engine.sh
+++ b/deploy/bin/start-engine.sh
@@ -35,20 +35,14 @@ is_pid() { [[ "$1" =~ ^[1-9][0-9]*$ ]]; }
 # Read /proc/$pid/cmdline as a space-joined string. Returns empty if the
 # pid no longer exists or proc isn't available.
 pid_cmdline() {
-  if [ -r "/proc/$1/cmdline" ]; then
-    tr '\0' ' ' <"/proc/$1/cmdline" 2>/dev/null
-  fi
+  # `cat | tr` returns 0 with empty output if the proc file vanishes mid-call —
+  # avoids the [ -r ] / read TOCTOU window that could abort the script under
+  # `set -e`. [#15 item 3]
+  cat "/proc/$1/cmdline" 2>/dev/null | tr '\0' ' ' || true
 }
 
 RADIO_HOME="${RADIO_HOME:-$HOME/webradio-v3}"
 ENV_FILE="${RADIO_ENV_FILE:-$HOME/.config/radio/env}"
-# Wait budget for an in-flight engine to drain (graceful shutdown) before we
-# treat it as wedged. Engine's SHUTDOWN_TIMEOUT_MS is 15 s
-# (apps/engine/src/index.ts), so the default 20 s gives a small buffer.
-DRAIN_WAIT_SECS="${ENGINE_DRAIN_WAIT_SECS:-20}"
-# Wait budget for a freshly-spawned engine to start responding 2xx on
-# /api/health. Real bootstrap is ~1–5 s on Whatbox; 15 s is generous.
-HEALTH_WAIT_SECS="${ENGINE_HEALTH_WAIT_SECS:-15}"
 
 NODE_BIN="$RADIO_HOME/bin/node"
 ENGINE_ENTRY="$RADIO_HOME/apps/engine/dist/index.js"
@@ -66,6 +60,17 @@ set -a
 # shellcheck disable=SC1090  # path resolved at runtime, not lintable here
 . "$ENV_FILE"
 set +a
+
+# Read wait-knob env vars AFTER sourcing the env file — the operator's
+# overrides in $ENV_FILE need to take effect, not the bash environment at
+# script-start time. [#15 item 1]
+# Wait budget for an in-flight engine to drain (graceful shutdown) before
+# we treat it as wedged. Engine's SHUTDOWN_TIMEOUT_MS is 15 s
+# (apps/engine/src/index.ts), so the default 20 s gives a small buffer.
+DRAIN_WAIT_SECS="${ENGINE_DRAIN_WAIT_SECS:-20}"
+# Wait budget for a freshly-spawned engine to start responding 2xx on
+# /api/health. Real bootstrap is ~1–5 s on Whatbox; 15 s is generous.
+HEALTH_WAIT_SECS="${ENGINE_HEALTH_WAIT_SECS:-15}"
 
 # Validate the wait knobs before any arithmetic — a non-numeric value would
 # crash the script under `set -e` mid-loop, leaving an unclear failure state.

--- a/deploy/bin/watchdog.sh
+++ b/deploy/bin/watchdog.sh
@@ -1,0 +1,223 @@
+#!/usr/bin/env bash
+# watchdog.sh — Whatbox cron-minute watchdog for the Pavoia v3 audio engine.
+#
+# Invoked from cron `* * * * *`. Probes /api/health once and decides:
+#   200 (or any 2xx)  → engine healthy, reset failure counter, exit 0.
+#   5xx               → engine alive-but-degraded (Req J: must NOT trigger
+#                       restart, restart would destroy diagnostic state),
+#                       reset counter, exit 0.
+#   000 (refused/timeout) → increment counter.
+#       <THRESHOLD consecutive  → log + exit 0.
+#       =THRESHOLD consecutive  → reset counter, restart sequence:
+#         1. Read engine.pid; verify it points at OUR engine via cmdline
+#            (defends against PID-recycle to an unrelated same-user proc).
+#         2. SIGTERM the engine; wait up to TERM_WAIT_SECS for exit.
+#         3. If still alive, escalate to SIGKILL; wait KILL_WAIT_SECS more.
+#         4. Invoke start-engine.sh. Its own preconditions + health probe
+#            decide whether the new spawn is healthy; we just propagate
+#            its exit code.
+#
+# State file: $RUN_DIR/watchdog.state — single integer line, the current
+# consecutive-000 count. Persists across cron re-execs (Req J) and is
+# atomically rewritten via temp + mv.
+#
+# Lock: $RUN_DIR/watchdog.lock — non-blocking flock, prevents two
+# overlapping cron invocations during long restart sequences.
+#
+# Exit codes:
+#   0 — probe handled successfully (any decision).
+#   1 — preconditions failed, lock error, or restart sequence couldn't
+#       complete (engine still alive after SIGKILL, start-engine.sh failed).
+
+set -euo pipefail
+umask 077
+
+log() { printf '[watchdog] %s\n' "$*" >&2; }
+die() { log "ERROR: $*"; exit 1; }
+is_pid() { [[ "$1" =~ ^[1-9][0-9]*$ ]]; }
+pid_cmdline() {
+  cat "/proc/$1/cmdline" 2>/dev/null | tr '\0' ' ' || true
+}
+
+RADIO_HOME="${RADIO_HOME:-$HOME/webradio-v3}"
+ENV_FILE="${RADIO_ENV_FILE:-$HOME/.config/radio/env}"
+
+START_ENGINE_SH="$RADIO_HOME/bin/start-engine.sh"
+ENGINE_ENTRY="$RADIO_HOME/apps/engine/dist/index.js"
+RUN_DIR="$RADIO_HOME/run"
+PID_FILE="$RUN_DIR/engine.pid"
+STATE_FILE="$RUN_DIR/watchdog.state"
+LOCK_FILE="$RUN_DIR/watchdog.lock"
+
+[ -f "$ENV_FILE" ] || die "env file not found: $ENV_FILE (see WEEK0_LOG.md Req G)"
+set -a
+# shellcheck disable=SC1090  # path resolved at runtime, not lintable here
+. "$ENV_FILE"
+set +a
+
+# Read all knobs AFTER env source so operator overrides in $ENV_FILE win.
+THRESHOLD="${WATCHDOG_FAILURE_THRESHOLD:-3}"
+TERM_WAIT_SECS="${WATCHDOG_TERM_WAIT_SECS:-15}"
+KILL_WAIT_SECS="${WATCHDOG_KILL_WAIT_SECS:-5}"
+ENGINE_PORT="${ENGINE_PORT:-3001}"
+
+# Validate every knob before any arithmetic — non-numeric values would
+# crash the script under `set -e` and cron would silently log the failure.
+case "$THRESHOLD" in
+  ''|*[!0-9]*) die "WATCHDOG_FAILURE_THRESHOLD must be a positive integer, got '$THRESHOLD'" ;;
+esac
+[ "$THRESHOLD" -ge 1 ] && [ "$THRESHOLD" -le 100 ] || die "WATCHDOG_FAILURE_THRESHOLD out of range [1..100], got $THRESHOLD"
+case "$TERM_WAIT_SECS" in
+  ''|*[!0-9]*) die "WATCHDOG_TERM_WAIT_SECS must be a non-negative integer, got '$TERM_WAIT_SECS'" ;;
+esac
+[ "$TERM_WAIT_SECS" -le 600 ] || die "WATCHDOG_TERM_WAIT_SECS too large (>600s), got $TERM_WAIT_SECS"
+case "$KILL_WAIT_SECS" in
+  ''|*[!0-9]*) die "WATCHDOG_KILL_WAIT_SECS must be a non-negative integer, got '$KILL_WAIT_SECS'" ;;
+esac
+[ "$KILL_WAIT_SECS" -le 600 ] || die "WATCHDOG_KILL_WAIT_SECS too large (>600s), got $KILL_WAIT_SECS"
+case "$ENGINE_PORT" in
+  ''|*[!0-9]*) die "ENGINE_PORT must be a positive integer, got '$ENGINE_PORT'" ;;
+esac
+[ "$ENGINE_PORT" -ge 1 ] && [ "$ENGINE_PORT" -le 65535 ] || die "ENGINE_PORT out of range [1..65535], got $ENGINE_PORT"
+
+[ -x "$START_ENGINE_SH" ] || die "start-engine.sh not found or not executable: $START_ENGINE_SH"
+command -v curl  >/dev/null 2>&1 || die "curl not found on PATH (required for /api/health probe)"
+command -v flock >/dev/null 2>&1 || die "flock not found on PATH (required for concurrency lock)"
+command -v ps    >/dev/null 2>&1 || die "ps not found on PATH (required for PID identity check)"
+
+mkdir -p "$RUN_DIR"
+
+# Lock — distinguish lock contention (exit 1 from flock) from any other
+# flock failure. Without this, a missing/broken flock would silently no-op
+# and cron would think the watchdog ran successfully.
+exec 9>"$LOCK_FILE"
+if flock -n 9; then
+  : # acquired
+else
+  rc=$?
+  case "$rc" in
+    1) log "another watchdog invocation in flight (lock $LOCK_FILE); exiting 0"; exit 0 ;;
+    *) die "flock failed unexpectedly (exit=$rc)" ;;
+  esac
+fi
+
+HEALTH_URL="http://127.0.0.1:${ENGINE_PORT}/api/health"
+
+# curl writes the HTTP code to stdout via --write-out (including "000" on
+# connection refused / timeout). `|| true` keeps set -e from killing us on
+# curl's non-zero exit; the ${code:-000} default covers the unlikely case
+# where curl wrote literally nothing.
+# Don't append `|| echo 000` to the curl pipe — curl ALREADY prints "000"
+# in the failure case, and a fallback would concatenate to "000000" which
+# would miss the `000)` case below.
+http_code() {
+  local code
+  code="$(curl --silent --max-time 2 --output /dev/null --write-out '%{http_code}' "$HEALTH_URL" 2>/dev/null || true)"
+  printf '%s' "${code:-000}"
+}
+
+write_state() {
+  local n="$1"
+  printf '%s\n' "$n" >"$STATE_FILE.tmp" && mv "$STATE_FILE.tmp" "$STATE_FILE"
+}
+
+# Read consecutive-000 counter from state file. Treat missing or malformed
+# values as 0 (no prior failures recorded).
+count=0
+if [ -f "$STATE_FILE" ]; then
+  raw="$(tr -d '[:space:]' <"$STATE_FILE" 2>/dev/null || true)"
+  case "$raw" in
+    ''|*[!0-9]*) log "invalid state file content ('$raw'); resetting to 0" ;;
+    *)           count="$raw" ;;
+  esac
+fi
+
+code="$(http_code)"
+log "probe: HTTP $code  (consecutive_000=$count, threshold=$THRESHOLD)"
+
+case "$code" in
+  2*)
+    if [ "$count" -gt 0 ]; then log "engine recovered from $count consecutive failure(s)"; fi
+    write_state 0
+    exit 0
+    ;;
+  5*)
+    # Per Req J: 5xx is alive-but-degraded; restart would destroy state.
+    if [ "$count" -gt 0 ]; then log "engine returned 5xx (alive-but-degraded); resetting counter"; fi
+    write_state 0
+    exit 0
+    ;;
+  000)
+    count=$((count + 1))
+    if [ "$count" -lt "$THRESHOLD" ]; then
+      log "HTTP 000 — count now $count/$THRESHOLD"
+      write_state "$count"
+      exit 0
+    fi
+    log "HTTP 000 reached threshold ($count/$THRESHOLD) — restarting engine"
+    # Reset counter BEFORE the restart so a failed restart attempt doesn't
+    # immediately re-trigger restart on the next tick — the next tick gets
+    # a fresh 0 → 1 → 2 → 3 cycle, giving the operator 3 minutes to
+    # intervene before the next attempt.
+    write_state 0
+    ;;
+  *)
+    log "unexpected HTTP code: $code; treating as alive-but-degraded (no restart)"
+    write_state 0
+    exit 0
+    ;;
+esac
+
+# --- Restart sequence ---
+
+existing_pid=""
+if [ -f "$PID_FILE" ]; then
+  raw="$(tr -d '[:space:]' <"$PID_FILE" 2>/dev/null || true)"
+  if is_pid "$raw"; then existing_pid="$raw"; fi
+fi
+
+wait_pid_exit() {
+  local pid="$1" budget="$2"
+  local deadline=$(($(date +%s) + budget))
+  while [ "$(date +%s)" -lt "$deadline" ]; do
+    kill -0 "$pid" 2>/dev/null || return 0
+    sleep 0.5
+  done
+  kill -0 "$pid" 2>/dev/null && return 1 || return 0
+}
+
+if [ -n "$existing_pid" ] && kill -0 "$existing_pid" 2>/dev/null; then
+  cmdline="$(pid_cmdline "$existing_pid")"
+  if [[ " $cmdline " == *" $ENGINE_ENTRY "* ]]; then
+    log "sending SIGTERM to engine pid $existing_pid"
+    kill -TERM "$existing_pid" 2>/dev/null || true
+    if wait_pid_exit "$existing_pid" "$TERM_WAIT_SECS"; then
+      log "engine pid $existing_pid exited cleanly"
+    else
+      log "engine pid $existing_pid did not exit within ${TERM_WAIT_SECS}s — escalating to SIGKILL"
+      # Re-check cmdline before SIGKILL — if the PID was recycled to
+      # something else during our wait, don't kill the unrelated process.
+      cmdline_now="$(pid_cmdline "$existing_pid")"
+      if [[ " $cmdline_now " == *" $ENGINE_ENTRY "* ]]; then
+        kill -KILL "$existing_pid" 2>/dev/null || true
+        if ! wait_pid_exit "$existing_pid" "$KILL_WAIT_SECS"; then
+          die "engine pid $existing_pid still alive after SIGKILL; aborting restart (next tick will retry)"
+        fi
+        log "engine pid $existing_pid killed"
+      else
+        log "pid $existing_pid no longer matches our engine cmdline; skipping SIGKILL"
+      fi
+    fi
+  else
+    log "pid $existing_pid alive but cmdline does not include $ENGINE_ENTRY; not killing (start-engine.sh will sort it out)"
+  fi
+fi
+
+log "invoking $START_ENGINE_SH"
+if "$START_ENGINE_SH"; then
+  log "engine restart succeeded"
+  exit 0
+else
+  rc=$?
+  die "start-engine.sh failed (exit=$rc); next watchdog tick will retry"
+fi


### PR DESCRIPTION
## What

Second slice of Week 1 Task 6: `deploy/bin/watchdog.sh` (~216 LOC), the cron `* * * * *` companion to `start-engine.sh`. Implements Req J: restart on 3 consecutive HTTP 000, never restart on 5xx.

Plus 2 fixes from issue #15 batched in:
- **Item 1** (commit b013e2f): wait-knob env-file overrides now actually take effect in `start-engine.sh`.
- **Item 3** (commit b013e2f): `pid_cmdline` no longer has the TOCTOU that could abort the script under `set -e`.

Plus a real bug discovered while writing the watchdog probe (commit 70bc2c6): `curl ... || echo 000` was concatenating curl's own "000" output with the fallback to produce literal "000000". `start-engine.sh`'s `case "2*)` happened to give the right boolean, so functionally OK there — but the literal value was wrong and `watchdog.sh`'s `case "000)` would have missed it. Both scripts now use the same robust idiom.

## Lessons applied from PR #14's 5 review rounds

`watchdog.sh` is a brand-new file, so I baked in patterns we landed on the hard way:

- All env reads (`THRESHOLD`, `TERM_WAIT_SECS`, `KILL_WAIT_SECS`, `ENGINE_PORT`) happen AFTER `set -a; . "$ENV_FILE"; set +a` so operator overrides actually take effect (#15 item 1, applied from the start).
- `ENGINE_PORT` validated as positive integer in `[1, 65535]` before constructing the health URL (#15 item 5).
- `flock -n` failures distinguished by exit code: `1` = contention (idempotent exit 0), anything else = real error (die with the exit code) (#15 item 2 lesson).
- `pid_cmdline` uses the safer `cat | tr || true` idiom from the start (#15 item 3 applied).
- Re-checks cmdline matches `ENGINE_ENTRY` BEFORE `kill -KILL` to avoid SIGKILL'ing a recycled PID (#15 item 4 applied).
- All wait loops use wall-clock deadlines (`date +%s`), not iteration counts.
- Lock fd held only for wrapper lifetime — engine child not affected (we don't spawn the engine here, but pattern is consistent).

`start-engine.sh` keeps the wait-knob ordering fix (item 1) + safer `pid_cmdline` (item 3) from this branch's first commit. Items 2, 4, 5 stay in #15 for a future cleanup since touching all of them would expand this PR's surface unnecessarily.

## Decision tree (watchdog.sh)

| Probe | Counter action | Restart? |
|---|---|---|
| 2xx | reset to 0 | no |
| 5xx | reset to 0 | no — alive-but-degraded per Req J |
| 000 (n+1 < THRESHOLD) | write n+1 | no |
| 000 (n+1 = THRESHOLD) | reset to 0 | yes — kill (with cmdline guard) + invoke start-engine.sh |
| other (4xx, etc.) | reset to 0 | no — defensive, log + exit |

## Restart sequence

1. Read `engine.pid`. If valid PID and process alive:
   - Verify `/proc/$pid/cmdline` includes `ENGINE_ENTRY`. If not → log + skip kill (let `start-engine.sh` sort it out).
   - SIGTERM, wait up to `WATCHDOG_TERM_WAIT_SECS` (default 15s) for exit.
   - If still alive → re-check cmdline (PID may have recycled), then SIGKILL, wait `WATCHDOG_KILL_WAIT_SECS` (default 5s).
   - If still alive after SIGKILL → die exit 1 (next cron tick will retry).
2. Invoke `~/webradio-v3/bin/start-engine.sh`. Propagate its exit code.

## Smoke test (12 cases, all green)

- 200 → reset count
- 5xx → reset count, no restart (Req J)
- 000 below threshold → increment counter
- 000 reaches threshold → reset + restart
- SIGKILL escalation when engine ignores SIGTERM
- Cmdline mismatch → don't kill
- Garbage state file → resets to 0
- Missing env file → die
- Env-file `WATCHDOG_FAILURE_THRESHOLD=2` honored
- Bad `ENGINE_PORT` → die
- Concurrent invocations → second exits 0 via lock

## What's NOT in this slice

- `~/.config/radio/env` template file with documented vars (next slice).
- `crontab` entries (`@reboot` + `* * * * *`) — next slice.
- Whatbox deploy itself (Task 7).
- Items 2, 4, 5 from issue #15 (defer to a cleanup commit alongside the next slice).

## Test plan

- [x] Local smoke test (12 cases for watchdog, 2 quick re-verify for start-engine)
- [x] Pre-push CodeRabbit clean
- [x] Engine 230/230 still green
- [ ] Codex `/codex review --base main` clean
- [ ] CodeRabbit GitHub App clean
- [ ] Triple-signoff merge gate satisfied

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved engine startup robustness by enhancing error handling and addressing reliability issues that could cause unexpected script failures during initialization and environment configuration.

* **New Features**
  * Added automatic health monitoring and recovery capabilities for the audio engine that continuously monitors service health, detects issues, and automatically restarts the service when necessary to maintain continuous operation and reduce service interruptions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->