### PR TITLE
feat(web): hls.js audio playback + Play/Pause (Week 2 Slice D — moment of truth)

### DIFF
--- a/apps/web/src/audio/useHls.ts
+++ b/apps/web/src/audio/useHls.ts
@@ -1,0 +1,157 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import Hls from "hls.js";
+
+/**
+ * Cold-start HLS playback for one stage. Single audio element per
+ * page; switching stages unmounts this hook (which destroys the
+ * Hls.js instance and releases the element), then re-mounts at the
+ * new stream URL. There is no crossfade or pre-warm — the SLIM_V3
+ * decision was simpler-and-cleaner over slicker.
+ *
+ * Browser support:
+ *   - Chromium / Firefox / Edge: hls.js (MSE).
+ *   - Safari (iOS / macOS): native HLS via <audio src=...> when
+ *     hls.js reports unsupported. We could force hls.js even on
+ *     Safari but native is usually more battery-efficient.
+ *   - Anything else (rare): we report an error state.
+ *
+ * Autoplay policy: browsers block .play() before user gesture, so
+ * we don't auto-call it. The PlayPauseButton triggers play(); the
+ * first user click is the gesture. Subsequent stage switches still
+ * require a fresh click — if Slice E adds session-scoped "user
+ * wants audio" memory, this hook can opt in then.
+ */
+export type PlaybackState =
+  | "idle" // hooked up but never played in this mount
+  | "loading" // waiting for buffer / first segment
+  | "playing"
+  | "paused"
+  | "error";
+
+export interface UseHlsResult {
+  /** Attach to a hidden <audio> element. */
+  audioRef: React.RefObject<HTMLAudioElement | null>;
+  state: PlaybackState;
+  error: string | null;
+  play: () => Promise<void>;
+  pause: () => void;
+}
+
+export function useHls(streamUrl: string): UseHlsResult {
+  const audioRef = useRef<HTMLAudioElement | null>(null);
+  const hlsRef = useRef<Hls | null>(null);
+  const [state, setState] = useState<PlaybackState>("idle");
+  const [error, setError] = useState<string | null>(null);
+
+  // Single effect that wires both the stream AND the audio-element
+  // event listeners. They share the same lifecycle (mount/streamUrl
+  // change/unmount), so combining them avoids the previous footgun
+  // where the listeners' empty-deps effect could miss a late-mounted
+  // ref (e.g. under React.lazy + Suspense).
+  useEffect(() => {
+    const audio = audioRef.current;
+    if (!audio) return;
+
+    setState("idle");
+    setError(null);
+
+    let cancelled = false;
+
+    // ── Media-element listeners ────────────────────────────────────
+    const onPlay = () => setState("playing");
+    const onPause = () => {
+      // pause fires both on user pause AND on stream change cleanup.
+      // The cleanup case is harmless: this effect's cleanup resets
+      // state back to "idle" via the next mount.
+      setState((prev) => (prev === "playing" ? "paused" : prev));
+    };
+    const onWaiting = () => setState("loading");
+    const onPlaying = () => setState("playing");
+    const onElementError = () => {
+      setState("error");
+      setError("Audio element reported an error.");
+    };
+
+    audio.addEventListener("play", onPlay);
+    audio.addEventListener("pause", onPause);
+    audio.addEventListener("waiting", onWaiting);
+    audio.addEventListener("playing", onPlaying);
+    audio.addEventListener("error", onElementError);
+
+    // ── HLS attachment ─────────────────────────────────────────────
+    if (Hls.isSupported()) {
+      const hls = new Hls({
+        // Live HLS tuning. The engine emits 3 s segments with a
+        // 6-segment rolling window (Req K), so a small back-buffer
+        // keeps memory bounded; capLevelToPlayerSize is moot for
+        // audio-only streams.
+        backBufferLength: 30,
+        maxBufferLength: 30,
+        // Engine drops segments that roll off the playlist; refusing
+        // to seek past the live edge is the safest default.
+        liveSyncDuration: 6,
+      });
+      hlsRef.current = hls;
+
+      hls.loadSource(streamUrl);
+      hls.attachMedia(audio);
+      hls.on(Hls.Events.ERROR, (_event, data) => {
+        if (cancelled) return;
+        if (data.fatal) {
+          setState("error");
+          setError(`${data.type}: ${data.details}`);
+          // Don't tear down — caller may try again. hls.js will
+          // attempt media recovery itself on some fatal errors.
+        }
+      });
+    } else if (audio.canPlayType("application/vnd.apple.mpegurl")) {
+      // Safari native HLS path.
+      audio.src = streamUrl;
+    } else {
+      setState("error");
+      setError("HLS playback is not supported in this browser.");
+    }
+
+    return () => {
+      cancelled = true;
+      audio.removeEventListener("play", onPlay);
+      audio.removeEventListener("pause", onPause);
+      audio.removeEventListener("waiting", onWaiting);
+      audio.removeEventListener("playing", onPlaying);
+      audio.removeEventListener("error", onElementError);
+
+      const hls = hlsRef.current;
+      hlsRef.current = null;
+      if (hls) {
+        hls.destroy();
+      }
+      // Detach src so the element fully releases the network buffer.
+      audio.pause();
+      audio.removeAttribute("src");
+      audio.load();
+    };
+  }, [streamUrl]);
+
+  const play = useCallback(async () => {
+    const audio = audioRef.current;
+    if (!audio) return;
+    setState("loading");
+    setError(null);
+    try {
+      await audio.play();
+    } catch (err) {
+      // Most common failure: NotAllowedError before user gesture.
+      // We surface it as an error state; the button will re-render
+      // its "Play" affordance and the next click usually succeeds
+      // because the gesture chain is now valid.
+      setState("error");
+      setError(err instanceof Error ? err.message : String(err));
+    }
+  }, []);
+
+  const pause = useCallback(() => {
+    audioRef.current?.pause();
+  }, []);
+
+  return { audioRef, state, error, play, pause };
+}

