### PR TITLE
feat(deploy): log-rotate.sh — copytruncate rotation (issue #19)

### DIFF
--- a/deploy/README.md
+++ b/deploy/README.md
@@ -15,7 +15,8 @@ manager — just `cron + nohup + watchdog`, the pattern v1/v2 already use
 ├── bin/
 │   ├── node                  # symlink → mise-managed Node 22.22.2
 │   ├── start-engine.sh       # symlink → ../deploy/bin/start-engine.sh
-│   └── watchdog.sh           # symlink → ../deploy/bin/watchdog.sh
+│   ├── watchdog.sh           # symlink → ../deploy/bin/watchdog.sh
+│   └── log-rotate.sh         # symlink → ../deploy/bin/log-rotate.sh
 ├── deploy/                   # checked-in scripts + this README
 ├── logs/
 │   ├── engine.log            # engine stdout + stderr (append-only)
@@ -62,7 +63,8 @@ Verify `~/webradio-v3/apps/engine/dist/index.js` exists.
 ```bash
 ssh whatbox 'cd ~/webradio-v3/bin && \
   ln -sf ../deploy/bin/start-engine.sh && \
-  ln -sf ../deploy/bin/watchdog.sh'
+  ln -sf ../deploy/bin/watchdog.sh && \
+  ln -sf ../deploy/bin/log-rotate.sh'
 ```
 
 ### 4. Create the env file

--- a/deploy/bin/log-rotate.sh
+++ b/deploy/bin/log-rotate.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+# deploy/bin/log-rotate.sh — size-capped, copytruncate log rotation.
+#
+# Closes one of the four follow-ups in #19 (log-rotation hygiene).
+#
+# What it does:
+#   - For each managed log under $RADIO_HOME/logs/, if size > MAX_BYTES,
+#     save the last TAIL_BYTES to <file>.last (so recent context survives),
+#     then truncate the live file IN-PLACE (`: > file`).
+#
+# Why copytruncate (not move-and-signal):
+#   - The engine is nohup'd and has an open append-mode fd on engine.log.
+#     If we `mv engine.log engine.log.1` and create a new engine.log, the
+#     engine's fd still points at the old inode, and future writes land
+#     in engine.log.1 — not what cron-tail expects.
+#   - `: > file` truncates the inode in place, leaving the engine's fd
+#     pointing at the (now-empty) same file. The next append starts at
+#     position 0. Lossy for whatever the engine wrote between our tail
+#     copy and the truncate, but the window is sub-millisecond and the
+#     log is informational, not transactional.
+#
+# Defaults are conservative for a personal Whatbox deploy (252 GB tmpfs,
+# ~5 TB user disk):
+#   - MAX_BYTES default: 50 MB. Triggered nightly per crontab.example.
+#   - TAIL_BYTES default: 5 MB. Saved to <file>.last for post-mortem.
+#
+# Operator override via env (or before invocation):
+#   LOG_ROTATE_MAX_BYTES=104857600 ~/webradio-v3/bin/log-rotate.sh
+#
+# Failure semantics:
+#   - Missing log file → no-op (engine may not have started yet).
+#   - LOG_DIR missing → no-op + non-zero exit (cron will mail the error).
+#   - tail / : > / cp failures bubble up via set -e; cron logs them.
+
+set -euo pipefail
+
+RADIO_HOME="${RADIO_HOME:-$HOME/webradio-v3}"
+LOG_DIR="$RADIO_HOME/logs"
+MAX_BYTES="${LOG_ROTATE_MAX_BYTES:-52428800}"   # 50 MB
+TAIL_BYTES="${LOG_ROTATE_TAIL_BYTES:-5242880}"  # 5 MB
+
+# Bail on garbage env values (cron treats stderr as mail).
+case "$MAX_BYTES" in
+  ''|*[!0-9]*) echo "log-rotate: LOG_ROTATE_MAX_BYTES must be a non-negative integer, got $MAX_BYTES" >&2; exit 2 ;;
+esac
+case "$TAIL_BYTES" in
+  ''|*[!0-9]*) echo "log-rotate: LOG_ROTATE_TAIL_BYTES must be a non-negative integer, got $TAIL_BYTES" >&2; exit 2 ;;
+esac
+if [ "$TAIL_BYTES" -ge "$MAX_BYTES" ]; then
+  echo "log-rotate: LOG_ROTATE_TAIL_BYTES ($TAIL_BYTES) must be less than LOG_ROTATE_MAX_BYTES ($MAX_BYTES)" >&2
+  exit 2
+fi
+
+if [ ! -d "$LOG_DIR" ]; then
+  echo "log-rotate: $LOG_DIR not found (engine never deployed?)" >&2
+  exit 1
+fi
+
+# Files we manage. Anything else under logs/ is left alone (operator may
+# have placed manual archives there).
+LOGS=(engine.log cron.log)
+
+rotate_one() {
+  local file="$1"
+  if [ ! -f "$file" ]; then
+    # Log not yet created (e.g. first cron tick before engine ever ran).
+    # No-op, no warning.
+    return 0
+  fi
+
+  local size
+  size=$(stat -c%s "$file")
+  if [ "$size" -lt "$MAX_BYTES" ]; then
+    return 0
+  fi
+
+  # Save the tail before truncating. If the whole file is shorter than
+  # TAIL_BYTES (shouldn't happen given the size>MAX_BYTES gate above,
+  # but defensive), fall back to a full copy.
+  if [ "$size" -gt "$TAIL_BYTES" ]; then
+    tail -c "$TAIL_BYTES" "$file" > "$file.last"
+  else
+    cp -p "$file" "$file.last"
+  fi
+  chmod 600 "$file.last"
+
+  # Truncate the live file in place (keeps inode → engine's open fd
+  # remains valid).
+  : > "$file"
+
+  printf '[log-rotate] %s rotated %s (was %s bytes; tail saved to %s.last)\n' \
+    "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$file" "$size" "$file"
+}
+
+for name in "${LOGS[@]}"; do
+  rotate_one "$LOG_DIR/$name"
+done

