### PR TITLE
feat(engine): reap orphan ffmpeg children on bootstrap (issue #19)

### DIFF
--- a/apps/engine/src/bootstrap.test.ts
+++ b/apps/engine/src/bootstrap.test.ts
@@ -224,6 +224,9 @@ describe("bootstrap — startup", () => {
       audioStages: TWO_STAGES,
       pollerSchedule: sched.schedule,
       log: () => {},
+      // Skip real /proc scan so the timing assertion measures Plex
+      // fetch parallelism, not /proc walk overhead.
+      cleanupOrphanFfmpegsImpl: async () => ({ killed: 0, attempted: 0 }),
     });
 
     const elapsed = Date.now() - start;
@@ -753,6 +756,138 @@ describe("bootstrap — HTTP integration", () => {
     assert.equal(res.status, 503);
     const body = (await res.json()) as { error: string };
     assert.equal(body.error, "stage_not_running");
+
+    await result.shutdown();
+  });
+});
+
+describe("bootstrap — orphan ffmpeg reaper (issue #19)", () => {
+  it("calls cleanupOrphanFfmpegsImpl before any supervisor starts", async () => {
+    const plex = scriptedPlex();
+    plex.setNext(100, []);
+    const { fakeStartStage, created } = fakeStartStageFactory();
+    const sched = manualSchedule();
+
+    const callOrder: string[] = [];
+    const fakeCleanup: typeof import("./orphan-cleanup.ts").cleanupOrphanFfmpegs =
+      async (opts) => {
+        callOrder.push("cleanup");
+        assert.equal(opts.hlsRoot, BASE_CONFIG.hlsRoot);
+        return { killed: 0, attempted: 0 };
+      };
+    // Stamp every supervisor creation so we can check ordering.
+    const stampedFakeStartStage: typeof fakeStartStage = (cfg) => {
+      callOrder.push(`startStage:${cfg.stageId}`);
+      return fakeStartStage(cfg);
+    };
+
+    const result = await bootstrap({
+      config: BASE_CONFIG,
+      plexClient: plex.client,
+      startStageImpl: stampedFakeStartStage,
+      audioStages: TWO_STAGES.slice(0, 1),
+      pollerSchedule: sched.schedule,
+      log: () => {},
+      cleanupOrphanFfmpegsImpl: fakeCleanup,
+    });
+
+    assert.equal(callOrder[0], "cleanup", "cleanup must run first");
+    assert.ok(callOrder.includes("startStage:opening"));
+    assert.equal(created.length, 1);
+
+    await result.shutdown();
+  });
+
+  it("logs the reap result when orphans are found", async () => {
+    const plex = scriptedPlex();
+    plex.setNext(100, []);
+    const { fakeStartStage } = fakeStartStageFactory();
+    const sched = manualSchedule();
+
+    const fakeCleanup: typeof import("./orphan-cleanup.ts").cleanupOrphanFfmpegs =
+      async () => ({ killed: 3, attempted: 3 });
+
+    const lines: string[] = [];
+    const result = await bootstrap({
+      config: BASE_CONFIG,
+      plexClient: plex.client,
+      startStageImpl: fakeStartStage,
+      audioStages: TWO_STAGES.slice(0, 1),
+      pollerSchedule: sched.schedule,
+      log: (l) => lines.push(l),
+      cleanupOrphanFfmpegsImpl: fakeCleanup,
+    });
+
+    assert.ok(
+      lines.some(
+        (l) =>
+          l.includes("orphan ffmpeg reap") &&
+          l.includes("attempted=3") &&
+          l.includes("killed=3"),
+      ),
+      `expected reap-summary log; got: ${JSON.stringify(lines)}`,
+    );
+
+    await result.shutdown();
+  });
+
+  it("does NOT log a reap line when there were no orphans (clean start)", async () => {
+    const plex = scriptedPlex();
+    plex.setNext(100, []);
+    const { fakeStartStage } = fakeStartStageFactory();
+    const sched = manualSchedule();
+
+    const fakeCleanup: typeof import("./orphan-cleanup.ts").cleanupOrphanFfmpegs =
+      async () => ({ killed: 0, attempted: 0 });
+
+    const lines: string[] = [];
+    const result = await bootstrap({
+      config: BASE_CONFIG,
+      plexClient: plex.client,
+      startStageImpl: fakeStartStage,
+      audioStages: TWO_STAGES.slice(0, 1),
+      pollerSchedule: sched.schedule,
+      log: (l) => lines.push(l),
+      cleanupOrphanFfmpegsImpl: fakeCleanup,
+    });
+
+    assert.ok(
+      !lines.some((l) => l.includes("orphan ffmpeg reap")),
+      "clean start should not log a reap summary",
+    );
+
+    await result.shutdown();
+  });
+
+  it("continues bootstrap even if cleanup throws (non-fatal)", async () => {
+    const plex = scriptedPlex();
+    plex.setNext(100, []);
+    const { fakeStartStage, created } = fakeStartStageFactory();
+    const sched = manualSchedule();
+
+    const fakeCleanup: typeof import("./orphan-cleanup.ts").cleanupOrphanFfmpegs =
+      async () => {
+        throw new Error("simulated /proc unreadable");
+      };
+
+    const lines: string[] = [];
+    const result = await bootstrap({
+      config: BASE_CONFIG,
+      plexClient: plex.client,
+      startStageImpl: fakeStartStage,
+      audioStages: TWO_STAGES.slice(0, 1),
+      pollerSchedule: sched.schedule,
+      log: (l) => lines.push(l),
+      cleanupOrphanFfmpegsImpl: fakeCleanup,
+    });
+
+    // Engine still came up.
+    assert.equal(created.length, 1);
+    // Failure was logged as non-fatal.
+    assert.ok(
+      lines.some((l) => l.includes("orphan ffmpeg cleanup failed")),
+      `expected non-fatal failure log; got: ${JSON.stringify(lines)}`,
+    );
 
     await result.shutdown();
   });

--- a/apps/engine/src/bootstrap.test.ts
+++ b/apps/engine/src/bootstrap.test.ts
@@ -3,6 +3,15 @@ import assert from "node:assert/strict";
 import type { Stage, Track } from "@pavoia/shared";
 
 import { bootstrap } from "./bootstrap.ts";
+import type { cleanupOrphanFfmpegs } from "./orphan-cleanup.ts";
+
+/** Default to a no-op so tests don't walk real /proc or call real
+ *  process.kill. The orphan-reaper-specific test block injects its
+ *  own fake when behavior matters. */
+const NOOP_CLEANUP: typeof cleanupOrphanFfmpegs = async () => ({
+  killed: 0,
+  attempted: 0,
+});
 import type { EngineConfig } from "./config.ts";
 import type {
   FetchPlaylistResult,
@@ -170,6 +179,7 @@ describe("bootstrap — startup", () => {
       audioStages: TWO_STAGES,
       pollerSchedule: sched.schedule,
       log: () => {},
+      cleanupOrphanFfmpegsImpl: NOOP_CLEANUP,
     });
 
     assert.equal(result.registry.size, 2);
@@ -299,6 +309,7 @@ describe("bootstrap — startup", () => {
       ],
       pollerSchedule: sched.schedule,
       log: () => {},
+      cleanupOrphanFfmpegsImpl: NOOP_CLEANUP,
     });
 
     assert.equal(created.length, 1);
@@ -323,6 +334,7 @@ describe("bootstrap — Plex polling queues track updates", () => {
       audioStages: TWO_STAGES,
       pollerSchedule: sched.schedule,
       log: () => {},
+      cleanupOrphanFfmpegsImpl: NOOP_CLEANUP,
     });
 
     // Opening's tracks change — add track 3.
@@ -364,6 +376,7 @@ describe("bootstrap — Plex polling queues track updates", () => {
       audioStages: TWO_STAGES,
       pollerSchedule: sched.schedule,
       log: () => {},
+      cleanupOrphanFfmpegsImpl: NOOP_CLEANUP,
     });
 
     plex.setNext(100, [makeTrack(2), makeTrack(1)]); // reordered only
@@ -404,6 +417,7 @@ describe("bootstrap — Plex polling queues track updates", () => {
       audioStages: [fakeStage("opening", 100)],
       pollerSchedule: sched.schedule,
       log: () => {},
+      cleanupOrphanFfmpegsImpl: NOOP_CLEANUP,
     });
 
     // Simulate the original controller having reached a terminal
@@ -460,6 +474,7 @@ describe("bootstrap — controller liveness watcher (issue #12)", () => {
       audioStages: [fakeStage("opening", 100)],
       pollerSchedule: sched.schedule,
       log: () => {},
+      cleanupOrphanFfmpegsImpl: NOOP_CLEANUP,
     });
 
     assert.equal(created.length, 1);
@@ -504,6 +519,7 @@ describe("bootstrap — controller liveness watcher (issue #12)", () => {
       audioStages: [fakeStage("opening", 100)],
       pollerSchedule: sched.schedule,
       log: () => {},
+      cleanupOrphanFfmpegsImpl: NOOP_CLEANUP,
     });
 
     // Initiate shutdown — that flips the internal flag BEFORE
@@ -538,6 +554,7 @@ describe("bootstrap — controller liveness watcher (issue #12)", () => {
       audioStages: [fakeStage("opening", 100)],
       pollerSchedule: sched.schedule,
       log: () => {},
+      cleanupOrphanFfmpegsImpl: NOOP_CLEANUP,
     });
 
     // Kill controllers one at a time until the watcher stops
@@ -583,6 +600,7 @@ describe("bootstrap — controller liveness watcher (issue #12)", () => {
       audioStages: [fakeStage("opening", 100)],
       pollerSchedule: sched.schedule,
       log: () => {},
+      cleanupOrphanFfmpegsImpl: NOOP_CLEANUP,
     });
 
     // Burn the revival budget — same loop structure as the cap test
@@ -634,6 +652,7 @@ describe("bootstrap — controller liveness watcher (issue #12)", () => {
       audioStages: [fakeStage("opening", 100)],
       pollerSchedule: sched.schedule,
       log: () => {},
+      cleanupOrphanFfmpegsImpl: NOOP_CLEANUP,
     });
 
     // First poller tick changes the playlist; setTracks is called
@@ -673,6 +692,7 @@ describe("bootstrap — shutdown", () => {
       audioStages: TWO_STAGES,
       pollerSchedule: sched.schedule,
       log: () => {},
+      cleanupOrphanFfmpegsImpl: NOOP_CLEANUP,
     });
 
     await result.shutdown();
@@ -695,6 +715,7 @@ describe("bootstrap — shutdown", () => {
       audioStages: TWO_STAGES,
       pollerSchedule: sched.schedule,
       log: () => {},
+      cleanupOrphanFfmpegsImpl: NOOP_CLEANUP,
     });
 
     await Promise.all([
@@ -721,6 +742,7 @@ describe("bootstrap — HTTP integration", () => {
       audioStages: TWO_STAGES,
       pollerSchedule: sched.schedule,
       log: () => {},
+      cleanupOrphanFfmpegsImpl: NOOP_CLEANUP,
     });
 
     const res = await result.app.request("/api/stages/opening/now");
@@ -750,6 +772,7 @@ describe("bootstrap — HTTP integration", () => {
       audioStages: [fakeStage("opening", 100)],
       pollerSchedule: sched.schedule,
       log: () => {},
+      cleanupOrphanFfmpegsImpl: NOOP_CLEANUP,
     });
 
     const res = await result.app.request("/api/stages/closing/now");

--- a/apps/engine/src/bootstrap.test.ts
+++ b/apps/engine/src/bootstrap.test.ts
@@ -275,6 +275,7 @@ describe("bootstrap — startup", () => {
       audioStages: TWO_STAGES,
       pollerSchedule: sched.schedule,
       log: (line) => logged.push(line),
+      cleanupOrphanFfmpegsImpl: NOOP_CLEANUP,
     });
 
     assert.equal(result.registry.size, 2, "both stages registered");

--- a/apps/engine/src/bootstrap.ts
+++ b/apps/engine/src/bootstrap.ts
@@ -39,6 +39,7 @@ import {
   type PollerController,
   type StageBinding,
 } from "./stages/poller.ts";
+import { cleanupOrphanFfmpegs } from "./orphan-cleanup.ts";
 
 /** Subset of Plex client config the bootstrap layer derives from
  *  EngineConfig — extracted so tests can stub the client without
@@ -66,6 +67,9 @@ export interface BootstrapInput {
   /** Source of audio stages. Default: AUDIO_STAGES from @pavoia/shared.
    *  Tests use a smaller subset to keep parallelism bounded. */
   audioStages?: readonly Stage[];
+  /** Inject a custom orphan-ffmpeg reaper (tests). Default: real
+   *  `cleanupOrphanFfmpegs` against /proc. */
+  cleanupOrphanFfmpegsImpl?: typeof cleanupOrphanFfmpegs;
 }
 
 export interface BootstrapResult {
@@ -86,7 +90,37 @@ export async function bootstrap(
     log = (line) => console.log(line),
     audioStages = AUDIO_STAGES,
     pollerSchedule,
+    cleanupOrphanFfmpegsImpl = cleanupOrphanFfmpegs,
   } = input;
+
+  // Reap any ffmpeg processes left over from a previous engine run
+  // before any new supervisor starts. On crash recovery (kill -9,
+  // OOM, watchdog respawn after HTTP 000), the previous engine's
+  // ffmpeg children become orphans (PPID=1) and keep writing HLS
+  // segments until they hit a broken pipe or finish their input.
+  // If we don't reap them, the new ffmpegs spawn with `+append_list`
+  // and pick up the leftover m3u8, continuing the segment counter
+  // (e.g. start at 4060+ instead of 0). Verified live on Whatbox
+  // during Task 7 smoke-test (see issue #19).
+  //
+  // Non-fatal: if the cleanup itself fails, log and continue. The
+  // engine will still come up; orphans will just persist and rack up
+  // delete-segment warnings until they die naturally.
+  try {
+    const result = await cleanupOrphanFfmpegsImpl({
+      hlsRoot: config.hlsRoot,
+      log,
+    });
+    if (result.attempted > 0) {
+      log(
+        `[engine] orphan ffmpeg reap: attempted=${result.attempted} killed=${result.killed}`,
+      );
+    }
+  } catch (err) {
+    log(
+      `[engine] orphan ffmpeg cleanup failed (non-fatal): ${formatErr(err)}`,
+    );
+  }
 
   const plexClient =
     input.plexClient ??

--- a/apps/engine/src/orphan-cleanup.test.ts
+++ b/apps/engine/src/orphan-cleanup.test.ts
@@ -1,0 +1,406 @@
+import { describe, it, beforeEach, afterEach } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtemp, mkdir, writeFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import { cleanupOrphanFfmpegs } from "./orphan-cleanup.ts";
+
+/**
+ * Tests use a fake /proc directory rooted in a tmpdir. Each test
+ * builds the /proc/<pid>/cmdline entries it cares about, then runs
+ * the cleanup with a fake `killImpl` so we don't touch real
+ * processes.
+ *
+ * The fake kill simulates a process that dies on SIGTERM unless
+ * `simulateIgnoreSigterm` includes the pid (in which case only
+ * SIGKILL kills it).
+ */
+
+interface FakeKill {
+  killImpl: (pid: number, signal: NodeJS.Signals | 0) => void;
+  signals: { pid: number; signal: NodeJS.Signals | 0 }[];
+  /** Pids that survive SIGTERM (only SIGKILL kills them). */
+  ignoreSigterm: Set<number>;
+  /** Pids that die naturally before any signal arrives. */
+  alreadyDead: Set<number>;
+}
+
+function fakeKill(initialAlive: number[] = []): FakeKill {
+  const alive = new Set<number>(initialAlive);
+  const signals: { pid: number; signal: NodeJS.Signals | 0 }[] = [];
+  const ignoreSigterm = new Set<number>();
+  const alreadyDead = new Set<number>();
+
+  const killImpl = (pid: number, signal: NodeJS.Signals | 0) => {
+    signals.push({ pid, signal });
+    if (alreadyDead.has(pid) || !alive.has(pid)) {
+      const err: NodeJS.ErrnoException = new Error("ESRCH");
+      err.code = "ESRCH";
+      throw err;
+    }
+    if (signal === 0) return; // existence probe; alive
+    if (signal === "SIGKILL") {
+      alive.delete(pid);
+      return;
+    }
+    if (signal === "SIGTERM" && !ignoreSigterm.has(pid)) {
+      alive.delete(pid);
+      return;
+    }
+    // SIGTERM ignored: process keeps running
+  };
+
+  return { killImpl, signals, ignoreSigterm, alreadyDead };
+}
+
+const HLS_ROOT = "/dev/shm/1008/radio-hls";
+
+describe("cleanupOrphanFfmpegs", () => {
+  let proc: string;
+
+  beforeEach(async () => {
+    proc = await mkdtemp(path.join(tmpdir(), "pavoia-orphan-proc-"));
+  });
+  afterEach(async () => {
+    await rm(proc, { recursive: true, force: true });
+  });
+
+  /** Write a fake /proc/<pid>/cmdline with NUL-separated argv. */
+  async function writeCmdline(pid: number, ...argv: string[]): Promise<void> {
+    const dir = path.join(proc, String(pid));
+    await mkdir(dir);
+    await writeFile(path.join(dir, "cmdline"), argv.join("\0"));
+  }
+
+  /** Make /proc/<pid>/ exist but cmdline unreadable (EACCES sim via missing file). */
+  async function writeUnreadable(pid: number): Promise<void> {
+    await mkdir(path.join(proc, String(pid)));
+    // Don't write cmdline — readFile will ENOENT, which the scanner
+    // tolerates the same way it tolerates EACCES.
+  }
+
+  it("returns {killed:0, attempted:0} when /proc has no matches", async () => {
+    await writeCmdline(101, "/usr/bin/sleep", "60");
+    await writeCmdline(102, "/usr/bin/bash", "-c", "echo hi");
+    const fake = fakeKill();
+    const result = await cleanupOrphanFfmpegs({
+      hlsRoot: HLS_ROOT,
+      procRoot: proc,
+      killImpl: fake.killImpl,
+      delayMs: async () => {},
+    });
+    assert.deepEqual(result, { killed: 0, attempted: 0 });
+    assert.equal(fake.signals.length, 0);
+  });
+
+  it("kills ffmpeg processes whose cmdline references hlsRoot", async () => {
+    await writeCmdline(
+      201,
+      "/usr/bin/ffmpeg",
+      "-i",
+      "/path/to/track.mp3",
+      "/dev/shm/1008/radio-hls/opening/index.m3u8",
+    );
+    await writeCmdline(
+      202,
+      "/usr/bin/ffmpeg",
+      "-i",
+      "/path/to/other.mp3",
+      "/dev/shm/1008/radio-hls/closing/index.m3u8",
+    );
+    const fake = fakeKill([201, 202]);
+    const result = await cleanupOrphanFfmpegs({
+      hlsRoot: HLS_ROOT,
+      procRoot: proc,
+      killImpl: fake.killImpl,
+      delayMs: async () => {},
+    });
+    assert.equal(result.attempted, 2);
+    assert.equal(result.killed, 2);
+    const sigterms = fake.signals
+      .filter((s) => s.signal === "SIGTERM")
+      .map((s) => s.pid)
+      .sort((a, b) => a - b);
+    assert.deepEqual(sigterms, [201, 202]);
+  });
+
+  it("does not match ffmpeg processes that don't reference hlsRoot", async () => {
+    // Other tenant's ffmpeg, jellyfin's ffmpeg, etc.
+    await writeCmdline(
+      301,
+      "/usr/bin/ffmpeg",
+      "-i",
+      "/home/other-user/media/movie.mkv",
+      "out.mp4",
+    );
+    const fake = fakeKill([301]);
+    const result = await cleanupOrphanFfmpegs({
+      hlsRoot: HLS_ROOT,
+      procRoot: proc,
+      killImpl: fake.killImpl,
+      delayMs: async () => {},
+    });
+    assert.deepEqual(result, { killed: 0, attempted: 0 });
+    assert.equal(fake.signals.length, 0);
+  });
+
+  it("does not match non-ffmpeg processes that mention hlsRoot", async () => {
+    // e.g. an `ls` we ran during debugging, or a `tail` on the m3u8.
+    await writeCmdline(
+      401,
+      "/usr/bin/ls",
+      "/dev/shm/1008/radio-hls/opening/",
+    );
+    await writeCmdline(
+      402,
+      "/usr/bin/cat",
+      "/dev/shm/1008/radio-hls/opening/index.m3u8",
+    );
+    const fake = fakeKill([401, 402]);
+    const result = await cleanupOrphanFfmpegs({
+      hlsRoot: HLS_ROOT,
+      procRoot: proc,
+      killImpl: fake.killImpl,
+      delayMs: async () => {},
+    });
+    assert.deepEqual(result, { killed: 0, attempted: 0 });
+    assert.equal(fake.signals.length, 0);
+  });
+
+  it("matches when argv[0] is the bare basename 'ffmpeg' (no path)", async () => {
+    // ffmpeg invoked via PATH with no leading directory.
+    await writeCmdline(
+      501,
+      "ffmpeg",
+      "-i",
+      "/path/in.mp3",
+      "/dev/shm/1008/radio-hls/etage-0/index.m3u8",
+    );
+    const fake = fakeKill([501]);
+    const result = await cleanupOrphanFfmpegs({
+      hlsRoot: HLS_ROOT,
+      procRoot: proc,
+      killImpl: fake.killImpl,
+      delayMs: async () => {},
+    });
+    assert.equal(result.attempted, 1);
+    assert.equal(result.killed, 1);
+  });
+
+  it("escalates to SIGKILL after termWaitMs when SIGTERM is ignored", async () => {
+    await writeCmdline(
+      601,
+      "/usr/bin/ffmpeg",
+      "-i",
+      "in.mp3",
+      "/dev/shm/1008/radio-hls/opening/index.m3u8",
+    );
+    const fake = fakeKill([601]);
+    fake.ignoreSigterm.add(601);
+    const result = await cleanupOrphanFfmpegs({
+      hlsRoot: HLS_ROOT,
+      procRoot: proc,
+      killImpl: fake.killImpl,
+      termWaitMs: 50,
+      delayMs: async (ms) => {
+        await new Promise((r) => setTimeout(r, ms));
+      },
+    });
+    assert.equal(result.attempted, 1);
+    assert.equal(result.killed, 1);
+    const seen = fake.signals.map((s) => s.signal);
+    assert.ok(seen.includes("SIGTERM"), "expected SIGTERM");
+    assert.ok(seen.includes("SIGKILL"), "expected SIGKILL escalation");
+  });
+
+  it("tolerates a pid that exits between scan and SIGTERM (ESRCH)", async () => {
+    await writeCmdline(
+      701,
+      "/usr/bin/ffmpeg",
+      "-i",
+      "in.mp3",
+      "/dev/shm/1008/radio-hls/opening/index.m3u8",
+    );
+    // Process is "already dead" by the time we try to signal it.
+    const fake = fakeKill([]); // not in the alive set
+    const result = await cleanupOrphanFfmpegs({
+      hlsRoot: HLS_ROOT,
+      procRoot: proc,
+      killImpl: fake.killImpl,
+      delayMs: async () => {},
+    });
+    assert.equal(result.attempted, 1);
+    // Counted as killed (it's dead — that's all we needed).
+    assert.equal(result.killed, 1);
+  });
+
+  it("tolerates /proc/<pid>/cmdline that vanishes mid-scan (race)", async () => {
+    // Directory exists but no cmdline file — simulates the process
+    // exiting between readdir and readFile, OR EACCES on a shared
+    // host with hidepid mounted.
+    await writeUnreadable(801);
+    await writeCmdline(
+      802,
+      "/usr/bin/ffmpeg",
+      "-i",
+      "in.mp3",
+      "/dev/shm/1008/radio-hls/opening/index.m3u8",
+    );
+    const fake = fakeKill([802]);
+    const result = await cleanupOrphanFfmpegs({
+      hlsRoot: HLS_ROOT,
+      procRoot: proc,
+      killImpl: fake.killImpl,
+      delayMs: async () => {},
+    });
+    // 801 was skipped (unreadable); 802 was reaped.
+    assert.equal(result.attempted, 1);
+    assert.equal(result.killed, 1);
+  });
+
+  it("ignores empty cmdline (kernel threads, just-died zombies)", async () => {
+    const dir = path.join(proc, "901");
+    await mkdir(dir);
+    await writeFile(path.join(dir, "cmdline"), Buffer.alloc(0));
+    const fake = fakeKill();
+    const result = await cleanupOrphanFfmpegs({
+      hlsRoot: HLS_ROOT,
+      procRoot: proc,
+      killImpl: fake.killImpl,
+      delayMs: async () => {},
+    });
+    assert.deepEqual(result, { killed: 0, attempted: 0 });
+  });
+
+  it("ignores non-numeric /proc entries (e.g. /proc/cpuinfo, /proc/self)", async () => {
+    await mkdir(path.join(proc, "self"));
+    await writeFile(path.join(proc, "cpuinfo"), "");
+    await writeFile(path.join(proc, "meminfo"), "");
+    const fake = fakeKill();
+    const result = await cleanupOrphanFfmpegs({
+      hlsRoot: HLS_ROOT,
+      procRoot: proc,
+      killImpl: fake.killImpl,
+      delayMs: async () => {},
+    });
+    assert.deepEqual(result, { killed: 0, attempted: 0 });
+  });
+
+  it("skips own pid (does not kill the engine itself)", async () => {
+    await writeCmdline(
+      process.pid,
+      "/usr/bin/ffmpeg", // hypothetical; the real engine isn't ffmpeg
+      "/dev/shm/1008/radio-hls/opening/index.m3u8",
+    );
+    const fake = fakeKill([process.pid]);
+    const result = await cleanupOrphanFfmpegs({
+      hlsRoot: HLS_ROOT,
+      procRoot: proc,
+      killImpl: fake.killImpl,
+      delayMs: async () => {},
+    });
+    assert.deepEqual(result, { killed: 0, attempted: 0 });
+    assert.equal(
+      fake.signals.length,
+      0,
+      "must never signal own pid",
+    );
+  });
+
+  it("returns {killed:0, attempted:0} when /proc itself is unreadable (no throw)", async () => {
+    const fake = fakeKill();
+    const result = await cleanupOrphanFfmpegs({
+      hlsRoot: HLS_ROOT,
+      procRoot: path.join(proc, "does-not-exist"),
+      killImpl: fake.killImpl,
+      delayMs: async () => {},
+    });
+    assert.deepEqual(result, { killed: 0, attempted: 0 });
+  });
+
+  it("logs match count and reap result when orphans are found", async () => {
+    await writeCmdline(
+      1001,
+      "/usr/bin/ffmpeg",
+      "-i",
+      "in.mp3",
+      "/dev/shm/1008/radio-hls/opening/index.m3u8",
+    );
+    const fake = fakeKill([1001]);
+    const lines: string[] = [];
+    await cleanupOrphanFfmpegs({
+      hlsRoot: HLS_ROOT,
+      procRoot: proc,
+      killImpl: fake.killImpl,
+      delayMs: async () => {},
+      log: (line) => lines.push(line),
+    });
+    assert.ok(
+      lines.some((l) => l.includes("found 1 ffmpeg")),
+      "expected match-count log line",
+    );
+    assert.ok(
+      lines.some((l) => l.includes("reaped 1 of 1")),
+      "expected reap-summary log line",
+    );
+  });
+
+  it("does not log on the no-match no-op path (clean startup)", async () => {
+    const fake = fakeKill();
+    const lines: string[] = [];
+    await cleanupOrphanFfmpegs({
+      hlsRoot: HLS_ROOT,
+      procRoot: proc,
+      killImpl: fake.killImpl,
+      delayMs: async () => {},
+      log: (line) => lines.push(line),
+    });
+    assert.deepEqual(lines, [], "clean start should be silent");
+  });
+
+  it("matches a different hlsRoot when configured (no hard-coded path)", async () => {
+    await writeCmdline(
+      1101,
+      "/usr/bin/ffmpeg",
+      "-i",
+      "in.mp3",
+      "/var/cache/myradio/opening/index.m3u8",
+    );
+    const fake = fakeKill([1101]);
+    const result = await cleanupOrphanFfmpegs({
+      hlsRoot: "/var/cache/myradio",
+      procRoot: proc,
+      killImpl: fake.killImpl,
+      delayMs: async () => {},
+    });
+    assert.equal(result.attempted, 1);
+    assert.equal(result.killed, 1);
+  });
+
+  it("does not match when hlsRoot only appears as a substring of another path", async () => {
+    // We use String.includes() so a hlsRoot of "/dev/shm/1008" would
+    // match a cmdline path "/dev/shm/1008-other/...". Document the
+    // current contract: substring match. Operators should pass a
+    // path-with-trailing-slash if they need stricter matching.
+    //
+    // This test pins the current behavior so future changes are
+    // intentional.
+    await writeCmdline(
+      1201,
+      "/usr/bin/ffmpeg",
+      "-i",
+      "in.mp3",
+      "/dev/shm/1008-decoy/opening/index.m3u8",
+    );
+    const fake = fakeKill([1201]);
+    // With hlsRoot ending in a slash, the decoy doesn't match.
+    const result = await cleanupOrphanFfmpegs({
+      hlsRoot: "/dev/shm/1008/",
+      procRoot: proc,
+      killImpl: fake.killImpl,
+      delayMs: async () => {},
+    });
+    assert.deepEqual(result, { killed: 0, attempted: 0 });
+  });
+});

--- a/apps/engine/src/orphan-cleanup.test.ts
+++ b/apps/engine/src/orphan-cleanup.test.ts
@@ -67,11 +67,28 @@ describe("cleanupOrphanFfmpegs", () => {
     await rm(proc, { recursive: true, force: true });
   });
 
-  /** Write a fake /proc/<pid>/cmdline with NUL-separated argv. */
+  /** Write a fake /proc/<pid>/cmdline AND /proc/<pid>/status with
+   *  PPid: 1 (i.e. orphan). Tests that need a non-orphan parent
+   *  should override status via writeStatus(). */
   async function writeCmdline(pid: number, ...argv: string[]): Promise<void> {
     const dir = path.join(proc, String(pid));
     await mkdir(dir);
     await writeFile(path.join(dir, "cmdline"), argv.join("\0"));
+    // Default to "true orphan" (PPID=1) so existing matching tests
+    // pass without extra setup.
+    await writeFile(
+      path.join(dir, "status"),
+      `Name:\tffmpeg\nPid:\t${pid}\nPPid:\t1\nUid:\t1000\t1000\t1000\t1000\n`,
+    );
+  }
+
+  /** Overwrite /proc/<pid>/status with a custom PPid (used by tests
+   *  that probe the orphan ownership guard). */
+  async function writeStatus(pid: number, ppid: number): Promise<void> {
+    await writeFile(
+      path.join(proc, String(pid), "status"),
+      `Name:\tffmpeg\nPid:\t${pid}\nPPid:\t${ppid}\nUid:\t1000\t1000\t1000\t1000\n`,
+    );
   }
 
   /** Make /proc/<pid>/ exist but cmdline unreadable (EACCES sim via missing file). */
@@ -442,6 +459,76 @@ describe("cleanupOrphanFfmpegs", () => {
     assert.equal(result.killed, 1);
   });
 
+  it("skips a process whose PPID is not 1 (live parent — not an orphan)", async () => {
+    // Defensive: a same-user ffmpeg supervised by another live engine
+    // (or a debugger holding it) has PPID != 1. Reaping it would be
+    // a friendly-fire bug. Codex flagged this on PR #21.
+    await writeCmdline(
+      1601,
+      "/usr/bin/ffmpeg",
+      "-i",
+      "in.mp3",
+      "/dev/shm/1008/radio-hls/opening/index.m3u8",
+    );
+    await writeStatus(1601, 4242); // some live parent pid
+    const fake = fakeKill([1601]);
+    const result = await cleanupOrphanFfmpegs({
+      hlsRoot: "/dev/shm/1008/radio-hls",
+      procRoot: proc,
+      killImpl: fake.killImpl,
+      delayMs: async () => {},
+    });
+    assert.deepEqual(result, { killed: 0, attempted: 0 });
+    assert.equal(fake.signals.length, 0);
+  });
+
+  it("skips a process whose /proc/<pid>/status is unreadable", async () => {
+    // Status missing means we can't verify orphan ownership. Better
+    // to skip than risk reaping a non-orphan.
+    await writeCmdline(
+      1701,
+      "/usr/bin/ffmpeg",
+      "-i",
+      "in.mp3",
+      "/dev/shm/1008/radio-hls/opening/index.m3u8",
+    );
+    // Stomp the status file with a missing one.
+    await rm(path.join(proc, "1701", "status"));
+    const fake = fakeKill([1701]);
+    const result = await cleanupOrphanFfmpegs({
+      hlsRoot: "/dev/shm/1008/radio-hls",
+      procRoot: proc,
+      killImpl: fake.killImpl,
+      delayMs: async () => {},
+    });
+    assert.deepEqual(result, { killed: 0, attempted: 0 });
+  });
+
+  it("matches when hlsRoot env value has redundant separators or '..' (canonicalization)", async () => {
+    // Operators may write HLS_ROOT loosely (extra slashes, ../). The
+    // ffmpeg cmdline however contains the path produced via
+    // path.join() in the supervisor, which normalizes. Match must
+    // therefore canonicalize hlsRoot before comparing.
+    await writeCmdline(
+      1801,
+      "/usr/bin/ffmpeg",
+      "-i",
+      "in.mp3",
+      "/dev/shm/1008/radio-hls/opening/index.m3u8",
+    );
+    const fake = fakeKill([1801]);
+    const result = await cleanupOrphanFfmpegs({
+      // /dev/shm/1008/foo/../radio-hls/ → canonicalizes to
+      // /dev/shm/1008/radio-hls
+      hlsRoot: "/dev/shm/1008/foo/../radio-hls/",
+      procRoot: proc,
+      killImpl: fake.killImpl,
+      delayMs: async () => {},
+    });
+    assert.equal(result.attempted, 1);
+    assert.equal(result.killed, 1);
+  });
+
   it("tolerates a trailing slash in the configured hlsRoot", async () => {
     // Operators may write HLS_ROOT with or without a trailing slash;
     // the matcher must canonicalize either way.
@@ -571,44 +658,42 @@ describe("cleanupOrphanFfmpegs — real /proc + real defaultKill (integration)",
     };
   }
 
-  it("reaps a real pid via real /proc + real defaultKill", async () => {
-    // Unique hlsRoot so we can't possibly collide with another test
-    // run, another tenant on a shared CI host, or our actual engine.
-    const hlsRoot = `/tmp/pavoia-orphan-itest-${process.pid}-${Date.now()}`;
+  it("does NOT reap a NON-orphan: PPID != 1 means somebody supervises it", async () => {
+    // The child is OUR child (PPID = test process). The orphan guard
+    // must skip it — reaping a supervised process would be friendly
+    // fire (e.g. another live engine on a shared host).
+    const hlsRoot = `/tmp/pavoia-nonorphan-itest-${process.pid}-${Date.now()}`;
     const child = spawnFakeFfmpeg(hlsRoot);
     try {
-      // Give the kernel a moment to populate /proc/<pid>/cmdline.
       await new Promise((r) => setTimeout(r, 200));
 
       const result = await cleanupOrphanFfmpegs({
         hlsRoot,
-        // Default termWaitMs (2 s) plus the test runner's tolerance.
         log: () => {},
       });
 
-      // We may catch sibling sh processes from the test runner
-      // itself spawning helpers, but our fake-ffmpeg should be among
-      // them, and all matched processes should be killed.
-      assert.ok(
-        result.attempted >= 1,
-        `expected ≥1 match for hlsRoot=${hlsRoot}; got ${result.attempted}`,
-      );
       assert.equal(
-        result.killed,
         result.attempted,
-        "every matched pid should be killed",
+        0,
+        `non-orphan must not be matched (PPID=${process.pid}); got attempted=${result.attempted}`,
       );
-
-      // Wait for the child to actually exit so the test cleanly
-      // closes its handle.
-      await Promise.race([
-        child.waitForExit,
-        new Promise((_, reject) =>
-          setTimeout(() => reject(new Error("child did not exit")), 5000),
-        ),
-      ]);
+      assert.equal(result.killed, 0);
     } finally {
       child.forceKill();
+      // Wait for child to clean up before next test starts.
+      await Promise.race([
+        child.waitForExit,
+        new Promise((r) => setTimeout(r, 1000)),
+      ]);
     }
   });
+
+  // NOTE: we deliberately do NOT have an integration test for the
+  // PPID=1 happy path. On systemd-based hosts, a Linux child
+  // subreaper (`systemd --user`) intercepts orphans before they
+  // reach PID 1, so a double-fork from inside a test session ends
+  // up with PPID=<systemd-user-pid>, not 1. The PPID=1 check is
+  // production-correct (Whatbox has no systemd) but cannot be
+  // observed cross-platform from inside the test runner. The unit
+  // tests above cover the contract via fake /proc/<pid>/status.
 });

--- a/apps/engine/src/orphan-cleanup.test.ts
+++ b/apps/engine/src/orphan-cleanup.test.ts
@@ -1,10 +1,11 @@
 import { describe, it, beforeEach, afterEach } from "node:test";
 import assert from "node:assert/strict";
+import { spawn } from "node:child_process";
 import { mkdtemp, mkdir, writeFile, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 
-import { cleanupOrphanFfmpegs } from "./orphan-cleanup.ts";
+import { cleanupOrphanFfmpegs, defaultKill } from "./orphan-cleanup.ts";
 
 /**
  * Tests use a fake /proc directory rooted in a tmpdir. Each test
@@ -402,5 +403,154 @@ describe("cleanupOrphanFfmpegs", () => {
       delayMs: async () => {},
     });
     assert.deepEqual(result, { killed: 0, attempted: 0 });
+  });
+});
+
+/**
+ * The unit tests above use a fake killImpl that throws ESRCH on dead
+ * pids. The PRODUCTION defaultKill must do the same on signal 0 (the
+ * existence probe used by isAlive) — otherwise isAlive always returns
+ * true and the SIGTERM grace period collapses to "always SIGKILL".
+ *
+ * CodeRabbit caught this on the original PR (#21): the original
+ * defaultKill swallowed ESRCH unconditionally, masking real death from
+ * the existence probe. This block asserts the contract directly and
+ * runs a real-process integration test so a regression couldn't slip
+ * past the unit tests' fake killImpl.
+ */
+describe("defaultKill — ESRCH propagation contract", () => {
+  /** Spawn /bin/true and resolve with its (now-dead) pid once exited. */
+  function spawnAndAwaitExit(): Promise<number> {
+    return new Promise((resolve, reject) => {
+      const child = spawn("/bin/true", [], { stdio: "ignore" });
+      const pid = child.pid;
+      if (pid === undefined) {
+        reject(new Error("spawn /bin/true failed: no pid"));
+        return;
+      }
+      child.on("error", reject);
+      child.on("exit", () => {
+        // Give the kernel a moment to clear the pid from /proc so a
+        // subsequent kill(pid, 0) sees ESRCH cleanly. This is paranoid
+        // — exit handlers usually fire after the kernel has reaped —
+        // but the test is timing-sensitive enough to warrant the wait.
+        setTimeout(() => resolve(pid), 50);
+      });
+    });
+  }
+
+  it("throws ESRCH on signal 0 for a dead pid (so isAlive can detect death)", async () => {
+    const deadPid = await spawnAndAwaitExit();
+    assert.throws(
+      () => defaultKill(deadPid, 0),
+      (err: NodeJS.ErrnoException) => err.code === "ESRCH",
+    );
+  });
+
+  it("swallows ESRCH on SIGTERM for a dead pid (already-dead == success)", async () => {
+    const deadPid = await spawnAndAwaitExit();
+    assert.doesNotThrow(() => defaultKill(deadPid, "SIGTERM"));
+  });
+
+  it("swallows ESRCH on SIGKILL for a dead pid (already-dead == success)", async () => {
+    const deadPid = await spawnAndAwaitExit();
+    assert.doesNotThrow(() => defaultKill(deadPid, "SIGKILL"));
+  });
+
+  it("does not throw on signal 0 for an alive pid (own process)", () => {
+    assert.doesNotThrow(() => defaultKill(process.pid, 0));
+  });
+});
+
+describe("cleanupOrphanFfmpegs — real /proc + real defaultKill (integration)", () => {
+  /**
+   * Spawn a real /bin/sh that pretends to be ffmpeg via Node's argv0
+   * option. The sh process loops forever on `read -t` so it stays
+   * alive in /proc with our hlsRoot marker visible in cmdline, and
+   * dies cleanly on SIGTERM (sh interrupts the read).
+   */
+  function spawnFakeFfmpeg(hlsRoot: string): {
+    pid: number;
+    waitForExit: Promise<void>;
+    forceKill: () => void;
+  } {
+    const child = spawn(
+      "/bin/bash",
+      [
+        "-c",
+        // Multi-statement loop body so bash CAN'T tail-exec the
+        // sleep (which would replace bash's argv with sleep's, hiding
+        // our hlsRoot marker from /proc/<pid>/cmdline).
+        "while :; do sleep 1; done",
+        // bash's $0 — visible in cmdline:
+        "fake-ffmpeg-driver",
+        // bash's $1 — also visible in cmdline, contains hlsRoot marker:
+        `${hlsRoot}/opening/index.m3u8`,
+      ],
+      {
+        stdio: "ignore",
+        // argv0 puts "ffmpeg" as argv[0] in /proc/<pid>/cmdline so
+        // the basename matcher inside cleanupOrphanFfmpegs accepts it.
+        argv0: "ffmpeg",
+        detached: false,
+      },
+    );
+    const pid = child.pid;
+    if (pid === undefined) throw new Error("spawn failed");
+    const waitForExit = new Promise<void>((resolve) => {
+      child.on("exit", () => resolve());
+    });
+    return {
+      pid,
+      waitForExit,
+      forceKill: () => {
+        try {
+          child.kill("SIGKILL");
+        } catch {
+          // already dead
+        }
+      },
+    };
+  }
+
+  it("reaps a real pid via real /proc + real defaultKill", async () => {
+    // Unique hlsRoot so we can't possibly collide with another test
+    // run, another tenant on a shared CI host, or our actual engine.
+    const hlsRoot = `/tmp/pavoia-orphan-itest-${process.pid}-${Date.now()}`;
+    const child = spawnFakeFfmpeg(hlsRoot);
+    try {
+      // Give the kernel a moment to populate /proc/<pid>/cmdline.
+      await new Promise((r) => setTimeout(r, 200));
+
+      const result = await cleanupOrphanFfmpegs({
+        hlsRoot,
+        // Default termWaitMs (2 s) plus the test runner's tolerance.
+        log: () => {},
+      });
+
+      // We may catch sibling sh processes from the test runner
+      // itself spawning helpers, but our fake-ffmpeg should be among
+      // them, and all matched processes should be killed.
+      assert.ok(
+        result.attempted >= 1,
+        `expected ≥1 match for hlsRoot=${hlsRoot}; got ${result.attempted}`,
+      );
+      assert.equal(
+        result.killed,
+        result.attempted,
+        "every matched pid should be killed",
+      );
+
+      // Wait for the child to actually exit so the test cleanly
+      // closes its handle.
+      await Promise.race([
+        child.waitForExit,
+        new Promise((_, reject) =>
+          setTimeout(() => reject(new Error("child did not exit")), 5000),
+        ),
+      ]);
+    } finally {
+      child.forceKill();
+    }
   });
 });

--- a/apps/engine/src/orphan-cleanup.test.ts
+++ b/apps/engine/src/orphan-cleanup.test.ts
@@ -379,30 +379,88 @@ describe("cleanupOrphanFfmpegs", () => {
     assert.equal(result.killed, 1);
   });
 
-  it("does not match when hlsRoot only appears as a substring of another path", async () => {
-    // We use String.includes() so a hlsRoot of "/dev/shm/1008" would
-    // match a cmdline path "/dev/shm/1008-other/...". Document the
-    // current contract: substring match. Operators should pass a
-    // path-with-trailing-slash if they need stricter matching.
-    //
-    // This test pins the current behavior so future changes are
-    // intentional.
+  it("rejects a sibling path that shares hlsRoot's prefix but is not under it", async () => {
+    // Path-prefix matching: hlsRoot is treated as a directory
+    // boundary. /dev/shm/1008/radio-hls-DECOY/* must NOT match
+    // hlsRoot=/dev/shm/1008/radio-hls — the old substring-include
+    // matcher would have falsely reaped this.
     await writeCmdline(
       1201,
       "/usr/bin/ffmpeg",
       "-i",
       "in.mp3",
-      "/dev/shm/1008-decoy/opening/index.m3u8",
+      "/dev/shm/1008/radio-hls-DECOY/opening/index.m3u8",
     );
     const fake = fakeKill([1201]);
-    // With hlsRoot ending in a slash, the decoy doesn't match.
     const result = await cleanupOrphanFfmpegs({
-      hlsRoot: "/dev/shm/1008/",
+      hlsRoot: "/dev/shm/1008/radio-hls",
       procRoot: proc,
       killImpl: fake.killImpl,
       delayMs: async () => {},
     });
     assert.deepEqual(result, { killed: 0, attempted: 0 });
+  });
+
+  it("rejects a path that has hlsRoot as a non-prefix substring", async () => {
+    // /home/yolan/backups/dev/shm/1008/radio-hls/... contains the
+    // hlsRoot path but not at the start. The old substring matcher
+    // would have falsely matched; the new path-prefix matcher does
+    // not.
+    await writeCmdline(
+      1301,
+      "/usr/bin/ffmpeg",
+      "-i",
+      "in.mp3",
+      "/home/yolan/backups/dev/shm/1008/radio-hls/copy.ts",
+    );
+    const fake = fakeKill([1301]);
+    const result = await cleanupOrphanFfmpegs({
+      hlsRoot: "/dev/shm/1008/radio-hls",
+      procRoot: proc,
+      killImpl: fake.killImpl,
+      delayMs: async () => {},
+    });
+    assert.deepEqual(result, { killed: 0, attempted: 0 });
+  });
+
+  it("matches when an arg is exactly hlsRoot (no children)", async () => {
+    await writeCmdline(
+      1401,
+      "/usr/bin/ffmpeg",
+      "-i",
+      "in.mp3",
+      "/dev/shm/1008/radio-hls",
+    );
+    const fake = fakeKill([1401]);
+    const result = await cleanupOrphanFfmpegs({
+      hlsRoot: "/dev/shm/1008/radio-hls",
+      procRoot: proc,
+      killImpl: fake.killImpl,
+      delayMs: async () => {},
+    });
+    assert.equal(result.attempted, 1);
+    assert.equal(result.killed, 1);
+  });
+
+  it("tolerates a trailing slash in the configured hlsRoot", async () => {
+    // Operators may write HLS_ROOT with or without a trailing slash;
+    // the matcher must canonicalize either way.
+    await writeCmdline(
+      1501,
+      "/usr/bin/ffmpeg",
+      "-i",
+      "in.mp3",
+      "/dev/shm/1008/radio-hls/opening/index.m3u8",
+    );
+    const fake = fakeKill([1501]);
+    const result = await cleanupOrphanFfmpegs({
+      hlsRoot: "/dev/shm/1008/radio-hls/", // trailing slash
+      procRoot: proc,
+      killImpl: fake.killImpl,
+      delayMs: async () => {},
+    });
+    assert.equal(result.attempted, 1);
+    assert.equal(result.killed, 1);
   });
 });
 

--- a/apps/engine/src/orphan-cleanup.test.ts
+++ b/apps/engine/src/orphan-cleanup.test.ts
@@ -2,6 +2,7 @@ import { describe, it, beforeEach, afterEach } from "node:test";
 import assert from "node:assert/strict";
 import { spawn } from "node:child_process";
 import { mkdtemp, mkdir, writeFile, rm } from "node:fs/promises";
+import { writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 
@@ -527,6 +528,71 @@ describe("cleanupOrphanFfmpegs", () => {
     });
     assert.equal(result.attempted, 1);
     assert.equal(result.killed, 1);
+  });
+
+  it("re-validates identity before each signal: skips a pid whose cmdline was recycled mid-run (TOCTOU)", async () => {
+    // Both pids match at scan time. While processing the SIGTERM
+    // for pid 2001, the killImpl mutates pid 2002's cmdline to
+    // simulate Linux recycling 2002 into an unrelated process. The
+    // re-validation pass before SIGTERM(2002) MUST notice and skip,
+    // so 2002 does not receive a signal.
+    await writeCmdline(
+      2001,
+      "/usr/bin/ffmpeg",
+      "-i",
+      "in.mp3",
+      "/dev/shm/1008/radio-hls/opening/index.m3u8",
+    );
+    await writeCmdline(
+      2002,
+      "/usr/bin/ffmpeg",
+      "-i",
+      "in.mp3",
+      "/dev/shm/1008/radio-hls/closing/index.m3u8",
+    );
+    const fake = fakeKill([2001, 2002]);
+    const wrappedKill = (pid: number, signal: NodeJS.Signals | 0) => {
+      if (signal === "SIGTERM" && pid === 2001) {
+        // Mutate 2002's cmdline synchronously so the re-validation
+        // for 2002 (which hasn't run yet) sees recycled-state.
+        writeFileSync(
+          path.join(proc, "2002", "cmdline"),
+          ["/usr/bin/cat", "/etc/hostname"].join("\0"),
+        );
+      }
+      fake.killImpl(pid, signal);
+    };
+    const result = await cleanupOrphanFfmpegs({
+      hlsRoot: "/dev/shm/1008/radio-hls",
+      procRoot: proc,
+      killImpl: wrappedKill,
+      // 10ms keeps the poll loop short (2002 stays "alive" since
+      // we only mutated its cmdline, not its process state).
+      termWaitMs: 10,
+      delayMs: async () => {},
+    });
+
+    const sigtermPids = fake.signals
+      .filter((s) => s.signal === "SIGTERM")
+      .map((s) => s.pid);
+    assert.deepEqual(
+      sigtermPids,
+      [2001],
+      "SIGTERM must be sent only to 2001; 2002's recycled cmdline should skip it",
+    );
+    const sigkillPids = fake.signals
+      .filter((s) => s.signal === "SIGKILL")
+      .map((s) => s.pid);
+    assert.deepEqual(
+      sigkillPids,
+      [],
+      "SIGKILL must NOT fire for 2002 either — re-validate gates both passes",
+    );
+    // attempted is the scan count (set before re-validation), so
+    // both pids count. killed reflects what was actually killed:
+    // 2001 was killed by SIGTERM, 2002 was skipped (no signal).
+    assert.equal(result.attempted, 2);
+    assert.equal(result.killed, 1, "only 2001 should be tallied as killed");
   });
 
   it("tolerates a trailing slash in the configured hlsRoot", async () => {

--- a/apps/engine/src/orphan-cleanup.ts
+++ b/apps/engine/src/orphan-cleanup.ts
@@ -58,6 +58,25 @@ const FFMPEG_BASENAMES = new Set(["ffmpeg"]);
 const PROC_PID_PATTERN = /^\d+$/;
 
 /**
+ * Returns true iff `arg` is the configured hlsRoot or a path under it
+ * (treating it as a directory boundary). Substring matching would
+ * false-positive on sibling paths like
+ *   hlsRoot=/dev/shm/1008/radio-hls
+ *   arg=/dev/shm/1008/radio-hls-OTHER/seg.ts
+ * which we must NOT reap.
+ */
+function argIsUnderHlsRoot(arg: string, hlsRoot: string): boolean {
+  // Strip a trailing separator from hlsRoot so the comparison is
+  // canonical regardless of how the operator wrote the env value.
+  const root =
+    hlsRoot.endsWith(path.sep) && hlsRoot.length > 1
+      ? hlsRoot.slice(0, -1)
+      : hlsRoot;
+  if (arg === root) return true;
+  return arg.startsWith(root + path.sep);
+}
+
+/**
  * Wraps process.kill. For terminating signals, swallows ESRCH so a
  * process that died on its own between scan and signal is treated as
  * success (it's gone — that's what we wanted). For signal 0 (the
@@ -158,7 +177,7 @@ async function scanForOrphans(
     const argv0Basename = path.basename(argv0);
     if (!FFMPEG_BASENAMES.has(argv0Basename)) continue;
 
-    if (argv.some((arg) => arg.includes(hlsRoot))) {
+    if (argv.some((arg) => argIsUnderHlsRoot(arg, hlsRoot))) {
       matches.push(pid);
     }
   }

--- a/apps/engine/src/orphan-cleanup.ts
+++ b/apps/engine/src/orphan-cleanup.ts
@@ -64,16 +64,40 @@ const PROC_PID_PATTERN = /^\d+$/;
  *   hlsRoot=/dev/shm/1008/radio-hls
  *   arg=/dev/shm/1008/radio-hls-OTHER/seg.ts
  * which we must NOT reap.
+ *
+ * `hlsRoot` is canonicalized via path.resolve() so an env value with
+ * `..`, `.`, or repeated separators still matches ffmpeg argv produced
+ * via path.join(). The arg side is left raw — ffmpeg writes back what
+ * we passed it via path.join(), so the canonical-vs-canonical compare
+ * is the right one.
  */
-function argIsUnderHlsRoot(arg: string, hlsRoot: string): boolean {
-  // Strip a trailing separator from hlsRoot so the comparison is
-  // canonical regardless of how the operator wrote the env value.
-  const root =
-    hlsRoot.endsWith(path.sep) && hlsRoot.length > 1
-      ? hlsRoot.slice(0, -1)
-      : hlsRoot;
-  if (arg === root) return true;
-  return arg.startsWith(root + path.sep);
+function argIsUnderHlsRoot(arg: string, normalizedRoot: string): boolean {
+  if (arg === normalizedRoot) return true;
+  return arg.startsWith(normalizedRoot + path.sep);
+}
+
+/**
+ * Read `PPid` from /proc/<pid>/status. Returns null when the file is
+ * unreadable (process exited, EACCES on hidepid mounts) or the line
+ * is missing — callers treat null as "skip, can't verify orphan
+ * status".
+ */
+async function readPpid(
+  procRoot: string,
+  pid: number,
+): Promise<number | null> {
+  let raw: string;
+  try {
+    raw = (
+      await readFile(path.join(procRoot, String(pid), "status"))
+    ).toString("utf8");
+  } catch {
+    return null;
+  }
+  const m = raw.match(/^PPid:\s+(\d+)/m);
+  if (!m) return null;
+  const parsed = Number(m[1]);
+  return Number.isFinite(parsed) ? parsed : null;
 }
 
 /**
@@ -147,6 +171,11 @@ async function scanForOrphans(
 
   const matches: number[] = [];
   const ownPid = process.pid;
+  // Canonicalize hlsRoot once. ffmpeg arg paths come from
+  // path.join(config.hlsRoot, stage.id, ...) in the supervisor, so
+  // matching against a canonicalized root is consistent with how the
+  // engine produces those paths.
+  const normalizedRoot = path.resolve(hlsRoot);
 
   for (const entry of entries) {
     if (!PROC_PID_PATTERN.test(entry)) continue;
@@ -177,9 +206,24 @@ async function scanForOrphans(
     const argv0Basename = path.basename(argv0);
     if (!FFMPEG_BASENAMES.has(argv0Basename)) continue;
 
-    if (argv.some((arg) => argIsUnderHlsRoot(arg, hlsRoot))) {
-      matches.push(pid);
+    if (!argv.some((arg) => argIsUnderHlsRoot(arg, normalizedRoot))) {
+      continue;
     }
+
+    // Only reap true orphans: a previous-engine ffmpeg child whose
+    // parent died and got reparented to init. If PPID is anything
+    // else (a live engine, a debugger holding it, a manual run), we
+    // must NOT reap — that's somebody else's process.
+    //
+    // Why this works in production: when our engine dies (kill -9,
+    // OOM, panic), its ffmpeg children are reparented to init by the
+    // kernel synchronously at parent exit. By the time the watchdog
+    // calls start-engine.sh and the new engine boots, the orphans
+    // already have PPID=1.
+    const ppid = await readPpid(procRoot, pid);
+    if (ppid !== 1) continue;
+
+    matches.push(pid);
   }
 
   return matches;

--- a/apps/engine/src/orphan-cleanup.ts
+++ b/apps/engine/src/orphan-cleanup.ts
@@ -57,11 +57,22 @@ export interface CleanupResult {
 const FFMPEG_BASENAMES = new Set(["ffmpeg"]);
 const PROC_PID_PATTERN = /^\d+$/;
 
-/** Wraps process.kill so ESRCH (process already gone) is not thrown. */
-function defaultKill(pid: number, signal: NodeJS.Signals | 0): void {
+/**
+ * Wraps process.kill. For terminating signals, swallows ESRCH so a
+ * process that died on its own between scan and signal is treated as
+ * success (it's gone — that's what we wanted). For signal 0 (the
+ * existence probe), ESRCH MUST propagate so isAlive() can distinguish
+ * "alive" from "dead" — without this, the polling grace period
+ * collapses and we always SIGKILL after termWaitMs even when SIGTERM
+ * already worked.
+ *
+ * Exported only so tests can verify the propagation rule directly.
+ */
+export function defaultKill(pid: number, signal: NodeJS.Signals | 0): void {
   try {
     process.kill(pid, signal);
   } catch (err) {
+    if (signal === 0) throw err;
     if ((err as NodeJS.ErrnoException).code === "ESRCH") return;
     throw err;
   }

--- a/apps/engine/src/orphan-cleanup.ts
+++ b/apps/engine/src/orphan-cleanup.ts
@@ -1,0 +1,227 @@
+// Reaps orphan ffmpeg processes left over from a previous engine run.
+//
+// On crash recovery (kill -9, OOM, kernel panic, watchdog respawn after
+// HTTP 000), the previous engine's ffmpeg children are NOT taken down
+// with it — Linux makes them orphans (PPID=1) and they keep writing
+// HLS segments until they hit a broken pipe or finish their input.
+// During that window:
+//
+//   - the new engine's cleanStageDir runs and removes index.m3u8 +
+//     seg-*.ts, but the old ffmpegs immediately rewrite them
+//   - the new ffmpegs spawn with `+append_list`, read the leftover
+//     m3u8, and continue the segment counter (e.g. start at 4060+
+//     instead of 0)
+//   - listeners get a brief audio glitch and the dirs accumulate
+//     orphan segments that never get cleaned
+//
+// Verified live on Whatbox during Task 7 smoke-test (2026-05-05): a
+// kill -9 of the engine left 5 of 10 stages with leftover seg-04xxx
+// files written by orphan ffmpegs over ~3 minutes after engine death.
+//
+// Whatbox doesn't have setpriv(1) so we can't use --pdeathsig SIGKILL
+// at spawn time (the kernel-level fix). Instead, we reap on engine
+// start: scan /proc, match any ffmpeg cmdline that mentions our
+// HLS_ROOT, SIGTERM then SIGKILL.
+//
+// Called once at bootstrap, BEFORE any new supervisor starts.
+
+import { readdir, readFile } from "node:fs/promises";
+import path from "node:path";
+
+export interface CleanupOptions {
+  /** HLS output root (config.hlsRoot). An ffmpeg process is treated
+   *  as one of ours iff its cmdline references this path. */
+  hlsRoot: string;
+  /** Optional logger; defaults to no-op. */
+  log?: (line: string) => void;
+  /** How long to wait between SIGTERM and SIGKILL escalation. */
+  termWaitMs?: number;
+  // === injection points for tests; defaults are the real /proc + kernel ===
+  /** Defaults to "/proc". */
+  procRoot?: string;
+  /** Defaults to a wrapper around process.kill that swallows ESRCH. */
+  killImpl?: (pid: number, signal: NodeJS.Signals | 0) => void;
+  /** Defaults to setTimeout-based delay. */
+  delayMs?: (ms: number) => Promise<void>;
+}
+
+export interface CleanupResult {
+  /** Number of matched ffmpeg processes that ended up dead by the
+   *  time this function returned (whether via our SIGTERM, our
+   *  SIGKILL, or natural death between scan and signal). */
+  killed: number;
+  /** Number of matched processes (orphans we attempted to reap). */
+  attempted: number;
+}
+
+const FFMPEG_BASENAMES = new Set(["ffmpeg"]);
+const PROC_PID_PATTERN = /^\d+$/;
+
+/** Wraps process.kill so ESRCH (process already gone) is not thrown. */
+function defaultKill(pid: number, signal: NodeJS.Signals | 0): void {
+  try {
+    process.kill(pid, signal);
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === "ESRCH") return;
+    throw err;
+  }
+}
+
+function defaultDelay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/**
+ * Returns true iff `pid` is currently alive. Uses signal 0 (the
+ * standard Unix existence probe). Treats ESRCH as dead and any other
+ * error as alive (conservative — we'd rather try a SIGKILL than
+ * silently skip).
+ */
+function isAlive(
+  pid: number,
+  killImpl: (pid: number, signal: NodeJS.Signals | 0) => void,
+): boolean {
+  try {
+    killImpl(pid, 0);
+    return true;
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === "ESRCH") return false;
+    return true;
+  }
+}
+
+/**
+ * Scan procRoot for processes whose cmdline says they're an ffmpeg
+ * referencing hlsRoot. Returns the list of matched pids.
+ *
+ * Skips:
+ *   - non-numeric /proc entries (kernel virtual files)
+ *   - the current process pid (self)
+ *   - cmdline read errors (process exited, EACCES on shared hosts)
+ *   - empty cmdline (kernel threads, just-died zombies)
+ *   - non-ffmpeg argv[0]
+ *   - cmdlines that don't mention hlsRoot
+ */
+async function scanForOrphans(
+  procRoot: string,
+  hlsRoot: string,
+): Promise<number[]> {
+  let entries: string[];
+  try {
+    entries = await readdir(procRoot);
+  } catch {
+    // /proc unreadable — abort scan (returns empty so cleanup is a
+    // no-op rather than a fatal error).
+    return [];
+  }
+
+  const matches: number[] = [];
+  const ownPid = process.pid;
+
+  for (const entry of entries) {
+    if (!PROC_PID_PATTERN.test(entry)) continue;
+    const pid = Number(entry);
+    if (pid === ownPid) continue;
+
+    let raw: Buffer;
+    try {
+      raw = await readFile(path.join(procRoot, entry, "cmdline"));
+    } catch {
+      // Process exited between readdir and readFile (race), or
+      // we don't have permission (EACCES on shared hosts under a
+      // hidepid mount). Skip — not our concern.
+      continue;
+    }
+    if (raw.length === 0) continue;
+
+    // /proc/<pid>/cmdline is the process argv joined by NUL bytes.
+    // The buffer may end with a trailing NUL (some kernels) or not.
+    // Filter empty splits to handle either case.
+    const argv = raw
+      .toString("utf8")
+      .split("\0")
+      .filter((s) => s.length > 0);
+    const [argv0] = argv;
+    if (argv0 === undefined) continue;
+
+    const argv0Basename = path.basename(argv0);
+    if (!FFMPEG_BASENAMES.has(argv0Basename)) continue;
+
+    if (argv.some((arg) => arg.includes(hlsRoot))) {
+      matches.push(pid);
+    }
+  }
+
+  return matches;
+}
+
+/**
+ * Reap any orphan ffmpeg processes left over from a previous engine
+ * run. Returns counts; never throws (a /proc scan failure or a kill
+ * permission error is logged and treated as no-op).
+ */
+export async function cleanupOrphanFfmpegs(
+  opts: CleanupOptions,
+): Promise<CleanupResult> {
+  const {
+    hlsRoot,
+    log = () => {},
+    termWaitMs = 2000,
+    procRoot = "/proc",
+    killImpl = defaultKill,
+    delayMs = defaultDelay,
+  } = opts;
+
+  const matches = await scanForOrphans(procRoot, hlsRoot);
+  if (matches.length === 0) {
+    return { killed: 0, attempted: 0 };
+  }
+
+  log(
+    `[orphan-cleanup] found ${matches.length} ffmpeg process(es) referencing ${hlsRoot}; sending SIGTERM`,
+  );
+
+  for (const pid of matches) {
+    try {
+      killImpl(pid, "SIGTERM");
+    } catch (err) {
+      // Permission denied (other user) or some kernel-level error.
+      // Log + continue; the SIGKILL pass below will retry.
+      log(
+        `[orphan-cleanup] SIGTERM pid=${pid} failed: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
+  }
+
+  // Poll until all are dead OR termWaitMs elapses. 100ms granularity
+  // keeps the hot path tight on the common case where SIGTERM reaps
+  // them in <1s.
+  const POLL_MS = 100;
+  const deadline = Date.now() + termWaitMs;
+  while (Date.now() < deadline) {
+    if (matches.every((pid) => !isAlive(pid, killImpl))) break;
+    await delayMs(POLL_MS);
+  }
+
+  // SIGKILL stragglers. Anything still alive after termWaitMs is
+  // ignoring SIGTERM.
+  let killed = 0;
+  for (const pid of matches) {
+    if (isAlive(pid, killImpl)) {
+      try {
+        killImpl(pid, "SIGKILL");
+        killed++;
+      } catch (err) {
+        log(
+          `[orphan-cleanup] SIGKILL pid=${pid} failed: ${err instanceof Error ? err.message : String(err)}`,
+        );
+      }
+    } else {
+      // Already dead (SIGTERM landed cleanly, or natural death).
+      killed++;
+    }
+  }
+
+  log(`[orphan-cleanup] reaped ${killed} of ${matches.length}`);
+  return { killed, attempted: matches.length };
+}

--- a/apps/engine/src/orphan-cleanup.ts
+++ b/apps/engine/src/orphan-cleanup.ts
@@ -274,7 +274,11 @@ export async function cleanupOrphanFfmpegs(
   const deadline = Date.now() + termWaitMs;
   while (Date.now() < deadline) {
     if (matches.every((pid) => !isAlive(pid, killImpl))) break;
-    await delayMs(POLL_MS);
+    // Cap the sleep at remaining budget so a sub-100ms termWaitMs
+    // (e.g. tests with termWaitMs=50) doesn't always burn 100ms
+    // before checking again. Without the cap, "honor termWaitMs"
+    // is approximate to within +POLL_MS.
+    await delayMs(Math.min(POLL_MS, Math.max(0, deadline - Date.now())));
   }
 
   // SIGKILL stragglers. Anything still alive after termWaitMs is

--- a/apps/engine/src/orphan-cleanup.ts
+++ b/apps/engine/src/orphan-cleanup.ts
@@ -156,9 +156,63 @@ function isAlive(
  *   - non-ffmpeg argv[0]
  *   - cmdlines that don't mention hlsRoot
  */
+/**
+ * Returns true iff `pid` is, at this instant, an ffmpeg process whose
+ * argv0 basename is "ffmpeg", whose argv references hlsRoot, and
+ * whose PPID is 1 (true orphan).
+ *
+ * Used both for the initial scan AND for re-validation immediately
+ * before each kill — defending against PID reuse between scan and
+ * signal. If the matched pid exited between the two reads and Linux
+ * recycled it for an unrelated process, this returns false and we
+ * skip the kill.
+ */
+async function matchesOrphanFfmpeg(
+  procRoot: string,
+  pid: number,
+  normalizedRoot: string,
+): Promise<boolean> {
+  let raw: Buffer;
+  try {
+    raw = await readFile(path.join(procRoot, String(pid), "cmdline"));
+  } catch {
+    // Process exited or unreadable. Not our concern.
+    return false;
+  }
+  if (raw.length === 0) return false;
+
+  // /proc/<pid>/cmdline is the process argv joined by NUL bytes.
+  // The buffer may end with a trailing NUL (some kernels) or not.
+  // Filter empty splits to handle either case.
+  const argv = raw
+    .toString("utf8")
+    .split("\0")
+    .filter((s) => s.length > 0);
+  const [argv0] = argv;
+  if (argv0 === undefined) return false;
+
+  if (!FFMPEG_BASENAMES.has(path.basename(argv0))) return false;
+  if (!argv.some((arg) => argIsUnderHlsRoot(arg, normalizedRoot))) {
+    return false;
+  }
+
+  // Only reap true orphans: a previous-engine ffmpeg child whose
+  // parent died and got reparented to init. If PPID is anything
+  // else (a live engine, a debugger holding it, a manual run), we
+  // must NOT reap — that's somebody else's process.
+  //
+  // Why this works in production: when our engine dies (kill -9,
+  // OOM, panic), its ffmpeg children are reparented to init by the
+  // kernel synchronously at parent exit. By the time the watchdog
+  // calls start-engine.sh and the new engine boots, the orphans
+  // already have PPID=1.
+  const ppid = await readPpid(procRoot, pid);
+  return ppid === 1;
+}
+
 async function scanForOrphans(
   procRoot: string,
-  hlsRoot: string,
+  normalizedRoot: string,
 ): Promise<number[]> {
   let entries: string[];
   try {
@@ -171,59 +225,14 @@ async function scanForOrphans(
 
   const matches: number[] = [];
   const ownPid = process.pid;
-  // Canonicalize hlsRoot once. ffmpeg arg paths come from
-  // path.join(config.hlsRoot, stage.id, ...) in the supervisor, so
-  // matching against a canonicalized root is consistent with how the
-  // engine produces those paths.
-  const normalizedRoot = path.resolve(hlsRoot);
 
   for (const entry of entries) {
     if (!PROC_PID_PATTERN.test(entry)) continue;
     const pid = Number(entry);
     if (pid === ownPid) continue;
-
-    let raw: Buffer;
-    try {
-      raw = await readFile(path.join(procRoot, entry, "cmdline"));
-    } catch {
-      // Process exited between readdir and readFile (race), or
-      // we don't have permission (EACCES on shared hosts under a
-      // hidepid mount). Skip — not our concern.
-      continue;
+    if (await matchesOrphanFfmpeg(procRoot, pid, normalizedRoot)) {
+      matches.push(pid);
     }
-    if (raw.length === 0) continue;
-
-    // /proc/<pid>/cmdline is the process argv joined by NUL bytes.
-    // The buffer may end with a trailing NUL (some kernels) or not.
-    // Filter empty splits to handle either case.
-    const argv = raw
-      .toString("utf8")
-      .split("\0")
-      .filter((s) => s.length > 0);
-    const [argv0] = argv;
-    if (argv0 === undefined) continue;
-
-    const argv0Basename = path.basename(argv0);
-    if (!FFMPEG_BASENAMES.has(argv0Basename)) continue;
-
-    if (!argv.some((arg) => argIsUnderHlsRoot(arg, normalizedRoot))) {
-      continue;
-    }
-
-    // Only reap true orphans: a previous-engine ffmpeg child whose
-    // parent died and got reparented to init. If PPID is anything
-    // else (a live engine, a debugger holding it, a manual run), we
-    // must NOT reap — that's somebody else's process.
-    //
-    // Why this works in production: when our engine dies (kill -9,
-    // OOM, panic), its ffmpeg children are reparented to init by the
-    // kernel synchronously at parent exit. By the time the watchdog
-    // calls start-engine.sh and the new engine boots, the orphans
-    // already have PPID=1.
-    const ppid = await readPpid(procRoot, pid);
-    if (ppid !== 1) continue;
-
-    matches.push(pid);
   }
 
   return matches;
@@ -246,7 +255,13 @@ export async function cleanupOrphanFfmpegs(
     delayMs = defaultDelay,
   } = opts;
 
-  const matches = await scanForOrphans(procRoot, hlsRoot);
+  // Canonicalize hlsRoot once. ffmpeg arg paths come from
+  // path.join(config.hlsRoot, stage.id, ...) in the supervisor, so
+  // matching against a canonicalized root is consistent with how the
+  // engine produces those paths.
+  const normalizedRoot = path.resolve(hlsRoot);
+
+  const matches = await scanForOrphans(procRoot, normalizedRoot);
   if (matches.length === 0) {
     return { killed: 0, attempted: 0 };
   }
@@ -256,6 +271,13 @@ export async function cleanupOrphanFfmpegs(
   );
 
   for (const pid of matches) {
+    // PID-reuse TOCTOU defense: re-validate identity immediately
+    // before signaling. If the pid exited between scan and now and
+    // Linux recycled it for an unrelated process, we'd otherwise
+    // signal the wrong workload.
+    if (!(await matchesOrphanFfmpeg(procRoot, pid, normalizedRoot))) {
+      continue;
+    }
     try {
       killImpl(pid, "SIGTERM");
     } catch (err) {
@@ -286,6 +308,11 @@ export async function cleanupOrphanFfmpegs(
   let killed = 0;
   for (const pid of matches) {
     if (isAlive(pid, killImpl)) {
+      // Same TOCTOU defense as the SIGTERM pass: re-validate before
+      // SIGKILL in case the pid was recycled into something else.
+      if (!(await matchesOrphanFfmpeg(procRoot, pid, normalizedRoot))) {
+        continue;
+      }
       try {
         killImpl(pid, "SIGKILL");
         killed++;


### PR DESCRIPTION
## Summary

Reap any ffmpeg processes left behind by a previous engine run before any new supervisor starts. Closes one of the four follow-ups from #19.

## The bug

When the engine is killed (kill -9, OOM, watchdog respawn after HTTP 000), its ffmpeg children become orphans (PPID=1) and keep writing HLS segments until they hit a broken pipe or finish their input. The new engine's `cleanStageDir` then races with the dying orphans:

- New ffmpegs spawn with `+append_list`, read the leftover m3u8, continue the segment counter (e.g. start at `seg-04060` instead of `seg-00000`)
- `/dev/shm/<stage>/` accumulates leftover `seg-04xxx` files that `cleanStageDir` already passed by
- `failed to delete old segment` warnings spam `engine.log`

**Verified live on Whatbox during Task 7 smoke test (2026-05-05)**: `kill -9` of pid 121115 left 5 of 10 stages with leftover `seg-04xxx` files written by orphan ffmpegs over ~3 minutes after engine death. Listener-invisible, but operational hygiene matters.

## Approach

Whatbox lacks `setpriv(1)` so we can't use `--pdeathsig SIGKILL` at spawn time (the kernel-level fix). Instead, `cleanupOrphanFfmpegs` runs at bootstrap, **before any new supervisor starts**:

1. Scan `/proc` for ffmpeg processes whose cmdline references `HLS_ROOT`
2. SIGTERM all matches
3. Wait `termWaitMs` (default 2 s) for natural death
4. SIGKILL stragglers

Skips own pid, processes whose cmdline doesn't reference our HLS_ROOT (other tenants on shared host, jellyfin's bundled ffmpeg, etc.), and tolerates ESRCH/EACCES races.

## What this does NOT do

- No process group / setpgid changes (runner.ts spawn options unchanged) — defensive cleanup is sufficient
- Does not address the per-stage progress watchdog (separate slice from #19)
- Does not change ffmpeg lifecycle in normal operation — only on engine start after a previous run died

## Inner-loop CR feedback addressed

Pre-push CodeRabbit caught a [P1] correctness bug on the first commit: `defaultKill` swallowed ESRCH for **all** signals including `0`, which made `isAlive()` always return true and caused the SIGTERM grace period to collapse to "always SIGKILL." Fixed in commit `b950a0b` — `defaultKill` now propagates ESRCH on signal 0, with a regression test block that exercises real `defaultKill` against real spawned children plus an end-to-end integration test.

## Test plan

- [x] CodeRabbit pre-push (both commits): clean
- [x] 255 tests pass locally (was 230, +25 for this slice: 16 unit + 4 defaultKill regression + 1 integration + 4 bootstrap integration)
- [x] Smoke-tested against real `/proc` on dev machine (Linux)
- [ ] CodeRabbit GH App review on pushed HEAD: pending
- [ ] Codex independent review: pending

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Engine runs an initial, non-fatal orphan-ffmpeg cleanup at startup (before supervisors), logs a reap summary only when orphans are found, and treats cleanup failures as non-fatal.

* **Tests**
  * Added comprehensive tests for orphan detection, signal escalation/timing, real-process behavior, logging, and improved test isolation to prevent accidental process kills during bootstrap tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->