### PR TITLE
chore(deploy): close out issue #15 polish items 2, 4, 5, 6

### DIFF
--- a/deploy/bin/start-engine.sh
+++ b/deploy/bin/start-engine.sh
@@ -32,8 +32,6 @@ umask 077
 log() { printf '[start-engine] %s\n' "$*" >&2; }
 die() { log "ERROR: $*"; exit 1; }
 is_pid() { [[ "$1" =~ ^[1-9][0-9]*$ ]]; }
-# Read /proc/$pid/cmdline as a space-joined string. Returns empty if the
-# pid no longer exists or proc isn't available.
 # Returns 0 iff /proc/<pid>/cmdline represents OUR engine: argv[0] basenames
 # to "node" AND $entry appears as a complete argv token.
 #

--- a/deploy/bin/start-engine.sh
+++ b/deploy/bin/start-engine.sh
@@ -40,6 +40,23 @@ pid_cmdline() {
   # `set -e`. [#15 item 3]
   cat "/proc/$1/cmdline" 2>/dev/null | tr '\0' ' ' || true
 }
+# Returns 0 iff the cmdline string represents OUR engine: argv[0] basenames
+# to "node" AND $ENGINE_ENTRY appears as a complete argv token. The previous
+# substring match (`*" $entry "*`) false-positived on commands like
+# `vim apps/engine/dist/index.js` where the path is just an argument to a
+# non-node program. [#15 item 6]
+is_our_engine() {
+  local cmdline="$1" entry="$2"
+  # shellcheck disable=SC2206  # we want word-splitting on the cmdline
+  local argv=( $cmdline )
+  [ "${#argv[@]}" -ge 2 ] || return 1
+  [ "${argv[0]##*/}" = "node" ] || return 1
+  local i
+  for ((i=1; i<${#argv[@]}; i++)); do
+    [ "${argv[i]}" = "$entry" ] && return 0
+  done
+  return 1
+}
 
 RADIO_HOME="${RADIO_HOME:-$HOME/webradio-v3}"
 ENV_FILE="${RADIO_ENV_FILE:-$HOME/.config/radio/env}"
@@ -99,12 +116,28 @@ mkdir -p "$LOG_DIR" "$RUN_DIR"
 # engine is still alive. That keeps the real lock semantics tight on
 # "wrapper in flight" instead of accidentally widening to "engine alive."
 exec 9>"$LOCK_FILE"
-if ! flock -n 9; then
-  log "another start-engine.sh holds the lock ($LOCK_FILE); nothing to do"
-  exit 0
+# Distinguish lock contention (flock exit 1, idempotent no-op) from any
+# other flock failure (kernel rejected, fd issues — die loudly so cron
+# doesn't silently report success on a wrapper that did nothing). [#15 item 2]
+if flock -n 9; then
+  : # acquired
+else
+  rc=$?
+  case "$rc" in
+    1) log "another start-engine.sh holds the lock ($LOCK_FILE); nothing to do"; exit 0 ;;
+    *) die "flock failed unexpectedly (exit=$rc)" ;;
+  esac
 fi
 
 ENGINE_PORT="${ENGINE_PORT:-3001}"
+# Validate ENGINE_PORT before constructing the health URL or ss filter — a
+# non-numeric or out-of-range value would otherwise produce cryptic curl/ss
+# errors. The engine's own loadConfig validates again at boot, but failing
+# here gives the operator the same clear punch-list error format. [#15 item 5]
+case "$ENGINE_PORT" in
+  ''|*[!0-9]*) die "ENGINE_PORT must be a positive integer, got '$ENGINE_PORT'" ;;
+esac
+[ "$ENGINE_PORT" -ge 1 ] && [ "$ENGINE_PORT" -le 65535 ] || die "ENGINE_PORT out of range [1..65535], got $ENGINE_PORT"
 HEALTH_URL="http://127.0.0.1:${ENGINE_PORT}/api/health"
 
 # Returns 0 iff /api/health responds with a 2xx within 2 s. curl writes the