--- a/deploy/bin/log-rotate.sh
+++ b/deploy/bin/log-rotate.sh
@@ -16,8 +16,11 @@
 #   - `: > file` truncates the inode in place, leaving the engine's fd
 #     pointing at the (now-empty) same file. The next append starts at
 #     position 0. Lossy for whatever the engine wrote between our tail
-#     copy and the truncate, but the window is sub-millisecond and the
-#     log is informational, not transactional.
+#     copy and the truncate — the window is the duration of the tail
+#     read (milliseconds for 5 MB on tmpfs, longer under IO pressure),
+#     which is acceptable because the log is informational, not
+#     transactional. cron.log gets rotated during a minute the watchdog
+#     also writes to; same trade-off.
 #
 # Defaults are conservative for a personal Whatbox deploy (252 GB tmpfs,
 # ~5 TB user disk):
@@ -34,8 +37,15 @@
 
 set -euo pipefail
 
+# Tighten file creation perms so the brief moment between creat() and
+# our explicit chmod 600 isn't a window for group/world-readable files
+# under a permissive cron umask. (Codex P3 on PR #23.)
+umask 077
+
 RADIO_HOME="${RADIO_HOME:-$HOME/webradio-v3}"
 LOG_DIR="$RADIO_HOME/logs"
+RUN_DIR="$RADIO_HOME/run"
+LOCK_FILE="$RUN_DIR/log-rotate.lock"
 MAX_BYTES="${LOG_ROTATE_MAX_BYTES:-52428800}"   # 50 MB
 TAIL_BYTES="${LOG_ROTATE_TAIL_BYTES:-5242880}"  # 5 MB
 
@@ -56,6 +66,18 @@ if [ ! -d "$LOG_DIR" ]; then
   exit 1
 fi
 
+# Single-instance lock so a manual run overlapping cron (or a hung
+# previous run) can't race two truncates. Same pattern as start-engine
+# and watchdog. RUN_DIR may not exist yet on a brand-new deploy; create
+# it best-effort.
+mkdir -p "$RUN_DIR" 2>/dev/null || true
+exec 9>"$LOCK_FILE"
+if ! flock -n 9; then
+  # Another rotator is running — exit silently. Cron will retry tomorrow,
+  # and the script is idempotent (rotate-if-too-large), so no work lost.
+  exit 0
+fi
+
 # Files we manage. Anything else under logs/ is left alone (operator may
 # have placed manual archives there).
 LOGS=(engine.log cron.log)
