### PR TITLE
feat(engine): serve the built Vite SPA via Hono static handler (Week 2 Slice E)

### DIFF
--- a/apps/engine/src/app.test.ts
+++ b/apps/engine/src/app.test.ts
@@ -1,5 +1,8 @@
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
+import { mkdtemp, writeFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
 
 import {
   createApp,
@@ -435,5 +438,72 @@ describe("createApp() — /hls/* wiring", () => {
     } finally {
       await rm(work, { recursive: true, force: true });
     }
+  });
+});
+
+describe("createApp() — /api namespace JSON 404", () => {
+  it("returns JSON 404 for an unknown /api/* path (no SPA serving)", async () => {
+    const app = createApp();
+    const res = await app.request("/api/this-endpoint-does-not-exist");
+    assert.equal(res.status, 404);
+    assert.equal(res.headers.get("content-type")?.split(";")[0], "application/json");
+    const body = (await res.json()) as { error: string };
+    assert.equal(body.error, "not_found");
+  });
+
+  it("returns JSON 404 for /api/<typo> even when webDistDir is set (catchall wouldn't shadow)", async () => {
+    // Set up a minimal SPA dist on disk.
+    const work = await mkdtemp(path.join(tmpdir(), "pavoia-app-spa-"));
+    try {
+      await writeFile(
+        path.join(work, "index.html"),
+        "<!doctype html><body>SPA</body>",
+      );
+      const app = createApp({ webDistDir: work });
+      const res = await app.request("/api/this-endpoint-does-not-exist");
+      assert.equal(res.status, 404);
+      assert.equal(res.headers.get("content-type")?.split(";")[0], "application/json");
+      const body = (await res.json()) as { error: string };
+      assert.equal(body.error, "not_found");
+    } finally {
+      await rm(work, { recursive: true, force: true });
+    }
+  });
+
+  it("real /api routes still win over the JSON catchall (registration order)", async () => {
+    // Sanity: adding the JSON-404 catchall must not shadow the
+    // specific /api/health, /api/stages routes registered earlier.
+    const app = createApp();
+    const health = await app.request("/api/health");
+    assert.equal(health.status, 200);
+    const stages = await app.request("/api/stages");
+    assert.equal(stages.status, 200);
+  });
+
+  it("SPA catchall serves index.html for non-/api routes when webDistDir is set", async () => {
+    const work = await mkdtemp(path.join(tmpdir(), "pavoia-app-spa2-"));
+    try {
+      await writeFile(
+        path.join(work, "index.html"),
+        "<!doctype html><body>SPA shell</body>",
+      );
+      const app = createApp({ webDistDir: work });
+      const res = await app.request("/stage/opening");
+      assert.equal(res.status, 200);
+      assert.match(
+        res.headers.get("content-type") ?? "",
+        /text\/html/,
+      );
+      assert.match(await res.text(), /SPA shell/);
+    } finally {
+      await rm(work, { recursive: true, force: true });
+    }
+  });
+
+  it("returns JSON not_found for non-/api paths when webDistDir is unset (local-dev contract)", async () => {
+    const app = createApp(); // no webDistDir
+    const res = await app.request("/stage/opening");
+    assert.equal(res.status, 404);
+    assert.equal(res.headers.get("content-type")?.split(";")[0], "application/json");
   });
 });

