### PR TITLE
feat(web): NowPlaying card + 5s /now polling (Week 2 Slice C)

### DIFF
--- a/apps/web/src/api/now.ts
+++ b/apps/web/src/api/now.ts
@@ -1,0 +1,36 @@
+import { useQuery } from "@tanstack/react-query";
+import type { NowPlaying } from "@pavoia/shared";
+
+import { ApiError } from "./stages.ts";
+
+async function fetchNow(stageId: string): Promise<NowPlaying> {
+  const res = await fetch(
+    `/api/stages/${encodeURIComponent(stageId)}/now`,
+  );
+  if (!res.ok) {
+    throw new ApiError(
+      `/api/stages/${stageId}/now returned HTTP ${res.status}`,
+      res.status,
+    );
+  }
+  return (await res.json()) as NowPlaying;
+}
+
+/**
+ * Polls /api/stages/:id/now every 5 s — matches v1's polling cadence
+ * and the SLIM_V3 spec. TanStack Query handles the visibility-pause
+ * automatically: when the tab goes hidden the interval halts, when
+ * it returns we refetch immediately.
+ */
+export function useStageNow(stageId: string) {
+  return useQuery({
+    queryKey: ["now", stageId],
+    queryFn: () => fetchNow(stageId),
+    refetchInterval: 5_000,
+    refetchIntervalInBackground: false,
+    // Treat the snapshot as fresh for one tick. If we leave staleTime
+    // at the global 5 s default, focus events trigger a flood of
+    // refetches; pinning to the interval keeps it predictable.
+    staleTime: 5_000,
+  });
+}

--- a/apps/web/src/components/NowPlaying.tsx
+++ b/apps/web/src/components/NowPlaying.tsx
@@ -1,0 +1,108 @@
+import type { NowPlaying as NowPlayingPayload, Stage } from "@pavoia/shared";
+
+import { TrackProgress } from "./TrackProgress.tsx";
+
+interface NowPlayingProps {
+  stage: Stage;
+  payload: NowPlayingPayload;
+}
+
+/**
+ * Card showing the currently audible track on a stage.
+ *
+ * Three states:
+ *   - playing + track: title/artist/album/year + progress bar
+ *   - curating (fallback loop is on, no real track) or any other
+ *     status without a track: an honest placeholder that says so
+ *   - any unrecognized state: same placeholder; never a crash
+ *
+ * Cover art is intentionally text-only for now. Slice E (player
+ * chrome polish) adds a Plex-thumb proxy on the engine side and
+ * wires the cover image here.
+ */
+export function NowPlaying({ stage, payload }: NowPlayingProps) {
+  const { status, track, startedAt } = payload;
+
+  if (track && startedAt !== null && status === "playing") {
+    const yearSuffix =
+      typeof track.albumYear === "number" ? ` · ${track.albumYear}` : "";
+    return (
+      <article className="rounded-2xl border border-slate-800/60 bg-black/40 p-6 backdrop-blur-sm md:p-8">
+        <StatusPill status={status} accent={stage.accent} />
+        <h3 className="mt-4 text-balance text-2xl font-semibold leading-tight text-slate-100 md:text-3xl">
+          {track.title}
+        </h3>
+        <p className="mt-1 text-base text-slate-300">{track.artist}</p>
+        <p className="mt-0.5 text-sm text-slate-400">
+          {track.album}
+          {yearSuffix}
+        </p>
+        <div className="mt-6">
+          <TrackProgress
+            startedAt={startedAt}
+            durationSec={track.durationSec}
+            accent={stage.accent}
+          />
+        </div>
+      </article>
+    );
+  }
+
+  return (
+    <article className="rounded-2xl border border-slate-800/60 bg-black/40 p-6 backdrop-blur-sm md:p-8">
+      <StatusPill status={status} accent={stage.accent} />
+      <p className="mt-4 text-base text-slate-400">{describePlaceholder(status)}</p>
+    </article>
+  );
+}
+
+function StatusPill({
+  status,
+  accent,
+}: {
+  status: NowPlayingPayload["status"];
+  accent: string;
+}) {
+  return (
+    <div className="inline-flex items-center gap-2 rounded-full border border-slate-700/60 bg-slate-900/60 px-3 py-1 text-xs uppercase tracking-wide text-slate-400">
+      <span
+        className="h-2 w-2 rounded-full"
+        style={{ backgroundColor: status === "playing" ? accent : "#475569" }}
+      />
+      {label(status)}
+    </div>
+  );
+}
+
+function label(status: NowPlayingPayload["status"]): string {
+  switch (status) {
+    case "playing":
+      return "Now playing";
+    case "curating":
+      return "Curating";
+    case "starting":
+      return "Starting";
+    case "stopping":
+      return "Stopping";
+    case "stopped":
+      return "Stopped";
+  }
+}
+
+function describePlaceholder(status: NowPlayingPayload["status"]): string {
+  switch (status) {
+    case "curating":
+      return "Between tracks — fallback loop is playing.";
+    case "starting":
+      return "Stage is starting up…";
+    case "stopping":
+      return "Stage is shutting down.";
+    case "stopped":
+      return "Stage is offline.";
+    case "playing":
+      // Edge case: status=playing but track or startedAt missing.
+      // The supervisor briefly sits here between a track ending and
+      // the next first segment landing on disk.
+      return "Loading next track…";
+  }
+}