--- a/apps/web/src/audio/useHls.ts
+++ b/apps/web/src/audio/useHls.ts
@@ -40,6 +40,10 @@ export interface UseHlsResult {
 export function useHls(streamUrl: string): UseHlsResult {
   const audioRef = useRef<HTMLAudioElement | null>(null);
   const hlsRef = useRef<Hls | null>(null);
+  // Bumped on every streamUrl change so a play() rejection from a
+  // torn-down stream (e.g. user clicked play, then immediately
+  // switched stages) can't stamp the fresh stream as errored.
+  const streamVersionRef = useRef(0);
   const [state, setState] = useState<PlaybackState>("idle");
   const [error, setError] = useState<string | null>(null);
 
@@ -49,6 +53,7 @@ export function useHls(streamUrl: string): UseHlsResult {
   // where the listeners' empty-deps effect could miss a late-mounted
   // ref (e.g. under React.lazy + Suspense).
   useEffect(() => {
+    streamVersionRef.current += 1;
     const audio = audioRef.current;
     if (!audio) return;
 
@@ -97,11 +102,23 @@ export function useHls(streamUrl: string): UseHlsResult {
       hls.attachMedia(audio);
       hls.on(Hls.Events.ERROR, (_event, data) => {
         if (cancelled) return;
-        if (data.fatal) {
-          setState("error");
-          setError(`${data.type}: ${data.details}`);
-          // Don't tear down — caller may try again. hls.js will
-          // attempt media recovery itself on some fatal errors.
+        if (!data.fatal) return;
+        // hls.js exposes recovery APIs for the two common fatal
+        // types. Try them once before falling through to a terminal
+        // error state — this catches transient network blips and
+        // the occasional decoder hiccup without losing playback.
+        switch (data.type) {
+          case Hls.ErrorTypes.NETWORK_ERROR:
+            hls.startLoad();
+            setState("loading");
+            return;
+          case Hls.ErrorTypes.MEDIA_ERROR:
+            hls.recoverMediaError();
+            setState("loading");
+            return;
+          default:
+            setState("error");
+            setError(`${data.type}: ${data.details}`);
         }
       });
     } else if (audio.canPlayType("application/vnd.apple.mpegurl")) {
@@ -135,15 +152,25 @@ export function useHls(streamUrl: string): UseHlsResult {
   const play = useCallback(async () => {
     const audio = audioRef.current;
     if (!audio) return;
+    // Snapshot the stream version before we await play(). If the
+    // user switches stages mid-await, the rejection that fires when
+    // the old element gets paused/unloaded must NOT clobber the
+    // fresh stream's state.
+    const versionAtCall = streamVersionRef.current;
     setState("loading");
     setError(null);
     try {
       await audio.play();
     } catch (err) {
-      // Most common failure: NotAllowedError before user gesture.
-      // We surface it as an error state; the button will re-render
-      // its "Play" affordance and the next click usually succeeds
-      // because the gesture chain is now valid.
+      // Stale rejection from a torn-down stream — drop silently.
+      if (versionAtCall !== streamVersionRef.current) return;
+      // AbortError fires when the audio's src is yanked while a play
+      // promise is in flight. Same source: stale, drop silently.
+      if (err instanceof DOMException && err.name === "AbortError") return;
+      // Most common real failure: NotAllowedError before user gesture.
+      // Surface it as an error state; the button will re-render its
+      // "Play" affordance and the next click usually succeeds because
+      // the gesture chain is now valid.
       setState("error");
       setError(err instanceof Error ? err.message : String(err));
     }

--- a/apps/web/src/components/PlayPauseButton.tsx
+++ b/apps/web/src/components/PlayPauseButton.tsx
@@ -1,0 +1,116 @@
+import type { PlaybackState } from "../audio/useHls.ts";
+
+interface PlayPauseButtonProps {
+  state: PlaybackState;
+  accent: string;
+  onPlay: () => void;
+  onPause: () => void;
+  /** Disabled when the underlying stream URL isn't yet available. */
+  disabled?: boolean;
+}
+
+/**
+ * Single circular button with three visual states:
+ *   - idle / paused / error → play triangle (accent-colored fill)
+ *   - loading             → spinner ring
+ *   - playing             → pause bars
+ *
+ * v1's button had finer-grained loading detection but for radio's
+ * essentially-binary user model (you're listening or you're not),
+ * this is simpler and the listener gets exactly the affordance they
+ * expected. Slice E adds an EqualizerBars decoration for the
+ * "playing" state.
+ */
+export function PlayPauseButton({
+  state,
+  accent,
+  onPlay,
+  onPause,
+  disabled = false,
+}: PlayPauseButtonProps) {
+  const isPlaying = state === "playing";
+  const isLoading = state === "loading";
+
+  const ariaLabel = isPlaying ? "Pause" : "Play";
+
+  return (
+    <button
+      type="button"
+      onClick={isPlaying ? onPause : onPlay}
+      disabled={disabled}
+      aria-label={ariaLabel}
+      aria-pressed={isPlaying}
+      className="group relative flex h-16 w-16 items-center justify-center rounded-full border border-slate-700 bg-slate-900/80 text-slate-100 transition-all hover:border-slate-500 disabled:cursor-not-allowed disabled:opacity-50 md:h-20 md:w-20"
+      style={
+        isPlaying
+          ? {
+              borderColor: accent,
+              backgroundColor: `${accent}22`,
+            }
+          : undefined
+      }
+    >
+      {isLoading ? <Spinner accent={accent} /> : null}
+      {!isLoading && isPlaying ? <PauseIcon /> : null}
+      {!isLoading && !isPlaying ? <PlayIcon accent={accent} /> : null}
+    </button>
+  );
+}
+
+function PlayIcon({ accent }: { accent: string }) {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      width="28"
+      height="28"
+      fill={accent}
+      aria-hidden="true"
+      className="ml-1 transition-transform group-hover:scale-110"
+    >
+      <path d="M8 5.14v13.72L19 12 8 5.14z" />
+    </svg>
+  );
+}
+
+function PauseIcon() {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      width="24"
+      height="24"
+      fill="currentColor"
+      aria-hidden="true"
+    >
+      <rect x="6" y="4" width="4" height="16" rx="1" />
+      <rect x="14" y="4" width="4" height="16" rx="1" />
+    </svg>
+  );
+}
+
+function Spinner({ accent }: { accent: string }) {
+  return (
+    <svg
+      width="28"
+      height="28"
+      viewBox="0 0 24 24"
+      aria-hidden="true"
+      className="animate-spin"
+    >
+      <circle
+        cx="12"
+        cy="12"
+        r="9"
+        stroke="#475569"
+        strokeWidth="3"
+        fill="none"
+      />
+      <path
+        d="M21 12a9 9 0 0 0-9-9"
+        stroke={accent}
+        strokeWidth="3"
+        strokeLinecap="round"
+        fill="none"
+      />
+    </svg>
+  );
+}

--- a/apps/web/src/components/StagePlayer.tsx
+++ b/apps/web/src/components/StagePlayer.tsx
@@ -28,7 +28,16 @@ export function StagePlayer({ stage, streamUrl }: StagePlayerProps) {
         }}
         onPause={pause}
       />
-      <div className="min-w-0 flex-1">
+      {/* Live region so screen readers announce state transitions
+          (buffering, paused, playback error) without needing focus
+          on the button. polite + atomic = read the full status text
+          when it changes, don't interrupt mid-utterance. */}
+      <div
+        className="min-w-0 flex-1"
+        role="status"
+        aria-live="polite"
+        aria-atomic="true"
+      >
         <div className="text-sm font-medium text-slate-200">
           {labelForState(state, stage)}
         </div>

--- a/apps/web/src/components/StagePlayer.tsx
+++ b/apps/web/src/components/StagePlayer.tsx
@@ -1,0 +1,69 @@
+import type { Stage } from "@pavoia/shared";
+
+import { useHls } from "../audio/useHls.ts";
+import { PlayPauseButton } from "./PlayPauseButton.tsx";
+
+interface StagePlayerProps {
+  stage: Stage;
+  /** HLS m3u8 path (NowPlaying.streamUrl, e.g. /hls/opening/index.m3u8). */
+  streamUrl: string;
+}
+
+/**
+ * Hidden audio element + Play/Pause button + lightweight error
+ * surface. One per stage detail page; stage switch unmounts and
+ * recreates, which destroys the underlying Hls.js instance and
+ * fully releases the network buffer.
+ */
+export function StagePlayer({ stage, streamUrl }: StagePlayerProps) {
+  const { audioRef, state, error, play, pause } = useHls(streamUrl);
+
+  return (
+    <div className="flex items-center gap-5">
+      <PlayPauseButton
+        state={state}
+        accent={stage.accent}
+        onPlay={() => {
+          void play();
+        }}
+        onPause={pause}
+      />
+      <div className="min-w-0 flex-1">
+        <div className="text-sm font-medium text-slate-200">
+          {labelForState(state, stage)}
+        </div>
+        {error ? (
+          <p className="mt-0.5 truncate text-xs text-rose-400/80">{error}</p>
+        ) : null}
+      </div>
+      <audio
+        ref={audioRef}
+        preload="none"
+        // We render no native controls — PlayPauseButton is the only
+        // affordance. crossOrigin "anonymous" is required for hls.js
+        // to fetch segments via fetch() when CORS is needed. Engine
+        // serves /hls/* with permissive CORS via createHlsHandler.
+        crossOrigin="anonymous"
+        className="sr-only"
+      />
+    </div>
+  );
+}
+
+function labelForState(
+  state: ReturnType<typeof useHls>["state"],
+  stage: Stage,
+): string {
+  switch (state) {
+    case "playing":
+      return `Streaming ${stage.fallbackTitle}`;
+    case "loading":
+      return "Buffering…";
+    case "paused":
+      return "Paused";
+    case "error":
+      return "Playback error";
+    case "idle":
+      return "Press play to listen";
+  }
+}

--- a/apps/web/src/pages/StageDetailPage.tsx
+++ b/apps/web/src/pages/StageDetailPage.tsx
@@ -1,8 +1,18 @@
 import { useParams } from "@tanstack/react-router";
 
+import { lazy, Suspense } from "react";
+
 import { useStages } from "../api/stages.ts";
 import { useStageNow } from "../api/now.ts";
 import { NowPlaying } from "../components/NowPlaying.tsx";
+
+// Lazy-load the player + hls.js so the home and sidebar bundles
+// don't pay the ~500 KB HLS cost. Only listeners who navigate to
+// a stage detail page pull in the audio code.
+const StagePlayer = lazy(async () => {
+  const mod = await import("../components/StagePlayer.tsx");
+  return { default: mod.StagePlayer };
+});
 
 /**
  * Per-stage detail page. Slice C will fill this with a NowPlaying
@@ -133,7 +143,18 @@ function StageNowSection({ stageId, stage }: StageNowSectionProps) {
 
   return (
     <>
-      <NowPlaying stage={stage} payload={data} />
+      <div className="rounded-2xl border border-slate-800/60 bg-black/40 p-6 backdrop-blur-sm md:p-8">
+        <Suspense
+          fallback={
+            <p className="text-sm text-slate-500">Loading player…</p>
+          }
+        >
+          <StagePlayer stage={stage} streamUrl={data.streamUrl} />
+        </Suspense>
+      </div>
+      <div className="mt-4">
+        <NowPlaying stage={stage} payload={data} />
+      </div>
       {error ? (
         <p className="mt-2 text-xs text-amber-300/80">
           ⚠ Live updates are stalled (engine unreachable). Track shown is


### PR DESCRIPTION
## Summary

**THE MOMENT OF TRUTH.** Clicking play on a stage detail page now actually streams Plex audio through the v3 stack: browser → Vite proxy → SSH tunnel → Whatbox engine → hls.js → speakers.

## What ships

- **\`src/audio/useHls.ts\`** — cold-start HLS hook. One audio element per page; switching stages unmounts (destroys Hls.js, releases buffer) then re-mounts at the new \`streamUrl\`. Single \`useEffect\` for both the stream attachment AND the audio-element event listeners (combined per CR pre-push so a late-mounted ref under \`React.lazy\` can't miss the listeners).
- **Browser support**: hls.js for Chromium/Firefox/Edge (MSE), native HLS for Safari (\`canPlayType("application/vnd.apple.mpegurl")\`). Anything else gets an honest "HLS playback is not supported" error.
- **Tuning**: \`backBufferLength\` + \`maxBufferLength\` = 30 s, \`liveSyncDuration\` = 6 s. Matches the engine's 3 s × 6-segment rolling window.

- **\`src/components/PlayPauseButton.tsx\`** — 64 / 80 px circular button, three visual states (play / pause / spinner). Accent-colored when playing. ARIA \`pressed\` + \`label\`.

- **\`src/components/StagePlayer.tsx\`** — hidden \`<audio>\` element + button + status label + error surface. \`crossOrigin="anonymous"\` so hls.js's \`fetch()\` requests work; engine's \`createHlsHandler\` already sets permissive CORS.

- **StageDetailPage** lazy-loads StagePlayer via \`React.lazy\` + \`Suspense\` — keeps the home + sidebar bundle at 322 KB / 101 KB gzipped instead of 848 KB / 265 KB. The 526 KB audio chunk loads only when a listener navigates to \`/stage/:id\`.

## Autoplay (or rather, the lack thereof)

Browsers block \`.play()\` before user gesture, so the first PlayPauseButton click IS the gesture. Stage switch unmounts audio (paused) and the new stage requires a fresh click. Slice E will add session-scoped "user wants audio" memory if the cold cut gets old.

## Verified

- [x] CodeRabbit pre-push: clean (after combining the two effects per CR feedback)
- [x] typecheck clean
- [x] Vite build: main 322 KB / 101 KB gzipped, StagePlayer chunk 526 KB / 163 KB gzipped
- [x] \`npm test\` green
- [ ] CodeRabbit GH App review on pushed HEAD
- [ ] Codex independent review
- [ ] **User listen test**: open SSH tunnel, \`npm run web:dev\`, click play on a stage, hear audio

## Known followups (deferred to later slices)

- Built SPA on Whatbox via Hono static handler (so you can listen without running Vite locally) — Slice D.5 / E
- Cover art via \`/api/plex/thumb\` engine proxy — Slice E
- Volume / mute / keyboard shortcuts — Slice E
- StreamPreview hover popover, ArtistDrawer, BusMysteryCard — Slice F
- useCrossfade replacement (cold-start is the spec, but a small fade-in via Web Audio gain node would soften the start) — Slice G

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an audio player component with play/pause control, spinner state, and accessible ARIA support
  * Shows clear playback statuses (idle, loading, playing, paused, error) and user-friendly messages
  * Supports stage-specific accent colors and exposes play/pause callbacks

* **Performance**
  * Player UI lazy-loads to reduce initial page bundle size and improve load time
<!-- end of auto-generated comment: release notes by coderabbit.ai -->