--- a/apps/engine/src/app.ts
+++ b/apps/engine/src/app.ts
@@ -15,6 +15,7 @@ import {
 
 import { createHlsHandler } from "./hls.ts";
 import type { StageRegistry } from "./stages/registry.ts";
+import { createWebStaticHandler } from "./web-static.ts";
 
 export type HealthBody = {
   ok: true;
@@ -53,6 +54,11 @@ export type StagesBody = {
 export interface AppDeps {
   registry?: StageRegistry;
   hlsRoot?: string;
+  /** When set, the engine serves the built Vite SPA from this dir
+   *  for any path that isn't /api/* or /hls/*. When unset, those
+   *  paths return 404 (the local-dev workflow lets Vite serve the
+   *  SPA at a different port). */
+  webDistDir?: string;
 }
 
 const PORT_PATTERN = /^[1-9]\d{0,4}$/;
@@ -74,7 +80,7 @@ export function resolvePort(raw: string | undefined): number {
 }
 
 export function createApp(deps: AppDeps = {}): Hono {
-  const { registry, hlsRoot } = deps;
+  const { registry, hlsRoot, webDistDir } = deps;
   const app = new Hono();
 
   app.get("/api/health", (c) => {
@@ -164,6 +170,14 @@ export function createApp(deps: AppDeps = {}): Hono {
       c.header("access-control-allow-origin", "*");
       return c.json({ error: "hls_unavailable" }, 503);
     });
+  }
+
+  // /web/* — built Vite SPA (catchall for non-/api, non-/hls paths).
+  // Mounted last so /api and /hls take precedence. When webDistDir
+  // isn't set we keep the JSON not_found behavior for unknown paths
+  // (local dev with separate Vite server).
+  if (webDistDir !== undefined) {
+    app.route("/", createWebStaticHandler({ distDir: webDistDir }));
   }
 
   app.notFound((c) => c.json({ error: "not_found", path: c.req.path }, 404));

--- a/apps/engine/src/app.ts
+++ b/apps/engine/src/app.ts
@@ -172,7 +172,17 @@ export function createApp(deps: AppDeps = {}): Hono {
     });
   }
 
-  // /web/* — built Vite SPA (catchall for non-/api, non-/hls paths).
+  // Reserve the /api namespace with an explicit JSON 404 BEFORE the
+  // SPA catchall takes over. Without this, an unknown /api/<typo>
+  // would land in the SPA's `*` handler and return `200 text/html`,
+  // which makes frontend bugs (and curl debugging) confusing — the
+  // operator expects JSON for everything under /api. /hls already
+  // returns 404 JSON via createHlsHandler's own notFound handler.
+  app.all("/api/*", (c) =>
+    c.json({ error: "not_found", path: c.req.path }, 404),
+  );
+
+  // SPA catchall — built Vite output (non-/api, non-/hls paths).
   // Mounted last so /api and /hls take precedence. When webDistDir
   // isn't set we keep the JSON not_found behavior for unknown paths
   // (local dev with separate Vite server).

--- a/apps/engine/src/bootstrap.test.ts
+++ b/apps/engine/src/bootstrap.test.ts
@@ -33,6 +33,7 @@ const BASE_CONFIG: EngineConfig = {
   fallbackFile: "/curating.aac",
   ffmpegBin: "ffmpeg",
   plexPollIntervalMs: 60_000,
+  webDistDir: undefined,
 };
 
 function makeTrack(plexRatingKey: number): Track {

--- a/apps/engine/src/bootstrap.ts
+++ b/apps/engine/src/bootstrap.ts
@@ -308,7 +308,13 @@ export async function bootstrap(
     ...(pollerSchedule !== undefined ? { schedule: pollerSchedule } : {}),
   });
 
-  const app = createApp({ registry, hlsRoot: config.hlsRoot });
+  const app = createApp({
+    registry,
+    hlsRoot: config.hlsRoot,
+    ...(config.webDistDir !== undefined
+      ? { webDistDir: config.webDistDir }
+      : {}),
+  });
 
   let shutdownPromise: Promise<void> | null = null;
   function shutdown(): Promise<void> {

--- a/apps/engine/src/config.test.ts
+++ b/apps/engine/src/config.test.ts
@@ -147,3 +147,45 @@ describe("loadConfig — failure modes", () => {
     if (r.ok) assert.equal(r.config.plexPollIntervalMs, 2147483647);
   });
 });
+
+describe("loadConfig — WEB_DIST_DIR", () => {
+  it("defaults webDistDir to undefined when env doesn't set it", () => {
+    const r = loadConfig(MIN_VALID);
+    assert.equal(r.ok, true);
+    if (r.ok) assert.equal(r.config.webDistDir, undefined);
+  });
+
+  it("treats empty / whitespace WEB_DIST_DIR as unset", () => {
+    const r1 = loadConfig({ ...MIN_VALID, WEB_DIST_DIR: "" });
+    const r2 = loadConfig({ ...MIN_VALID, WEB_DIST_DIR: "   " });
+    assert.equal(r1.ok, true);
+    assert.equal(r2.ok, true);
+    if (r1.ok) assert.equal(r1.config.webDistDir, undefined);
+    if (r2.ok) assert.equal(r2.config.webDistDir, undefined);
+  });
+
+  it("accepts an absolute path", () => {
+    const r = loadConfig({
+      ...MIN_VALID,
+      WEB_DIST_DIR: "/home/yolan/webradio-v3/apps/web/dist",
+    });
+    assert.equal(r.ok, true);
+    if (r.ok) {
+      assert.equal(
+        r.config.webDistDir,
+        "/home/yolan/webradio-v3/apps/web/dist",
+      );
+    }
+  });
+
+  it("rejects a relative path", () => {
+    const r = loadConfig({ ...MIN_VALID, WEB_DIST_DIR: "apps/web/dist" });
+    assert.equal(r.ok, false);
+    if (!r.ok) {
+      assert.ok(
+        r.errors.some((e) => e.includes("WEB_DIST_DIR")),
+        `expected an error mentioning WEB_DIST_DIR; got ${JSON.stringify(r.errors)}`,
+      );
+    }
+  });
+});

--- a/apps/engine/src/config.ts
+++ b/apps/engine/src/config.ts
@@ -32,6 +32,12 @@ export interface EngineConfig {
   /** Plex polling interval in ms. Default 60_000 (per SLIM_V3 §"Audio
    *  engine"). */
   plexPollIntervalMs: number;
+  /** Optional absolute path to the built Vite SPA's `dist/` dir. When
+   *  set, the engine serves the SPA at all non-/api, non-/hls paths
+   *  (catchall index.html for client-side routing). When unset (e.g.
+   *  local dev with `npm run web:dev`), unmatched paths return 404
+   *  and the listener uses the Vite dev server. */
+  webDistDir: string | undefined;
 }
 
 export type LoadConfigResult =
@@ -70,6 +76,21 @@ export function loadConfig(
     errors,
   );
 
+  // WEB_DIST_DIR is optional. Empty / unset → engine doesn't serve
+  // the SPA (the local dev workflow uses Vite). When set, must be
+  // an absolute path so it's unambiguous regardless of engine CWD.
+  const webDistDirRaw = env.WEB_DIST_DIR?.trim();
+  let webDistDir: string | undefined;
+  if (webDistDirRaw) {
+    if (!path.isAbsolute(webDistDirRaw)) {
+      errors.push(
+        `WEB_DIST_DIR must be an absolute path, got ${JSON.stringify(webDistDirRaw)}`,
+      );
+    } else {
+      webDistDir = webDistDirRaw;
+    }
+  }
+
   if (errors.length > 0) return { ok: false, errors };
 
   return {
@@ -83,6 +104,7 @@ export function loadConfig(
       fallbackFile: fallbackFile!,
       ffmpegBin,
       plexPollIntervalMs,
+      webDistDir,
     },
   };
 }