--- a/apps/web/src/components/NowPlaying.tsx
+++ b/apps/web/src/components/NowPlaying.tsx
@@ -74,6 +74,13 @@ function StatusPill({
   );
 }
 
+// Both label() and describePlaceholder() take the status as a typed
+// union, but the value is parsed from JSON without runtime validation
+// (see api/now.ts) — so future engine schema drift could deliver an
+// unrecognized string. Default arms keep the UI coherent instead of
+// rendering blank text, and the cast surfaces the unknown value to
+// the operator via the visible label.
+
 function label(status: NowPlayingPayload["status"]): string {
   switch (status) {
     case "playing":
@@ -86,6 +93,8 @@ function label(status: NowPlayingPayload["status"]): string {
       return "Stopping";
     case "stopped":
       return "Stopped";
+    default:
+      return String(status);
   }
 }
 
@@ -104,5 +113,7 @@ function describePlaceholder(status: NowPlayingPayload["status"]): string {
       // The supervisor briefly sits here between a track ending and
       // the next first segment landing on disk.
       return "Loading next track…";
+    default:
+      return `Stage is in an unknown state (${String(status)}).`;
   }
 }

--- a/apps/web/src/components/TrackProgress.tsx
+++ b/apps/web/src/components/TrackProgress.tsx
@@ -1,0 +1,78 @@
+import { useEffect, useState } from "react";
+
+interface TrackProgressProps {
+  /** Wall-clock ms when the track started playing (NowPlaying.startedAt). */
+  startedAt: number;
+  /** Track duration in seconds (PublicTrack.durationSec). */
+  durationSec: number;
+  /** Accent color for the progress fill (stage.accent). */
+  accent: string;
+}
+
+/**
+ * Local elapsed-time ticker driven from `startedAt` rather than from
+ * server polls — so the bar moves smoothly between 5 s /now refetches.
+ *
+ * Updates once per second; that's enough resolution for a track-length
+ * bar and avoids re-renders on every animation frame.
+ *
+ * Out-of-range elapsed values (negative if startedAt is in the future,
+ * or >duration if a poll missed the boundary) are clamped to [0, dur]
+ * so the bar never overflows.
+ */
+export function TrackProgress({
+  startedAt,
+  durationSec,
+  accent,
+}: TrackProgressProps) {
+  const [elapsedSec, setElapsedSec] = useState(() =>
+    computeElapsed(startedAt, durationSec),
+  );
+
+  useEffect(() => {
+    setElapsedSec(computeElapsed(startedAt, durationSec));
+    const id = setInterval(() => {
+      setElapsedSec(computeElapsed(startedAt, durationSec));
+    }, 1_000);
+    return () => clearInterval(id);
+  }, [startedAt, durationSec]);
+
+  const pct =
+    durationSec > 0
+      ? Math.min(100, Math.max(0, (elapsedSec / durationSec) * 100))
+      : 0;
+
+  return (
+    <div className="space-y-1.5">
+      <div
+        className="h-1 overflow-hidden rounded-full bg-slate-800"
+        role="progressbar"
+        aria-valuenow={Math.round(pct)}
+        aria-valuemin={0}
+        aria-valuemax={100}
+        aria-label="Track progress"
+      >
+        <div
+          className="h-full rounded-full transition-[width] duration-1000 ease-linear"
+          style={{ width: `${pct}%`, backgroundColor: accent }}
+        />
+      </div>
+      <div className="flex justify-between text-xs tabular-nums text-slate-400">
+        <span>{formatTime(elapsedSec)}</span>
+        <span>{formatTime(durationSec)}</span>
+      </div>
+    </div>
+  );
+}
+
+function computeElapsed(startedAt: number, durationSec: number): number {
+  const sec = Math.max(0, (Date.now() - startedAt) / 1000);
+  return Math.min(durationSec, sec);
+}
+
+function formatTime(totalSec: number): string {
+  const safe = Math.max(0, Math.floor(totalSec));
+  const m = Math.floor(safe / 60);
+  const s = safe % 60;
+  return `${m}:${s.toString().padStart(2, "0")}`;
+}