@@ -74,15 +96,18 @@ rotate_one() {
     return 0
   fi
 
-  # Save the tail before truncating. If the whole file is shorter than
-  # TAIL_BYTES (shouldn't happen given the size>MAX_BYTES gate above,
-  # but defensive), fall back to a full copy.
+  # Save the tail to a temp file in the same directory, then atomically
+  # rename to <file>.last. If tail/cp is interrupted (signal, ENOSPC),
+  # we keep the previous .last instead of clobbering it with a partial.
+  # (Codex P2 on PR #23.)
+  local tmp="$file.last.tmp.$$"
   if [ "$size" -gt "$TAIL_BYTES" ]; then
-    tail -c "$TAIL_BYTES" "$file" > "$file.last"
+    tail -c "$TAIL_BYTES" "$file" > "$tmp"
   else
-    cp -p "$file" "$file.last"
+    cp -p "$file" "$tmp"
   fi
-  chmod 600 "$file.last"
+  chmod 600 "$tmp"
+  mv -f "$tmp" "$file.last"
 
   # Truncate the live file in place (keeps inode → engine's open fd
   # remains valid).

--- a/deploy/crontab.example
+++ b/deploy/crontab.example
@@ -24,3 +24,9 @@
 # 5xx means alive-but-degraded and does NOT trigger restart — restart would
 # destroy diagnostic state.
 * * * * * ~/webradio-v3/bin/watchdog.sh >>~/webradio-v3/logs/cron.log 2>&1
+
+# Rotate engine.log + cron.log nightly. Copytruncate semantics: when a log
+# exceeds 50 MB, the last 5 MB is saved to <file>.last and the live file
+# is truncated in place (so the nohup'd engine's open fd keeps working).
+# Override sizes via LOG_ROTATE_MAX_BYTES / LOG_ROTATE_TAIL_BYTES env.
+0 3 * * * ~/webradio-v3/bin/log-rotate.sh >>~/webradio-v3/logs/cron.log 2>&1


### PR DESCRIPTION
## Summary

Closes the third of four follow-ups in #19 (log rotation hygiene). After this lands, the only remaining item from #19 is the deferred /api/health audio-plane visibility work (v3.1+).

Adds `deploy/bin/log-rotate.sh`: when `engine.log` or `cron.log` exceeds 50 MB (override via `LOG_ROTATE_MAX_BYTES`), saves the last 5 MB to `<file>.last`, then truncates the live file in place. Plus a nightly 03:00 cron entry.

## Why copytruncate (not move-and-signal)

The engine is `nohup`'d with an open append-mode fd on `engine.log`. `mv engine.log archive && touch engine.log` would leave the engine writing to the renamed file (its fd holds the old inode). `: > engine.log` truncates the inode in place; the open fd stays valid and the next append starts at position 0.

Verified live: a process holding fd 9 in append mode writes correctly to the truncated file post-rotation. Inode preserved across `: > file`.

## Operational defaults

- `LOG_ROTATE_MAX_BYTES=52428800` (50 MB)
- `LOG_ROTATE_TAIL_BYTES=5242880` (5 MB)
- Override via env vars set on the cron line if needed
- Whatbox has 252 GB tmpfs / ~5 TB user disk so this is mostly hygiene; intent is to keep tail manageable

## Failure modes

| Condition | Behavior |
|---|---|
| Log file doesn't exist | silent no-op |
| Log file under threshold | no-op |
| Log directory missing | exit 1 (cron mails error) |
| Invalid env value (non-numeric) | exit 2 (cron mails error) |
| TAIL_BYTES >= MAX_BYTES | exit 2 (config error) |

## Test plan

- [x] CodeRabbit pre-push: clean
- [x] `bash -n` syntax check
- [x] Smoke-tested 5 edge cases (missing file, small file, invalid env, config error, missing LOG_DIR)
- [x] Inode preservation + open-fd append behavior verified
- [ ] CodeRabbit GH App review on pushed HEAD
- [ ] Codex independent review

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automatic, size-based log rotation that preserves recent log content and prevents concurrent runs.
  * Added a nightly scheduled job to run the log rotation.

* **Documentation**
  * Updated installation steps to include creating the log-rotation symlink during setup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->