### PR TITLE
docs(deploy): env template + crontab + operator runbook (Task 6 slice 3)

### DIFF
--- a/deploy/README.md
+++ b/deploy/README.md
@@ -1,0 +1,149 @@
+# Pavoia Webradio v3 — deploy
+
+Operator runbook for running the v3 engine on Whatbox. No systemd, no process
+manager — just `cron + nohup + watchdog`, the pattern v1/v2 already use
+(verified 2026-04-21, see `docs/WEEK0_LOG.md` Step 2).
+
+## Layout on Whatbox
+
+```
+~/webradio-v3/
+├── apps/engine/dist/
+│   └── index.js              # built engine entry (npm run build)
+├── assets/
+│   └── curating.aac          # silence loop for empty playlists
+├── bin/
+│   ├── node                  # symlink → mise-managed Node 22.22.2
+│   ├── start-engine.sh       # symlink → ../deploy/bin/start-engine.sh
+│   └── watchdog.sh           # symlink → ../deploy/bin/watchdog.sh
+├── deploy/                   # checked-in scripts + this README
+├── logs/
+│   ├── engine.log            # engine stdout + stderr (append-only)
+│   └── cron.log              # @reboot + watchdog cron output
+└── run/
+    ├── engine.pid            # current engine PID
+    ├── engine.lock           # start-engine.sh single-instance lock
+    ├── watchdog.lock         # watchdog.sh single-instance lock
+    └── watchdog.state        # consecutive-HTTP-000 counter
+
+~/.config/radio/env           # Plex token + every tunable. Mode 0600.
+                              # Lives outside webradio-v3/ so deploys
+                              # (rsync) don't overwrite it.
+```
+
+## First-time install
+
+All commands below run on Whatbox (`ssh whatbox`).
+
+### 1. Pin Node 22.22.2 via mise
+
+```bash
+mise install node@22.22.2
+mkdir -p ~/webradio-v3/bin
+ln -sfn ~/.local/share/mise/installs/node/22.22.2/bin/node ~/webradio-v3/bin/node
+~/webradio-v3/bin/node --version   # → v22.22.2
+```
+
+### 2. Rsync the repo + build the engine
+
+From your dev machine:
+
+```bash
+rsync -av --exclude .git --exclude node_modules --exclude dist \
+      ./ whatbox:~/webradio-v3/
+ssh whatbox 'cd ~/webradio-v3 && npm ci && npm run build --workspace=@pavoia/engine'
+```
+
+Verify `~/webradio-v3/apps/engine/dist/index.js` exists.
+
+### 3. Symlink the wrapper scripts into bin/
+
+```bash
+ssh whatbox 'cd ~/webradio-v3/bin && \
+  ln -sf ../deploy/bin/start-engine.sh && \
+  ln -sf ../deploy/bin/watchdog.sh'
+```
+
+### 4. Create the env file
+
+```bash
+mkdir -p ~/.config/radio && chmod 700 ~/.config/radio
+cp ~/webradio-v3/deploy/env.example ~/.config/radio/env
+chmod 600 ~/.config/radio/env
+$EDITOR ~/.config/radio/env   # paste the real PLEX_TOKEN, etc.
+```
+
+### 5. Stage the curating fallback
+
+```bash
+mkdir -p ~/webradio-v3/assets
+ffmpeg -f lavfi -i anullsrc=r=44100:cl=stereo -t 10 \
+       -c:a aac -b:a 128k ~/webradio-v3/assets/curating.aac
+```
+
+### 6. First start (manually, to surface errors immediately)
+
+```bash
+~/webradio-v3/bin/start-engine.sh
+# Expected last line: "engine healthy in Ns (pid NNNNN); logs: ~/webradio-v3/logs/engine.log"
+curl -s http://127.0.0.1:3001/api/health | head -c 200
+```
+
+If anything fails the wrapper exits non-zero with a clear `[start-engine] ERROR: ...` line; check `~/webradio-v3/logs/engine.log` for the engine's own complaint.
+
+### 7. Install the crontab
+
+```bash
+crontab -l > /tmp/cron.bak                                       # backup
+cat /tmp/cron.bak ~/webradio-v3/deploy/crontab.example | crontab -
+crontab -l | grep webradio-v3                                    # verify
+```
+
+## Ongoing deploys
+
+```bash
+# 1. Push code
+rsync -av --exclude .git --exclude node_modules --exclude dist \
+      ./ whatbox:~/webradio-v3/
+
+# 2. Build
+ssh whatbox 'cd ~/webradio-v3 && npm ci && npm run build --workspace=@pavoia/engine'
+
+# 3. Restart (the wrapper handles drain race + post-spawn health verify)
+ssh whatbox '
+  if [ -f ~/webradio-v3/run/engine.pid ]; then
+    kill $(cat ~/webradio-v3/run/engine.pid) 2>/dev/null || true
+  fi
+  ~/webradio-v3/bin/start-engine.sh
+'
+```
+
+`start-engine.sh` exits 0 only if `/api/health` is responsive; the SSH session inherits its non-zero exit so a failed deploy is visible.
+
+## Stopping the engine
+
+```bash
+crontab -l | grep -v webradio-v3 | crontab -                # remove cron entries
+kill $(cat ~/webradio-v3/run/engine.pid) 2>/dev/null || true
+```
+
+The `crontab -l | grep -v ...` step is critical — otherwise the watchdog will respawn the engine within 3 minutes.
+
+## Troubleshooting
+
+**Engine won't start.** Check `~/webradio-v3/logs/engine.log`. Most failures are missing/wrong env vars; `apps/engine/src/config.ts` collects every error in one pass and exits 1 with the full punch list.
+
+**Engine alive but unresponsive.** `start-engine.sh` will refuse to spawn over a wedged engine (exits 1 "wedged"). Force kill: `kill -KILL $(cat ~/webradio-v3/run/engine.pid)`. Next watchdog tick (within 60s) respawns fresh.
+
+**Watchdog seems stuck.** Tail `~/webradio-v3/logs/cron.log` — every probe + decision lands there. If you see `cmdline does not include`, the recorded PID isn't our engine (it's been recycled). Manually clear: `rm ~/webradio-v3/run/engine.pid` and let the next watchdog tick spawn fresh.
+
+**Watchdog never triggers a restart.** Reset its state: `rm ~/webradio-v3/run/watchdog.state`. Next probe starts the consecutive-failure counter from zero.
+
+**Need to override a tunable temporarily.** Edit `~/.config/radio/env` and either restart manually (`kill $(cat run/engine.pid) && bin/start-engine.sh`) or wait for the next watchdog cycle. Both wrappers re-source the env file on every invocation.
+
+## Reference
+
+- `deploy/env.example` — every env var documented with default and source script.
+- `deploy/crontab.example` — annotated cron entries.
+- `apps/engine/README.md` — engine HTTP contract, exit codes, log format.
+- `docs/WEEK0_LOG.md` — the 16 locked deploy requirements (A–P) this all derives from.

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -6,7 +6,7 @@ manager — just `cron + nohup + watchdog`, the pattern v1/v2 already use
 
 ## Layout on Whatbox
 
