### PR TITLE
docs(deploy): exclude tsconfig.tsbuildinfo from rsync

### DIFF
--- a/deploy/README.md
+++ b/deploy/README.md
@@ -50,6 +50,7 @@ From your dev machine:
 
 ```bash
 rsync -av --exclude .git --exclude node_modules --exclude dist \
+      --exclude 'tsconfig.tsbuildinfo' \
       ./ whatbox:~/webradio-v3/
 ssh whatbox 'cd ~/webradio-v3 && npm ci && npm run build --workspace=@pavoia/engine'
 ```
@@ -104,6 +105,7 @@ crontab -l | grep webradio-v3                                    # verify
 ```bash
 # 1. Push code
 rsync -av --exclude .git --exclude node_modules --exclude dist \
+      --exclude 'tsconfig.tsbuildinfo' \
       ./ whatbox:~/webradio-v3/
 
 # 2. Build

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -50,7 +50,7 @@ From your dev machine:
 
 ```bash
 rsync -av --exclude .git --exclude node_modules --exclude dist \
-      --exclude 'tsconfig.tsbuildinfo' \
+      --exclude '*.tsbuildinfo' \
       ./ whatbox:~/webradio-v3/
 ssh whatbox 'cd ~/webradio-v3 && npm ci && npm run build --workspace=@pavoia/engine'
 ```
@@ -105,7 +105,7 @@ crontab -l | grep webradio-v3                                    # verify
 ```bash
 # 1. Push code
 rsync -av --exclude .git --exclude node_modules --exclude dist \
-      --exclude 'tsconfig.tsbuildinfo' \
+      --exclude '*.tsbuildinfo' \
       ./ whatbox:~/webradio-v3/
 
 # 2. Build


### PR DESCRIPTION
## Summary

Operators following `deploy/README.md` on a working tree where `npm run build` was already run locally would get an empty `apps/engine/dist/` on Whatbox: `tsc` reads the rsync'd `tsconfig.tsbuildinfo` and decides the project is up to date, so it skips emit.

The existing `--exclude dist` doesn't help — `tsc` never tries to write the files in the first place because the buildinfo says "all good."

This adds `--exclude 'tsconfig.tsbuildinfo'` to both rsync invocations in the README (initial deploy and ongoing deploys).

## Why

Caught during Task 7 (live Whatbox deploy, May 2026). After `npm ci && npm run build`, `apps/engine/dist/` was empty. Verbose tsc showed:

```
Project 'apps/engine/tsconfig.json' is up to date because newest input
'apps/engine/src/app.ts' is older than output 'apps/engine/tsconfig.tsbuildinfo'
```

Worked around live by deleting `tsconfig.tsbuildinfo` files on remote and rebuilding. This README change prevents the trap for the next operator.

## Test plan

- [x] CodeRabbit pre-push review: clean
- [x] Tests pass locally (230/230)
- [ ] CodeRabbit GH App review on the pushed HEAD: pending
- [ ] Codex review: pending
- [x] Verified live: rsync with the new exclusion produces a tree where `npm run build` emits `apps/engine/dist/index.js` correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated deployment instructions to exclude TypeScript build metadata files from being transferred during both first-time installs and ongoing deploys, reducing unnecessary file copy and streamlining deployments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->