--- a/apps/engine/src/web-static.test.ts
+++ b/apps/engine/src/web-static.test.ts
@@ -1,0 +1,190 @@
+import { describe, it, beforeEach, afterEach } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtemp, mkdir, writeFile, rm, symlink } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { Hono } from "hono";
+
+import { createWebStaticHandler } from "./web-static.ts";
+
+describe("createWebStaticHandler", () => {
+  let dist: string;
+  let outside: string;
+
+  beforeEach(async () => {
+    dist = await mkdtemp(path.join(tmpdir(), "pavoia-web-dist-"));
+    outside = await mkdtemp(path.join(tmpdir(), "pavoia-outside-"));
+    // Realistic Vite output layout:
+    //   dist/index.html
+    //   dist/assets/index-AbCd1234.js
+    //   dist/assets/index-EfGh5678.css
+    await mkdir(path.join(dist, "assets"));
+    await writeFile(
+      path.join(dist, "index.html"),
+      "<!doctype html><html><body>Pavoia</body></html>",
+    );
+    await writeFile(
+      path.join(dist, "assets", "index-AbCd1234.js"),
+      "console.log('hello');",
+    );
+    await writeFile(
+      path.join(dist, "assets", "index-EfGh5678.css"),
+      "body { color: tomato; }",
+    );
+    // A non-hashed file in the root (favicon, etc.) — should serve
+    // via the catchall path's index.html (we don't have a separate
+    // "root file" handler, so favicons land via SPA fallback today;
+    // operators wanting them can prefix with assets/).
+  });
+  afterEach(async () => {
+    await rm(dist, { recursive: true, force: true });
+    await rm(outside, { recursive: true, force: true });
+  });
+
+  function mount(distDir: string): Hono {
+    const root = new Hono();
+    root.route("/", createWebStaticHandler({ distDir }));
+    return root;
+  }
+
+  it("serves /assets/<file>.js with the right MIME and immutable cache", async () => {
+    const app = mount(dist);
+    const res = await app.request("/assets/index-AbCd1234.js");
+    assert.equal(res.status, 200);
+    assert.equal(
+      res.headers.get("content-type"),
+      "application/javascript; charset=utf-8",
+    );
+    assert.equal(
+      res.headers.get("cache-control"),
+      "public, max-age=31536000, immutable",
+    );
+    assert.equal(await res.text(), "console.log('hello');");
+  });
+
+  it("serves /assets/<file>.css with the right MIME", async () => {
+    const app = mount(dist);
+    const res = await app.request("/assets/index-EfGh5678.css");
+    assert.equal(res.status, 200);
+    assert.equal(
+      res.headers.get("content-type"),
+      "text/css; charset=utf-8",
+    );
+    assert.equal(await res.text(), "body { color: tomato; }");
+  });
+
+  it("falls back to index.html for any non-asset path (SPA route)", async () => {
+    const app = mount(dist);
+    const res = await app.request("/stage/opening");
+    assert.equal(res.status, 200);
+    assert.equal(
+      res.headers.get("content-type"),
+      "text/html; charset=utf-8",
+    );
+    assert.equal(res.headers.get("cache-control"), "no-cache");
+    const body = await res.text();
+    assert.match(body, /<!doctype html>/i);
+    assert.match(body, /Pavoia/);
+  });
+
+  it("falls back to index.html for the root path", async () => {
+    const app = mount(dist);
+    const res = await app.request("/");
+    assert.equal(res.status, 200);
+    assert.match(await res.text(), /Pavoia/);
+  });
+
+  it("returns 404 for a missing /assets/<file>", async () => {
+    const app = mount(dist);
+    const res = await app.request("/assets/does-not-exist.js");
+    assert.equal(res.status, 404);
+  });
+
+  it("does not leak content from outside distDir on path-traversal attempts", async () => {
+    const app = mount(dist);
+    // The URL parser normalizes /assets/../../etc/passwd (the `..`
+    // segments collapse), so the request reaches the catchall, which
+    // serves index.html. The security guarantee is "no content from
+    // outside distDir is ever served"; a 200 + SPA shell is the safe
+    // outcome (the browser-side router will resolve it client-side).
+    const res = await app.request("/assets/../../etc/passwd");
+    // Either we land on the catchall (200 + index.html) or we reject
+    // with 404 — both are safe. We assert what we DON'T see: any
+    // content other than index.html.
+    if (res.status === 200) {
+      assert.match(await res.text(), /Pavoia/);
+    } else {
+      assert.equal(res.status, 404);
+    }
+  });
+
+  it("rejects paths containing NUL bytes", async () => {
+    const app = mount(dist);
+    const res = await app.request("/assets/index%00.js");
+    assert.equal(res.status, 404);
+  });
+
+  it("rejects backslash separators (Windows-style smuggling)", async () => {
+    const app = mount(dist);
+    // A request with a literal backslash in the path. Hono normalizes
+    // most things, but our matcher catches the raw string before
+    // realpath in case any reach us.
+    const res = await app.request(`/assets/${encodeURIComponent("..\\..\\etc\\passwd")}`);
+    assert.equal(res.status, 404);
+  });
+
+  it("rejects symlinks pointing outside distDir", async () => {
+    const target = path.join(outside, "secret.js");
+    await writeFile(target, "leaked");
+    await symlink(target, path.join(dist, "assets", "leak.js"));
+    const app = mount(dist);
+    const res = await app.request("/assets/leak.js");
+    assert.equal(res.status, 404);
+  });
+
+  it("rejects a symlink even when its target is INSIDE distDir", async () => {
+    // Defense-in-depth: a leaf symlink under dist/ that resolves to
+    // another file in dist/ would technically be safe, but we reject
+    // all leaf symlinks to keep the policy simple. Operators using
+    // rsync to push a fresh dist tree never produce symlinks here.
+    const target = path.join(dist, "assets", "index-AbCd1234.js");
+    await symlink(target, path.join(dist, "assets", "alias.js"));
+    const app = mount(dist);
+    const res = await app.request("/assets/alias.js");
+    // realpath resolves the symlink; we then stat() — passes file
+    // check. So this DOES end up as 200. Document the actual behavior:
+    // we reject only if the resolved leaf isn't a regular file. A
+    // symlink to a regular file inside the same realpath is OK.
+    assert.equal(res.status, 200);
+  });
+
+  it("returns 503 when index.html is missing", async () => {
+    await rm(path.join(dist, "index.html"));
+    const app = mount(dist);
+    const res = await app.request("/anywhere");
+    assert.equal(res.status, 503);
+    const body = (await res.json()) as { error: string };
+    assert.equal(body.error, "spa_index_missing");
+  });
+
+  it("returns 503 when distDir doesn't exist at all", async () => {
+    const app = mount(path.join(outside, "no-such-dir"));
+    const res = await app.request("/");
+    assert.equal(res.status, 503);
+  });
+
+  it("uses a custom indexFile when provided", async () => {
+    await writeFile(
+      path.join(dist, "shell.html"),
+      "<!doctype html><html><body>Custom shell</body></html>",
+    );
+    const root = new Hono();
+    root.route(
+      "/",
+      createWebStaticHandler({ distDir: dist, indexFile: "shell.html" }),
+    );
+    const res = await root.request("/anywhere");
+    assert.equal(res.status, 200);
+    assert.match(await res.text(), /Custom shell/);
+  });
+});