-```
+```text
 ~/webradio-v3/
 ├── apps/engine/dist/
 │   └── index.js              # built engine entry (npm run build)

--- a/deploy/crontab.example
+++ b/deploy/crontab.example
@@ -1,0 +1,26 @@
+# Pavoia Webradio v3 — Whatbox crontab entries.
+#
+# Install (additive — preserves any other entries you already have):
+#   crontab -l > /tmp/cron.bak
+#   cat /tmp/cron.bak ~/webradio-v3/deploy/crontab.example | crontab -
+#   crontab -l | grep webradio-v3   # verify
+#
+# Or replace the entire crontab (DESTROYS ANY OTHER ENTRIES):
+#   crontab ~/webradio-v3/deploy/crontab.example
+#
+# Remove later:
+#   crontab -l | grep -v webradio-v3 | crontab -
+#
+# Watch the live decisions:
+#   tail -f ~/webradio-v3/logs/cron.log
+
+# Start the engine 10 s after every reboot. The sleep gives Plex Media Server
+# time to come up first (the engine fails fast if Plex isn't reachable on
+# boot, then the watchdog respawns it within ~3 minutes — but the 10 s lead
+# avoids the noise on the common case).
+@reboot sleep 10 && ~/webradio-v3/bin/start-engine.sh >>~/webradio-v3/logs/cron.log 2>&1
+
+# Probe /api/health every minute. Restarts on 3 consecutive HTTP 000 (Req J).
+# 5xx means alive-but-degraded and does NOT trigger restart — restart would
+# destroy diagnostic state.
+* * * * * ~/webradio-v3/bin/watchdog.sh >>~/webradio-v3/logs/cron.log 2>&1