@@ -147,8 +180,8 @@ if [ -f "$PID_FILE" ]; then
     if [ -z "$pid_uid" ] || [ "$pid_uid" != "$our_uid" ]; then
       log "pid $existing_pid alive but not owned by us (uid=${pid_uid:-?} vs ${our_uid}); treating as stale"
       rm -f "$PID_FILE"
-    elif ! [[ " $cmdline " == *" $ENGINE_ENTRY "* ]]; then
-      log "pid $existing_pid alive but cmdline does not include $ENGINE_ENTRY (probably another node service); treating as stale"
+    elif ! is_our_engine "$cmdline" "$ENGINE_ENTRY"; then
+      log "pid $existing_pid alive but cmdline doesn't match our engine (argv[0] != node OR $ENGINE_ENTRY not an argv token); treating as stale"
       rm -f "$PID_FILE"
     elif probe_health && { sleep 0.25; probe_health; }; then
       # Two probes 250 ms apart confirm the engine isn't just a few
@@ -238,7 +271,17 @@ if [ "$healthy" != "yes" ]; then
   log "engine pid $engine_pid did not become healthy within ${health_elapsed}s; killing"
   kill -TERM "$engine_pid" 2>/dev/null || true
   sleep 1
-  kill -KILL "$engine_pid" 2>/dev/null || true
+  # Re-check identity before SIGKILL — if PID was recycled to an unrelated
+  # same-user process during the SIGTERM grace window, don't kill it.
+  # [#15 item 4]
+  if kill -0 "$engine_pid" 2>/dev/null; then
+    cmdline_now="$(pid_cmdline "$engine_pid")"
+    if is_our_engine "$cmdline_now" "$ENGINE_ENTRY"; then
+      kill -KILL "$engine_pid" 2>/dev/null || true
+    else
+      log "pid $engine_pid no longer matches our engine cmdline; skipping SIGKILL"
+    fi
+  fi
   rm -f "$PID_FILE"
   die "engine failed to come up healthy in ${health_elapsed}s — check $LOG_FILE"
 fi

--- a/deploy/bin/start-engine.sh
+++ b/deploy/bin/start-engine.sh
@@ -34,21 +34,25 @@ die() { log "ERROR: $*"; exit 1; }
 is_pid() { [[ "$1" =~ ^[1-9][0-9]*$ ]]; }
 # Read /proc/$pid/cmdline as a space-joined string. Returns empty if the
 # pid no longer exists or proc isn't available.