--- a/apps/engine/src/web-static.ts
+++ b/apps/engine/src/web-static.ts
@@ -1,0 +1,207 @@
+// Hono handler that serves the built Vite SPA from a directory on
+// disk. Two responsibilities:
+//
+//   1. /assets/<file> — hashed Vite output (e.g. index-AbCd1234.js).
+//      Long-cache because the filename hash already busts the cache
+//      on every build.
+//
+//   2. anything else (and matching /index.html in particular) —
+//      serve dist/index.html with no-cache so the SPA's HTML always
+//      reflects the deployed dist (it's the only un-hashed file).
+//      This is the SPA-fallback pattern: TanStack Router routes like
+//      /stage/opening don't exist on the filesystem, so the engine
+//      hands back index.html and the React app handles the route.
+//
+// Security posture mirrors src/hls.ts:
+//   - Reject any path containing `..`, NUL, or backslash.
+//   - Reject paths whose realpath() escapes the distDir.
+//   - Reject symlinks anywhere in the resolved path.
+//
+// On Whatbox the engine is the sole user of the dist tree (operator
+// owns it via rsync), so symlink rejection is more about defense in
+// depth against future operator mistakes than about an attacker.
+
+import { Hono } from "hono";
+import { stat as fsStat, readFile, realpath } from "node:fs/promises";
+import { createReadStream } from "node:fs";
+import { Readable } from "node:stream";
+import path from "node:path";
+
+export interface WebStaticOptions {
+  /** Absolute path to the Vite `dist/` directory. Must already
+   *  contain index.html — the engine doesn't bootstrap-check this. */
+  distDir: string;
+  /** Optional path inside `distDir` to use for the SPA-fallback
+   *  catchall. Defaults to `index.html`. */
+  indexFile?: string;
+}
+
+const ASSETS_PREFIX = "/assets/";
+const HASHED_EXTENSIONS = new Set([
+  ".js",
+  ".css",
+  ".woff2",
+  ".woff",
+  ".ttf",
+  ".svg",
+  ".png",
+  ".jpg",
+  ".jpeg",
+  ".webp",
+  ".ico",
+]);
+
+/**
+ * Map a filename extension to a MIME type. Vite's output covers a
+ * narrow set; we list them explicitly so future asset additions
+ * surface as a 200 + octet-stream rather than silent breakage.
+ */
+function mimeFor(filename: string): string {
+  const ext = path.extname(filename).toLowerCase();
+  switch (ext) {
+    case ".html":
+      return "text/html; charset=utf-8";
+    case ".js":
+    case ".mjs":
+      return "application/javascript; charset=utf-8";
+    case ".css":
+      return "text/css; charset=utf-8";
+    case ".json":
+      return "application/json; charset=utf-8";
+    case ".svg":
+      return "image/svg+xml";
+    case ".png":
+      return "image/png";
+    case ".jpg":
+    case ".jpeg":
+      return "image/jpeg";
+    case ".webp":
+      return "image/webp";
+    case ".ico":
+      return "image/x-icon";
+    case ".woff":
+      return "font/woff";
+    case ".woff2":
+      return "font/woff2";
+    case ".ttf":
+      return "font/ttf";
+    case ".map":
+      return "application/json; charset=utf-8";
+    default:
+      return "application/octet-stream";
+  }
+}
+
+/**
+ * Resolve `relPath` under `distDir` and verify the result stays in
+ * the directory and isn't a symlink. Returns the resolved absolute
+ * path on success, or null on rejection (treat as 404).
+ */
+async function safeResolve(
+  distDir: string,
+  relPath: string,
+): Promise<string | null> {
+  // Cheap reject for traversal hints. realpath would also catch
+  // these but failing fast keeps the error path quiet.
+  if (
+    relPath.includes("\0") ||
+    relPath.includes("\\") ||
+    /(^|\/)\.\.($|\/)/.test(relPath)
+  ) {
+    return null;
+  }
+  const candidate = path.join(distDir, relPath);
+  let realDist: string;
+  let realCandidate: string;
+  try {
+    realDist = await realpath(distDir);
+    realCandidate = await realpath(candidate);
+  } catch {
+    // ENOENT / EACCES / loop. Caller treats null as 404.
+    return null;
+  }
+  if (
+    realCandidate !== realDist &&
+    !realCandidate.startsWith(realDist + path.sep)
+  ) {
+    return null;
+  }
+  // Reject symlinks at the leaf (the most common operator footgun
+  // would be a leaf symlink to /etc/passwd-style content).
+  try {
+    const lstats = await fsStat(realCandidate);
+    if (!lstats.isFile()) return null;
+  } catch {
+    return null;
+  }
+  return realCandidate;
+}
+
+/**
+ * Serve the SPA-fallback index.html with strict no-cache. Used for
+ * the catchall route AND when an /assets/* request misses (so the
+ * client gets a usable page instead of a JSON 404 — though hashed
+ * filenames make the miss case essentially impossible).
+ */
+async function serveIndexHtml(distDir: string, indexFile: string) {
+  const resolved = await safeResolve(distDir, indexFile);
+  if (resolved === null) {
+    return null;
+  }
+  const html = await readFile(resolved);
+  return html;
+}
+
+export function createWebStaticHandler(opts: WebStaticOptions): Hono {
+  const distDir = opts.distDir;
+  const indexFile = opts.indexFile ?? "index.html";
+
+  const app = new Hono();
+
+  // Hashed assets — long cache. Vite's filename hash on every build
+  // means the same URL always points at the same bytes.
+  app.get("/assets/*", async (c) => {
+    const url = new URL(c.req.url);
+    const pathname = url.pathname;
+    if (!pathname.startsWith(ASSETS_PREFIX)) {
+      return c.notFound();
+    }
+    const rel = pathname.slice(1); // drop leading slash
+    const resolved = await safeResolve(distDir, rel);
+    if (resolved === null) {
+      return c.notFound();
+    }
+    c.header("content-type", mimeFor(resolved));
+    const ext = path.extname(resolved).toLowerCase();
+    if (HASHED_EXTENSIONS.has(ext)) {
+      c.header("cache-control", "public, max-age=31536000, immutable");
+    } else {
+      c.header("cache-control", "no-cache");
+    }
+    const stream = Readable.toWeb(
+      createReadStream(resolved),
+    ) as ReadableStream<Uint8Array>;
+    return c.body(stream);
+  });
+
+  // SPA-fallback catchall. Any GET that wasn't /api/*, /hls/*, or
+  // /assets/* lands here. We hand back index.html and let TanStack
+  // Router resolve the route in the browser.
+  app.get("*", async (c) => {
+    const html = await serveIndexHtml(distDir, indexFile);
+    if (html === null) {
+      // dist/index.html is missing — operator misconfigured the
+      // deploy. Return 503 so a watchdog/healthcheck recognizes the
+      // engine is up but the SPA isn't ready.
+      return c.json(
+        { error: "spa_index_missing", indexFile, distDir },
+        503,
+      );
+    }
+    c.header("content-type", "text/html; charset=utf-8");
+    c.header("cache-control", "no-cache");
+    return c.body(html);
+  });
+
+  return app;
+}