--- a/deploy/env.example
+++ b/deploy/env.example
@@ -1,0 +1,95 @@
+# Pavoia Webradio v3 — engine + wrapper environment.
+#
+# Copy to ~/.config/radio/env on Whatbox (mode 0600 — contains the Plex token):
+#   mkdir -p ~/.config/radio && chmod 700 ~/.config/radio
+#   cp deploy/env.example ~/.config/radio/env
+#   chmod 600 ~/.config/radio/env
+#   $EDITOR ~/.config/radio/env
+#
+# Sourced by deploy/bin/start-engine.sh and deploy/bin/watchdog.sh; the engine
+# inherits these via process environment. All paths must be ABSOLUTE.
+#
+# RADIO_HOME and RADIO_ENV_FILE are NOT settable here — both wrappers read
+# them BEFORE this file is sourced. To override either, set them in the
+# crontab line itself (e.g. RADIO_HOME=/srv/webradio ~/webradio-v3/bin/...).
+
+# ============================================================================
+# Plex (REQUIRED)
+# ============================================================================
+
+# Plex Media Server base URL. http:// or https:// only. Trailing slashes stripped.
+# On Whatbox: 127.0.0.1:31711 — NOT the standard 32400 (see WEEK0_LOG.md).
+PLEX_BASE_URL=http://127.0.0.1:31711
+
+# Plex auth token. Obtain from
+#   ~/Library/Application Support/Plex Media Server/Preferences.xml
+# (PlexOnlineToken attribute). Sent as X-Plex-Token header, never logged.
+PLEX_TOKEN=PASTE_REAL_TOKEN_HERE
+
+# Single library root. Engine rejects any track whose Plex Part.file resolves
+# outside this directory (Req D — defense against malformed Plex responses).
+PLEX_LIBRARY_ROOT=/home/yolan/files/plex_music_library/opus
+
+# ============================================================================
+# HLS output (REQUIRED)
+# ============================================================================
+
+# Per-stage HLS lands at $HLS_ROOT/<stageId>/index.m3u8 + seg-NNNNN.ts.
+# Whatbox prod: tmpfs under UID prefix (Req F).
+HLS_ROOT=/dev/shm/1008/radio-hls
+
+# Pre-recorded silence loop for empty playlists. Validated at supervisor start
+# (Req O). Generate once with:
+#   ffmpeg -f lavfi -i anullsrc=r=44100:cl=stereo -t 10 \
+#          -c:a aac -b:a 128k ~/webradio-v3/assets/curating.aac
+FALLBACK_FILE=/home/yolan/webradio-v3/assets/curating.aac
+
+# ============================================================================
+# Engine tunables (optional — defaults shown commented)
+# Source: apps/engine/src/config.ts
+# ============================================================================
+
+# ffmpeg binary. Bare name (looked up on PATH) or absolute path.
+#FFMPEG_BIN=ffmpeg
+
+# Plex playlist poll cadence. Minimum 1000 ms; default 60000 (Req: every 60 s).
+#PLEX_POLL_INTERVAL_MS=60000
+
+# Engine HTTP port. Range 1–65535. Watchdog probes /api/health on this port.
+#ENGINE_PORT=3001
+
+# Set to "true" to skip Plex client + supervisors entirely (HTTP-only mode).
+# /api/stages/:id/now returns 503. Useful for canary deploys.
+#ENGINE_DISABLE_STAGES=
+
+# ============================================================================
+# start-engine.sh tunables (optional — defaults shown commented)
+# Source: deploy/bin/start-engine.sh
+# ============================================================================
+
+# How long to wait for an in-flight engine to drain (graceful shutdown) before
+# treating it as wedged. Engine's SHUTDOWN_TIMEOUT_MS is 15 s; the 20 s
+# default gives a small buffer. Range 0–600.
+#ENGINE_DRAIN_WAIT_SECS=20
+
+# How long to wait for a freshly-spawned engine to respond 2xx on /api/health
+# before giving up and killing it. Real bootstrap is 1–5 s; 15 s is generous.
+# Range 0–600.
+#ENGINE_HEALTH_WAIT_SECS=15
+
+# ============================================================================
+# watchdog.sh tunables (optional — defaults shown commented)
+# Source: deploy/bin/watchdog.sh
+# ============================================================================
+
+# Number of consecutive HTTP 000 (connection refused) responses before
+# triggering a restart. Per Req J: 3. Range 1–100.
+#WATCHDOG_FAILURE_THRESHOLD=3
+
+# How long to wait for SIGTERM to take effect before escalating to SIGKILL.
+# Should be ≥ engine's SHUTDOWN_TIMEOUT_MS (15 s). Range 0–600.
+#WATCHDOG_TERM_WAIT_SECS=15
+
+# How long to wait for SIGKILL to take effect before giving up.
+# Range 0–600.
+#WATCHDOG_KILL_WAIT_SECS=5


