### PR TITLE
chore(deploy): pin NODE_BIN after env source (issue #19)

### DIFF
--- a/deploy/bin/start-engine.sh
+++ b/deploy/bin/start-engine.sh
@@ -63,12 +63,21 @@ is_our_engine() {
 RADIO_HOME="${RADIO_HOME:-$HOME/webradio-v3}"
 ENV_FILE="${RADIO_ENV_FILE:-$HOME/.config/radio/env}"
 
+NODE_BIN="$RADIO_HOME/bin/node"
 ENGINE_ENTRY="$RADIO_HOME/apps/engine/dist/index.js"
 LOG_DIR="$RADIO_HOME/logs"
 RUN_DIR="$RADIO_HOME/run"
 PID_FILE="$RUN_DIR/engine.pid"
 LOG_FILE="$LOG_DIR/engine.log"
 LOCK_FILE="$RUN_DIR/engine.lock"
+
+# Snapshot the pre-source NODE_BIN so a legacy env (`NODE_BIN=...`
+# from Week 0, or — against the docs — `RADIO_HOME=...`) can't
+# shift our Node binary path. Other derived paths above are already
+# pre-source and not subject to this drift; only NODE_BIN needs
+# re-pinning because it's the only one operators are likely to
+# have in their env file.
+PINNED_NODE_BIN="$NODE_BIN"
 
 [ -f "$ENV_FILE" ] || die "env file not found: $ENV_FILE (see WEEK0_LOG.md Req G)"
 # Auto-export every assignment in the env file so PLEX_TOKEN, HLS_ROOT, etc.
@@ -79,14 +88,10 @@ set -a
 . "$ENV_FILE"
 set +a
 
-# Pin NODE_BIN to the deploy symlink AFTER sourcing the env file. The
-# Week-0 env template had NODE_BIN=<absolute path to a specific mise
-# install> (e.g. .../node/22.22.2/bin/node). With `set -a` above, a
-# surviving NODE_BIN= line in someone's env would override our default
-# and break the deploy if mise ever prunes that exact version. The
-# bin/node symlink is the supported path; legacy env values are
-# intentionally ignored.
-NODE_BIN="$RADIO_HOME/bin/node"
+# Restore the pre-source NODE_BIN. The bin/node symlink is the
+# supported path; legacy env values are intentionally ignored.
+NODE_BIN="$PINNED_NODE_BIN"
+unset PINNED_NODE_BIN
 
 # Read wait-knob env vars AFTER sourcing the env file — the operator's
 # overrides in $ENV_FILE need to take effect, not the bash environment at

--- a/deploy/bin/start-engine.sh
+++ b/deploy/bin/start-engine.sh
@@ -63,7 +63,6 @@ is_our_engine() {
 RADIO_HOME="${RADIO_HOME:-$HOME/webradio-v3}"
 ENV_FILE="${RADIO_ENV_FILE:-$HOME/.config/radio/env}"
 
-NODE_BIN="$RADIO_HOME/bin/node"
 ENGINE_ENTRY="$RADIO_HOME/apps/engine/dist/index.js"
 LOG_DIR="$RADIO_HOME/logs"
 RUN_DIR="$RADIO_HOME/run"
@@ -79,6 +78,15 @@ set -a
 # shellcheck disable=SC1090  # path resolved at runtime, not lintable here
 . "$ENV_FILE"
 set +a
+
+# Pin NODE_BIN to the deploy symlink AFTER sourcing the env file. The
+# Week-0 env template had NODE_BIN=<absolute path to a specific mise
+# install> (e.g. .../node/22.22.2/bin/node). With `set -a` above, a
+# surviving NODE_BIN= line in someone's env would override our default
+# and break the deploy if mise ever prunes that exact version. The
+# bin/node symlink is the supported path; legacy env values are
+# intentionally ignored.
+NODE_BIN="$RADIO_HOME/bin/node"
 
 # Read wait-knob env vars AFTER sourcing the env file — the operator's
 # overrides in $ENV_FILE need to take effect, not the bash environment at

--- a/deploy/env.example
+++ b/deploy/env.example
@@ -12,6 +12,12 @@
 # RADIO_HOME and RADIO_ENV_FILE are NOT settable here — both wrappers read
 # them BEFORE this file is sourced. To override either, set them in the
 # crontab line itself (e.g. RADIO_HOME=/srv/webradio ~/webradio-v3/bin/...).
+#
+# NODE_BIN is reserved by start-engine.sh: it always uses
+# $RADIO_HOME/bin/node (a symlink to the mise-managed Node 22.22.2). Any
+# NODE_BIN= line in this file is silently ignored — the wrapper re-pins
+# it after sourcing this file. Legacy operators with a hard-coded
+# NODE_BIN=<absolute path> from Week 0 setup can safely remove that line.
 
 # ============================================================================
 # Plex (REQUIRED)


### PR DESCRIPTION
## Summary

Closes one of the four follow-ups in #19 (NODE_BIN env-file drift trap).

`start-engine.sh` sets `NODE_BIN` to the deploy symlink (`\$RADIO_HOME/bin/node`), then sources `~/.config/radio/env` with `set -a`. If an operator has `NODE_BIN=<absolute path>` in their env (left over from Week 0 setup), it overrides the symlink and breaks the deploy if mise ever prunes that exact version.

Fix: re-pin `NODE_BIN` AFTER sourcing the env file. The `bin/node` symlink is the supported path; any `NODE_BIN=` line in env is silently ignored.

## Why this is safe

The `bin/node` symlink is set up during `Initial deploy` (per `deploy/README.md` step 1) and points at `~/.local/share/mise/installs/node/22.22.2/bin/node`. The wrapper has always trusted this symlink — sourcing the env was just letting the operator's env override it accidentally.

Documented the contract in `env.example` so operators know any `NODE_BIN=` line is safe to remove.

## Verified

Probe script with `NODE_BIN=/some/legacy/path/node` in env produces `NODE_BIN=\$RADIO_HOME/bin/node` after the wrapper's source-then-pin sequence. Other env vars (`PLEX_TOKEN`, `HLS_ROOT`, etc.) still propagate normally.

## Live state on Whatbox

The Whatbox `~/.config/radio/env` still has the legacy `NODE_BIN=` line. After this merges, that line becomes a no-op. I'll remove it from the live env file in the post-merge deploy step (next time we re-rsync after slices 2 + 3 land), but it's not required for correctness — the wrapper already defends against it.

## Test plan

- [x] CodeRabbit pre-push: clean
- [x] bash -n syntax check: OK
- [x] Probe script verifies override-after-source behavior
- [x] All 262 engine tests still pass (no TS changed)
- [ ] CodeRabbit GH App review on pushed HEAD
- [ ] Codex independent review

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Ensures the chosen Node binary cannot be overridden by environment files, keeping engine startup consistent.

* **Documentation**
  * Clarified environment guidance to note that the Node binary selection is reserved by the startup process and will be re-applied after loading env files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->