--- a/apps/web/src/pages/StageDetailPage.tsx
+++ b/apps/web/src/pages/StageDetailPage.tsx
@@ -102,7 +102,7 @@ interface StageNowSectionProps {
 }
 
 function StageNowSection({ stageId, stage }: StageNowSectionProps) {
-  const { data, isLoading, isError, error } = useStageNow(stageId);
+  const { data, isLoading, error } = useStageNow(stageId);
 
   if (isLoading) {
     return (
@@ -112,7 +112,13 @@ function StageNowSection({ stageId, stage }: StageNowSectionProps) {
     );
   }
 
-  if (isError || !data) {
+  // The blocking error state only fires on initial-load failure
+  // (data is undefined). TanStack Query keeps the last successful
+  // snapshot in `data` across transient refetch errors, so a 5 s
+  // poll that flakes mid-listen doesn't replace the live card with
+  // an error panel. The lower-corner badge still surfaces "stale"
+  // so the listener knows the timestamp may be lagging.
+  if (!data) {
     return (
       <article className="rounded-2xl border border-rose-900/60 bg-rose-950/20 p-6 backdrop-blur-sm md:p-8">
         <p className="text-sm font-medium text-rose-300">
@@ -125,5 +131,15 @@ function StageNowSection({ stageId, stage }: StageNowSectionProps) {
     );
   }
 
-  return <NowPlaying stage={stage} payload={data} />;
+  return (
+    <>
+      <NowPlaying stage={stage} payload={data} />
+      {error ? (
+        <p className="mt-2 text-xs text-amber-300/80">
+          ⚠ Live updates are stalled (engine unreachable). Track shown is
+          the last good snapshot.
+        </p>
+      ) : null}
+    </>
+  );
 }

--- a/apps/web/src/pages/StageDetailPage.tsx
+++ b/apps/web/src/pages/StageDetailPage.tsx
@@ -1,6 +1,8 @@
 import { useParams } from "@tanstack/react-router";
 
 import { useStages } from "../api/stages.ts";
+import { useStageNow } from "../api/now.ts";
+import { NowPlaying } from "../components/NowPlaying.tsx";
 
 /**
  * Per-stage detail page. Slice C will fill this with a NowPlaying
@@ -86,16 +88,42 @@ export function StageDetailPage() {
           {stage.fallbackDescription}
         </p>
 
-        <div className="mt-12 rounded-2xl border border-slate-800/60 bg-black/30 px-6 py-8 backdrop-blur-sm">
-          <p className="text-sm text-slate-400">
-            <span
-              className="mr-2 inline-block h-2 w-2 rounded-full"
-              style={{ backgroundColor: stage.accent }}
-            />
-            now-playing card lands in Slice C; audio in Slice D.
-          </p>
+        <div className="mt-12">
+          <StageNowSection stageId={stage.id} stage={stage} />
         </div>
       </div>
     </section>
   );
+}
+
+interface StageNowSectionProps {
+  stageId: string;
+  stage: import("@pavoia/shared").Stage;
+}
+
+function StageNowSection({ stageId, stage }: StageNowSectionProps) {
+  const { data, isLoading, isError, error } = useStageNow(stageId);
+
+  if (isLoading) {
+    return (
+      <article className="rounded-2xl border border-slate-800/60 bg-black/40 p-6 backdrop-blur-sm md:p-8">
+        <p className="text-sm text-slate-500">Loading current track…</p>
+      </article>
+    );
+  }
+
+  if (isError || !data) {
+    return (
+      <article className="rounded-2xl border border-rose-900/60 bg-rose-950/20 p-6 backdrop-blur-sm md:p-8">
+        <p className="text-sm font-medium text-rose-300">
+          Couldn't load the current track for this stage.
+        </p>
+        <p className="mt-1 text-xs text-rose-400/80">
+          {error instanceof Error ? error.message : "Unknown error"}
+        </p>
+      </article>
+    );
+  }
+
+  return <NowPlaying stage={stage} payload={data} />;
 }


### PR DESCRIPTION
## Summary

Week 2 Slice C — stage detail pages now show the current Plex track live: title, artist, album · year, status pill, and an animated progress bar that ticks locally between 5 s polls of \`/api/stages/:id/now\`.

## What ships

- **\`src/api/now.ts\`** — \`useStageNow(stageId)\` via TanStack Query, 5 s \`refetchInterval\`, \`refetchIntervalInBackground: false\` so hidden tabs don't burn engine CPU. Reuses \`ApiError\` from \`api/stages.ts\`.

- **\`src/components/TrackProgress.tsx\`** — local elapsed-time ticker driven from \`startedAt\`, updates 1×/sec so the bar moves smoothly between server polls. Clamps elapsed to \`[0, dur]\` to never overflow if a poll missed a track boundary. ARIA progressbar semantics.

- **\`src/components/NowPlaying.tsx\`** — three render branches:
  - \`playing\` + track + startedAt → full track card with progress
  - \`curating\` / \`starting\` / \`stopping\` / \`stopped\` → honest placeholder text
  - \`playing\` but no track yet → "Loading next track…" (the supervisor briefly sits here between a track ending and the next first segment landing on disk)

- **\`StageDetailPage\`** gains an internal \`StageNowSection\` that handles isLoading / isError around the card so the gradient backdrop doesn't flash an empty state.

## What this slice does NOT do

- **No cover art** — text-only on purpose. Slice E will add a \`/api/plex/thumb\` proxy to the engine (uses \`PLEX_TOKEN\` server-side; browser sees no token) and wire the image in. Doing it as part of Slice C would tangle web + engine in one PR.
- **No audio** — Slice D (the moment-of-truth).
- **No keyboard shortcuts / cross-stage hover preview** — Slice E / F.

## Verified

- [x] typecheck clean (\`NowPlaying\` type imported from \`@pavoia/shared\`)
- [x] Vite build: 320 KB JS / 101 KB gzipped, 20 KB CSS / 4 KB gzipped
- [x] CodeRabbit pre-push: clean
- [x] \`npm test\` green (262 engine + web echo)
- [ ] CodeRabbit GH App review on pushed HEAD
- [ ] Codex independent review

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added live now-playing display on stage pages with current track metadata and placeholder UIs for non-playing states.
  * Added a visual track progress indicator with elapsed time and duration.
  * Track information automatically refreshes every 5 seconds for up-to-date playback status.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->