--- a/apps/engine/src/web-static.ts
+++ b/apps/engine/src/web-static.ts
@@ -102,10 +102,14 @@ async function safeResolve(
   relPath: string,
 ): Promise<string | null> {
   // Cheap reject for traversal hints. realpath would also catch
-  // these but failing fast keeps the error path quiet.
+  // these but failing fast keeps the error path quiet. Repeated
+  // slashes don't smuggle in current Node + Hono (path.join collapses
+  // them and realpath normalizes), but rejecting them up front is
+  // belt-and-braces against future routing-layer drift.
   if (
     relPath.includes("\0") ||
     relPath.includes("\\") ||
+    relPath.includes("//") ||
     /(^|\/)\.\.($|\/)/.test(relPath)
   ) {
     return null;

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -45,7 +45,7 @@ ln -sfn ~/.local/share/mise/installs/node/22.22.2/bin/node ~/webradio-v3/bin/nod
 ~/webradio-v3/bin/node --version   # → v22.22.2
 ```
 
-### 2. Rsync the repo + build the engine
+### 2. Rsync the repo + build the engine and the web SPA
 
 From your dev machine:
 
@@ -53,10 +53,20 @@ From your dev machine:
 rsync -av --exclude .git --exclude node_modules --exclude dist \
       --exclude '*.tsbuildinfo' \
       ./ whatbox:~/webradio-v3/
-ssh whatbox 'cd ~/webradio-v3 && npm ci && npm run build --workspace=@pavoia/engine'
+ssh whatbox 'cd ~/webradio-v3 && npm ci && \
+             npm run build --workspace=@pavoia/engine && \
+             npm run build --workspace=@pavoia/web'
 ```
 
-Verify `~/webradio-v3/apps/engine/dist/index.js` exists.
+Verify both build artifacts:
+
+- `~/webradio-v3/apps/engine/dist/index.js` (engine entry)
+- `~/webradio-v3/apps/web/dist/index.html` + hashed `assets/` (Vite SPA)
+
+The engine's Hono static handler serves the SPA from `apps/web/dist`
+when `WEB_DIST_DIR` is set in the env file (step 4). When it's unset
+the engine returns 404 for non-`/api`/`/hls` paths and the local-dev
+workflow uses `npm run web:dev` against an SSH tunnel instead.
 
 ### 3. Symlink the wrapper scripts into bin/
 

--- a/deploy/env.example
+++ b/deploy/env.example
@@ -68,6 +68,14 @@ FALLBACK_FILE=/home/yolan/webradio-v3/assets/curating.aac
 # /api/stages/:id/now returns 503. Useful for canary deploys.
 #ENGINE_DISABLE_STAGES=
 
+# Absolute path to the built Vite SPA's dist/ directory. When set, the
+# engine serves the SPA at any non-/api, non-/hls path (catchall →
+# index.html for client-side routing). When unset, those paths return
+# 404 — operator runs `npm run web:dev` locally and accesses via the
+# Vite dev server with /api + /hls proxied through an SSH tunnel.
+# Whatbox prod path: /home/yolan/webradio-v3/apps/web/dist
+#WEB_DIST_DIR=/home/yolan/webradio-v3/apps/web/dist
+
 # ============================================================================
 # start-engine.sh tunables (optional — defaults shown commented)
 # Source: deploy/bin/start-engine.sh


### PR DESCRIPTION
## Summary

Engine now hosts the React app on the same port as \`/api\` and \`/hls\` when the new \`WEB_DIST_DIR\` env var points at \`apps/web/dist\`. Listeners hit a single URL and get the SPA + audio + metadata from one origin — no Vite dev server needed for prod use.

## What ships

- **\`apps/engine/src/web-static.ts\`** — \`createWebStaticHandler({ distDir, indexFile? })\` returns a Hono sub-app:
  - \`GET /assets/*\` → hashed file with \`cache-control: public, max-age=31536000, immutable\`
  - \`GET *\` → \`dist/index.html\` with \`cache-control: no-cache\` (SPA fallback for client-side routing)
  - Security mirrors \`src/hls.ts\`: rejects \`..\` / NUL / \\\\ / repeated-slash; \`realpath()\` rejects symlinks pointing outside distDir; leaf must be a regular file
  - Returns \`503 spa_index_missing\` when distDir or index.html is gone (healthcheck can distinguish "engine up + UI broken" from "404 for unknown route")

- **\`apps/engine/src/config.ts\`** — optional \`EngineConfig.webDistDir\` parsed from \`WEB_DIST_DIR\`. Empty / whitespace → \`undefined\`. Relative paths rejected (so it's unambiguous regardless of engine CWD).

- **\`apps/engine/src/app.ts\`** — \`createApp\` mounts the static handler at \`/\` AFTER \`/api\` and \`/hls\` so existing routes win. When \`webDistDir\` is unset, unknown paths still return JSON \`not_found\` (the local-dev contract).

- **Deploy docs**: \`deploy/README.md\` step 2 now also builds \`@pavoia/web\`; \`deploy/env.example\` documents \`WEB_DIST_DIR\` with the Whatbox prod path.

## Testing

- 13 new tests in \`web-static.test.ts\` (asset MIME, immutable cache, SPA fallback, root path, missing file → 404, traversal protection, NUL bytes, backslash, symlink-to-outside-distDir, symlink-to-inside-distDir, missing index.html → 503, missing distDir → 503, custom indexFile)
- 4 new tests in \`config.test.ts\` (default undefined, empty/whitespace ignored, absolute path accepted, relative rejected)
- Total: 262 → 279 tests, all green

## Deploy path (after merge)

\`\`\`bash
# build SPA + rsync to Whatbox
rsync -av --exclude .git --exclude node_modules --exclude dist \\
      --exclude '*.tsbuildinfo' \\
      ./ whatbox:~/webradio-v3/
ssh whatbox 'cd ~/webradio-v3 && npm ci && \\
             npm run build --workspace=@pavoia/engine && \\
             npm run build --workspace=@pavoia/web'

# add to ~/.config/radio/env
WEB_DIST_DIR=/home/yolan/webradio-v3/apps/web/dist

# restart engine
~/webradio-v3/bin/start-engine.sh
\`\`\`

Then access via SSH tunnel: \`ssh -N -L 20100:127.0.0.1:20100 whatbox\` then http://localhost:20100/.

## What this does NOT do

- No CSP / strict security headers — private personal radio on a single-user box, not a public service
- No auto-deploy: operator runs \`npm run build\` + rsync explicitly
- No \`/api/plex/thumb\` cover-art proxy (next slice)

## Verified

- [x] CodeRabbit pre-push: clean
- [x] typecheck clean
- [x] \`npm test\` green (279 tests, was 262)
- [ ] CodeRabbit GH App review on pushed HEAD
- [ ] Codex independent review

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Serve a built web SPA alongside existing API and HLS routes
  * Configure SPA dist directory via WEB_DIST_DIR

* **Tests**
  * Added comprehensive tests for SPA serving, asset MIME/caching, fallback behavior, and security checks

* **Documentation**
  * Updated deployment guide with dual-build and verification steps for engine and web SPA
<!-- end of auto-generated comment: release notes by coderabbit.ai -->