-pid_cmdline() {
-  # `cat | tr` returns 0 with empty output if the proc file vanishes mid-call —
-  # avoids the [ -r ] / read TOCTOU window that could abort the script under
-  # `set -e`. [#15 item 3]
-  cat "/proc/$1/cmdline" 2>/dev/null | tr '\0' ' ' || true
-}
-# Returns 0 iff the cmdline string represents OUR engine: argv[0] basenames
-# to "node" AND $ENGINE_ENTRY appears as a complete argv token. The previous
-# substring match (`*" $entry "*`) false-positived on commands like
-# `vim apps/engine/dist/index.js` where the path is just an argument to a
-# non-node program. [#15 item 6]
+# Returns 0 iff /proc/<pid>/cmdline represents OUR engine: argv[0] basenames
+# to "node" AND $entry appears as a complete argv token.
+#
+# Reads /proc directly with NUL-aware splitting via `mapfile -d ''` so that
+# argv tokens containing whitespace are preserved — the previous version
+# converted NUL→space and word-split, which broke for ENGINE_ENTRY paths
+# under a RADIO_HOME containing whitespace (e.g. '/srv/pavoia radio').
+# [#15 item 6, Codex round-1 P2 on PR #18]
+#
+# Original substring match was insufficient: `*" $entry "*` matched
+# `vim apps/engine/dist/index.js` because the path appeared as an argv to
+# a non-node program. The argv[0]=node + entry-as-token check fixes that.
 is_our_engine() {
-  local cmdline="$1" entry="$2"
-  # shellcheck disable=SC2206  # we want word-splitting on the cmdline
-  local argv=( $cmdline )
+  local pid="$1" entry="$2"
+  local -a argv
+  # mapfile -d '' splits on NUL (bash 4.4+, available on all modern Linux).
+  # 2>/dev/null + || return 1 covers the TOCTOU window where the pid exits
+  # between the caller's kill -0 check and our open here.
+  mapfile -d '' argv < "/proc/$pid/cmdline" 2>/dev/null || return 1
   [ "${#argv[@]}" -ge 2 ] || return 1
   [ "${argv[0]##*/}" = "node" ] || return 1
   local i
@@ -175,12 +179,11 @@ if [ -f "$PID_FILE" ]; then
     # the wrapper through the full drain wait then exit 1 "wedged," looping
     # every watchdog tick until manual cleanup. [Codex round-3 P2]
     pid_uid="$(ps -o uid= -p "$existing_pid" 2>/dev/null | tr -d '[:space:]' || true)"
-    cmdline="$(pid_cmdline "$existing_pid")"
     our_uid="$(id -u)"
     if [ -z "$pid_uid" ] || [ "$pid_uid" != "$our_uid" ]; then
       log "pid $existing_pid alive but not owned by us (uid=${pid_uid:-?} vs ${our_uid}); treating as stale"
       rm -f "$PID_FILE"
-    elif ! is_our_engine "$cmdline" "$ENGINE_ENTRY"; then
+    elif ! is_our_engine "$existing_pid" "$ENGINE_ENTRY"; then
       log "pid $existing_pid alive but cmdline doesn't match our engine (argv[0] != node OR $ENGINE_ENTRY not an argv token); treating as stale"
       rm -f "$PID_FILE"
     elif probe_health && { sleep 0.25; probe_health; }; then
@@ -275,8 +278,7 @@ if [ "$healthy" != "yes" ]; then
   # same-user process during the SIGTERM grace window, don't kill it.
   # [#15 item 4]
   if kill -0 "$engine_pid" 2>/dev/null; then
-    cmdline_now="$(pid_cmdline "$engine_pid")"
-    if is_our_engine "$cmdline_now" "$ENGINE_ENTRY"; then
+    if is_our_engine "$engine_pid" "$ENGINE_ENTRY"; then
       kill -KILL "$engine_pid" 2>/dev/null || true
     else
       log "pid $engine_pid no longer matches our engine cmdline; skipping SIGKILL"

--- a/deploy/bin/watchdog.sh
+++ b/deploy/bin/watchdog.sh
@@ -35,18 +35,25 @@ umask 077
 log() { printf '[watchdog] %s\n' "$*" >&2; }
 die() { log "ERROR: $*"; exit 1; }
 is_pid() { [[ "$1" =~ ^[1-9][0-9]*$ ]]; }
-pid_cmdline() {
-  cat "/proc/$1/cmdline" 2>/dev/null | tr '\0' ' ' || true
-}
-# Returns 0 iff the cmdline string represents OUR engine: argv[0] basenames
-# to "node" AND $ENGINE_ENTRY appears as a complete argv token. The previous
-# substring match (`*" $entry "*`) false-positived on commands like
-# `vim apps/engine/dist/index.js` where the path is just an argument to a
-# non-node program. [#15 item 6]
+# Returns 0 iff /proc/<pid>/cmdline represents OUR engine: argv[0] basenames
+# to "node" AND $entry appears as a complete argv token.
+#
+# Reads /proc directly with NUL-aware splitting via `mapfile -d ''` so that
+# argv tokens containing whitespace are preserved — the previous version
+# converted NUL→space and word-split, which broke for ENGINE_ENTRY paths
+# under a RADIO_HOME containing whitespace (e.g. '/srv/pavoia radio').
+# [#15 item 6, Codex round-1 P2 on PR #18]
+#
+# Original substring match was insufficient: `*" $entry "*` matched
+# `vim apps/engine/dist/index.js` because the path appeared as an argv to
+# a non-node program. The argv[0]=node + entry-as-token check fixes that.
 is_our_engine() {
-  local cmdline="$1" entry="$2"
-  # shellcheck disable=SC2206  # we want word-splitting on the cmdline
-  local argv=( $cmdline )
+  local pid="$1" entry="$2"
+  local -a argv
+  # mapfile -d '' splits on NUL (bash 4.4+, available on all modern Linux).
+  # 2>/dev/null + || return 1 covers the TOCTOU window where the pid exits
+  # between the caller's kill -0 check and our open here.
+  mapfile -d '' argv < "/proc/$pid/cmdline" 2>/dev/null || return 1
   [ "${#argv[@]}" -ge 2 ] || return 1
   [ "${argv[0]##*/}" = "node" ] || return 1
   local i
@@ -204,8 +211,7 @@ wait_pid_exit() {
 }
 
 if [ -n "$existing_pid" ] && kill -0 "$existing_pid" 2>/dev/null; then
-  cmdline="$(pid_cmdline "$existing_pid")"
-  if is_our_engine "$cmdline" "$ENGINE_ENTRY"; then
+  if is_our_engine "$existing_pid" "$ENGINE_ENTRY"; then
     log "sending SIGTERM to engine pid $existing_pid"
     kill -TERM "$existing_pid" 2>/dev/null || true
     if wait_pid_exit "$existing_pid" "$TERM_WAIT_SECS"; then
@@ -214,8 +220,7 @@ if [ -n "$existing_pid" ] && kill -0 "$existing_pid" 2>/dev/null; then
       log "engine pid $existing_pid did not exit within ${TERM_WAIT_SECS}s — escalating to SIGKILL"
       # Re-check cmdline before SIGKILL — if the PID was recycled to
       # something else during our wait, don't kill the unrelated process.
-      cmdline_now="$(pid_cmdline "$existing_pid")"
-      if is_our_engine "$cmdline_now" "$ENGINE_ENTRY"; then
+      if is_our_engine "$existing_pid" "$ENGINE_ENTRY"; then
         kill -KILL "$existing_pid" 2>/dev/null || true
         if ! wait_pid_exit "$existing_pid" "$KILL_WAIT_SECS"; then
           die "engine pid $existing_pid still alive after SIGKILL; aborting restart (next tick will retry)"

--- a/deploy/bin/watchdog.sh
+++ b/deploy/bin/watchdog.sh
@@ -38,6 +38,23 @@ is_pid() { [[ "$1" =~ ^[1-9][0-9]*$ ]]; }
 pid_cmdline() {
   cat "/proc/$1/cmdline" 2>/dev/null | tr '\0' ' ' || true
 }
+# Returns 0 iff the cmdline string represents OUR engine: argv[0] basenames
+# to "node" AND $ENGINE_ENTRY appears as a complete argv token. The previous
+# substring match (`*" $entry "*`) false-positived on commands like
+# `vim apps/engine/dist/index.js` where the path is just an argument to a
+# non-node program. [#15 item 6]
+is_our_engine() {
+  local cmdline="$1" entry="$2"
+  # shellcheck disable=SC2206  # we want word-splitting on the cmdline
+  local argv=( $cmdline )
+  [ "${#argv[@]}" -ge 2 ] || return 1
+  [ "${argv[0]##*/}" = "node" ] || return 1
+  local i
+  for ((i=1; i<${#argv[@]}; i++)); do
+    [ "${argv[i]}" = "$entry" ] && return 0
+  done
+  return 1
+}
 
 RADIO_HOME="${RADIO_HOME:-$HOME/webradio-v3}"
 ENV_FILE="${RADIO_ENV_FILE:-$HOME/.config/radio/env}"
@@ -188,7 +205,7 @@ wait_pid_exit() {
 
 if [ -n "$existing_pid" ] && kill -0 "$existing_pid" 2>/dev/null; then
   cmdline="$(pid_cmdline "$existing_pid")"
-  if [[ " $cmdline " == *" $ENGINE_ENTRY "* ]]; then
+  if is_our_engine "$cmdline" "$ENGINE_ENTRY"; then
     log "sending SIGTERM to engine pid $existing_pid"
     kill -TERM "$existing_pid" 2>/dev/null || true
     if wait_pid_exit "$existing_pid" "$TERM_WAIT_SECS"; then
@@ -198,7 +215,7 @@ if [ -n "$existing_pid" ] && kill -0 "$existing_pid" 2>/dev/null; then
       # Re-check cmdline before SIGKILL — if the PID was recycled to
       # something else during our wait, don't kill the unrelated process.
       cmdline_now="$(pid_cmdline "$existing_pid")"
-      if [[ " $cmdline_now " == *" $ENGINE_ENTRY "* ]]; then
+      if is_our_engine "$cmdline_now" "$ENGINE_ENTRY"; then
         kill -KILL "$existing_pid" 2>/dev/null || true
         if ! wait_pid_exit "$existing_pid" "$KILL_WAIT_SECS"; then
           die "engine pid $existing_pid still alive after SIGKILL; aborting restart (next tick will retry)"
@@ -209,7 +226,7 @@ if [ -n "$existing_pid" ] && kill -0 "$existing_pid" 2>/dev/null; then
       fi
     fi
   else
-    log "pid $existing_pid alive but cmdline does not include $ENGINE_ENTRY; not killing (start-engine.sh will sort it out)"
+    log "pid $existing_pid alive but cmdline doesn't match our engine (argv[0] != node OR $ENGINE_ENTRY not an argv token); not killing (start-engine.sh will sort it out)"
   fi
 fi
 


### PR DESCRIPTION
Bundles the four advisory items deferred from PR #14 (start-engine.sh) and PR #16 (watchdog.sh) into one cleanup. All addressed in both wrappers consistently via a shared `is_our_engine` helper.

## Items addressed

| # | Issue | Fix |
|---|---|---|
| 2 | flock failure indistinguishable from contention (start-engine.sh) | Distinguish exit 1 (idempotent) from any other exit (die loudly) — same pattern watchdog.sh already used. |
| 4 | SIGKILL on possibly-recycled PID (start-engine.sh) | Re-check `pid_cmdline` + `is_our_engine` before SIGKILL after the SIGTERM grace; skip kill if PID no longer matches. |
| 5 | `ENGINE_PORT` not validated before use (start-engine.sh) | Numeric + range check matching the existing pattern for the wait-knob env vars. |
| 6 | cmdline substring match could trigger on `vim apps/engine/dist/index.js` (both scripts) | New `is_our_engine` helper: splits cmdline → argv, requires argv[0] basename = `node` AND `$ENGINE_ENTRY` appears as a complete argv token. Replaces the previous brittle `*" $ENGINE_ENTRY "*` match in 3 sites across both scripts. |

After this lands, **issue #15 is fully closed** (items 1+3 in PR #16, the round-3 [P3] also in PR #16, and 2/4/5/6 here).

## Verification (5-case smoke test, all green)

- **R1** (item 5): `ENGINE_PORT=abc` → die "must be a positive integer". `ENGINE_PORT=99999` → die "out of range".
- **R2** (item 6): PID with `argv = [vim, ENGINE_ENTRY]` → wrapper says "doesn't match our engine", treats as stale, spawns fresh node. **vim left alive (would have been SIGKILL'd before).**
- **R3** (item 6): PID is real `node` but running a *different* JS file (no ENGINE_ENTRY in argv) → also treated as stale, fresh spawn.
- **R4** (regression): real engine spawned by the wrapper → still detected as ours, idempotent re-invoke goes through HTTP-probe branch as before.
- **R5** (item 6, watchdog): cross-script flow. PID file points at vim-like, watchdog's failure threshold reached, watchdog says "doesn't match our engine — not killing", invokes start-engine.sh, which independently agrees and spawns fresh.

230/230 engine tests still green. Pre-push CR clean.

## Risk

Low — all changes are additive (new helper) or defensive (broader rejection of non-engine PIDs). No change to the happy path; existing smoke tests for both scripts pass unchanged.

## Test plan

- [x] Local smoke test (5 cases targeting the 4 fixes + regression)
- [x] Pre-push CodeRabbit clean
- [x] Engine 230/230 tests pass
- [ ] Codex `/codex review --base main` clean
- [ ] CodeRabbit GitHub App clean
- [ ] Triple-signoff merge gate satisfied

Closes #15.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened process identification to avoid misidentifying unrelated processes.
  * Validated startup configuration (port) to ensure correct values before initialization.
  * Improved safety of forced shutdowns by re-verifying process identity before SIGKILL.
  * Made lock acquisition handling explicit to treat contention as a clean no-op.
  * Enhanced monitoring reliability with more precise process detection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->