### PR DESCRIPTION
## What

Third (and final code) slice of Week 1 Task 6. Three new files in `deploy/`:

- **`env.example`** (95 LOC) — every env var both wrappers + the engine read, organized REQUIRED vs optional-with-defaults. Operator copies to `~/.config/radio/env`, edits 5 REQUIRED values, done. Optional knobs are commented-out at their defaults so the file doubles as inline reference docs.
- **`crontab.example`** (26 LOC) — the two cron lines (`@reboot` start + per-minute watchdog) with header comments covering additive install, full-replacement install, removal, and live tailing.
- **`README.md`** (149 LOC) — operator runbook: layout diagram, 7-step first-time install, 3-step ongoing deploy, stop procedure, 5 troubleshooting scenarios.

## Why

Tasks 6 slice 1 (`start-engine.sh`) and slice 2 (`watchdog.sh`) shipped the executable plumbing. This slice ships the docs/config that turn the wrappers into a complete deploy story for an operator on Whatbox. Without these, someone with the rsync'd files would have to read the wrappers' source to know which env vars to set.

After this lands, Task 7 is just: do the actual rsync to Whatbox, follow the README's first-time install, hear the radio.

## Smoke test (4 cases, all green)

1. Symlinked layout works end-to-end — engine starts via `bin/` symlinks, env propagates through `start-engine.sh` into the engine process (PLEX_TOKEN, PLEX_BASE_URL, HLS_ROOT all visible from the engine's perspective).
2. `watchdog.sh` via `bin/` symlink probes successfully and finds `start-engine.sh`.
3. Minimal env file (only the 5 REQUIRED vars uncommented) starts the engine cleanly — confirms the optional-with-default defaults all work without explicit overrides.
4. `crontab.example` has exactly 2 command lines and both log to `~/webradio-v3/logs/cron.log`.

## What's NOT in this PR

- The actual deployment to `v3.nicemouth.box.ca` (Task 7 — separate PR or no PR, depending on whether deploy automation lives in the repo).
- Items 2, 4, 5, 6 from issue #15 (still deferred polish).

## Test plan

- [x] Local smoke test (4 cases)
- [x] Pre-push CodeRabbit clean
- [x] 230/230 engine tests still green
- [ ] Codex `/codex review --base main` clean
- [ ] CodeRabbit GitHub App clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a comprehensive deployment runbook for installing, configuring, running, and troubleshooting the Pavoia Webradio v3 engine on target hosts.
  * Added an example scheduler/crontab configuration to manage engine startup and periodic health probes.
  * Added an environment/template file documenting required and optional runtime variables and operational tunables for wrappers and the engine.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->