### PR TITLE
feat(web): mobile drawer + EqualizerBars + InfoDialog + BusMysteryCard (Week 2 Slice F)

### DIFF
--- a/apps/web/src/components/BusMysteryCard.tsx
+++ b/apps/web/src/components/BusMysteryCard.tsx
@@ -1,0 +1,37 @@
+import { Dialog } from "./Dialog.tsx";
+
+interface BusMysteryCardProps {
+  open: boolean;
+  onClose: () => void;
+}
+
+/**
+ * v1's Bus easter egg, ported. The Bus stage has no audio (it's
+ * disabled in the catalog) — when the listener clicks it from the
+ * sidebar, this card surfaces a hint that some things are not for
+ * the webradio. Click anywhere to dismiss.
+ */
+export function BusMysteryCard({ open, onClose }: BusMysteryCardProps) {
+  return (
+    <Dialog open={open} onClose={onClose} ariaLabel="Bus stage">
+      <div className="space-y-5 text-center">
+        <div className="text-6xl leading-none">🚌</div>
+        <div>
+          <h2 className="text-xl font-semibold text-slate-100">
+            The bus
+          </h2>
+          <p className="mt-2 text-balance text-sm leading-relaxed text-slate-400">
+            Some things must be experienced in person.
+          </p>
+        </div>
+        <button
+          type="button"
+          onClick={onClose}
+          className="mx-auto block rounded-full border border-amber-700/60 bg-amber-950/40 px-5 py-2 text-sm text-amber-200 transition-colors hover:bg-amber-900/40"
+        >
+          Got it
+        </button>
+      </div>
+    </Dialog>
+  );
+}

--- a/apps/web/src/components/Dialog.tsx
+++ b/apps/web/src/components/Dialog.tsx
@@ -1,0 +1,67 @@
+import { useEffect, useRef } from "react";
+
+interface DialogProps {
+  open: boolean;
+  onClose: () => void;
+  /** Visible label for screen readers; rendered as the dialog title
+   *  unless the caller provides their own heading inside `children`. */
+  ariaLabel: string;
+  children: React.ReactNode;
+}
+
+/**
+ * Thin wrapper around the native `<dialog>` element. Browsers handle
+ * the modal stacking, focus trap, and ESC-to-dismiss for us; we just
+ * sync the `open` prop to .showModal() / .close() and emit onClose
+ * when the dialog closes for any reason (ESC, backdrop click, or our
+ * caller setting open=false).
+ */
+export function Dialog({ open, onClose, ariaLabel, children }: DialogProps) {
+  const ref = useRef<HTMLDialogElement | null>(null);
+
+  // Sync `open` → element state. showModal() rejects if already open;
+  // close() is a no-op if closed, so guard with .open.
+  useEffect(() => {
+    const el = ref.current;
+    if (!el) return;
+    if (open && !el.open) {
+      el.showModal();
+    } else if (!open && el.open) {
+      el.close();
+    }
+  }, [open]);
+
+  // Native close events fire on ESC and on dialog.close(). Forward
+  // to onClose so our controlling parent stays in sync.
+  useEffect(() => {
+    const el = ref.current;
+    if (!el) return;
+    const onCloseEvent = () => onClose();
+    el.addEventListener("close", onCloseEvent);
+    return () => el.removeEventListener("close", onCloseEvent);
+  }, [onClose]);
+
+  // Click-outside-to-dismiss: when the click target IS the dialog
+  // element itself (not anything inside it), the user clicked the
+  // backdrop. Native dialog doesn't expose this directly; the
+  // pattern below works in all evergreen browsers.
+  const onBackdropClick = (e: React.MouseEvent<HTMLDialogElement>) => {
+    if (e.target === ref.current) {
+      onClose();
+    }
+  };
+
+  return (
+    <dialog
+      ref={ref}
+      aria-label={ariaLabel}
+      onClick={onBackdropClick}
+      className="m-auto max-w-md rounded-2xl border border-slate-700 bg-slate-900 p-0 text-slate-100 shadow-2xl backdrop:bg-black/70 backdrop:backdrop-blur-sm"
+    >
+      {/* Inner padding wrapper so the click-on-backdrop check above
+       * sees the dialog element directly when the user clicks
+       * outside the content area. */}
+      <div className="p-6 md:p-8">{children}</div>
+    </dialog>
+  );
+}

--- a/apps/web/src/components/Dialog.tsx
+++ b/apps/web/src/components/Dialog.tsx
@@ -19,6 +19,19 @@ interface DialogProps {
 export function Dialog({ open, onClose, ariaLabel, children }: DialogProps) {
   const ref = useRef<HTMLDialogElement | null>(null);
 
+  // Dedupe onClose. Without this, a click on the close button fires
+  // a chain: button onClick → parent setState → useEffect calls
+  // el.close() → element fires "close" event → onCloseEvent calls
+  // onClose() AGAIN. The ref short-circuits any subsequent emissions
+  // until the dialog reopens.
+  const closingRef = useRef(false);
+
+  // Reset the dedupe flag whenever the dialog opens — otherwise the
+  // second open in a session would have onClose suppressed.
+  useEffect(() => {
+    if (open) closingRef.current = false;
+  }, [open]);
+
   // Sync `open` → element state. showModal() rejects if already open;
   // close() is a no-op if closed, so guard with .open.
   useEffect(() => {
@@ -31,14 +44,24 @@ export function Dialog({ open, onClose, ariaLabel, children }: DialogProps) {
     }
   }, [open]);
 
-  // Native close events fire on ESC and on dialog.close(). Forward
-  // to onClose so our controlling parent stays in sync.
+  const handleClose = () => {
+    if (closingRef.current) return;
+    closingRef.current = true;
+    onClose();
+  };
+
+  // Native close events fire on ESC and on dialog.close(). Route
+  // through handleClose so the dedupe flag prevents a double emit.
   useEffect(() => {
     const el = ref.current;
     if (!el) return;
-    const onCloseEvent = () => onClose();
+    const onCloseEvent = () => handleClose();
     el.addEventListener("close", onCloseEvent);
     return () => el.removeEventListener("close", onCloseEvent);
+    // handleClose closes over onClose (stable for our usage), and
+    // we WANT this effect re-attached if the consumer's onClose
+    // changes — eslint-react-hooks would catch a stale closure.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [onClose]);
 
   // Click-outside-to-dismiss: when the click target IS the dialog
@@ -47,7 +70,7 @@ export function Dialog({ open, onClose, ariaLabel, children }: DialogProps) {
   // pattern below works in all evergreen browsers.
   const onBackdropClick = (e: React.MouseEvent<HTMLDialogElement>) => {
     if (e.target === ref.current) {
-      onClose();
+      handleClose();
     }
   };
 

--- a/apps/web/src/components/EqualizerBars.tsx
+++ b/apps/web/src/components/EqualizerBars.tsx
@@ -1,0 +1,47 @@
+interface EqualizerBarsProps {
+  /** Color of the bars. Usually the stage's accent. */
+  color: string;
+  /** Width of each bar (Tailwind class fragment OK; defaults to "0.5"). */
+  size?: "sm" | "md";
+}
+
+/**
+ * Decorative four-bar pulsing animation used as a "stage is live"
+ * affordance next to the play button. Pure visual — no audio
+ * analysis. v1 had the same pattern; we use CSS animation-delay
+ * staggers instead of v1's inline keyframes so Tailwind 4 can
+ * inline + minify the tokens.
+ *
+ * Each bar pulses on its own offset with a different period so the
+ * pattern feels organic rather than mechanical.
+ */
+export function EqualizerBars({ color, size = "md" }: EqualizerBarsProps) {
+  const barWidth = size === "sm" ? "w-0.5" : "w-1";
+  const containerWidth = size === "sm" ? "w-4" : "w-5";
+
+  return (
+    <div
+      className={`flex h-5 ${containerWidth} items-end justify-between`}
+      aria-hidden="true"
+    >
+      {BARS.map((bar) => (
+        <span
+          key={bar.key}
+          className={`${barWidth} animate-eq-bar rounded-t-sm`}
+          style={{
+            backgroundColor: color,
+            animationDuration: bar.duration,
+            animationDelay: bar.delay,
+          }}
+        />
+      ))}
+    </div>
+  );
+}
+
+const BARS = [
+  { key: "a", duration: "0.9s", delay: "0s" },
+  { key: "b", duration: "1.2s", delay: "0.15s" },
+  { key: "c", duration: "1.0s", delay: "0.30s" },
+  { key: "d", duration: "1.4s", delay: "0.05s" },
+];

--- a/apps/web/src/components/InfoDialog.tsx
+++ b/apps/web/src/components/InfoDialog.tsx
@@ -1,0 +1,50 @@
+import { Dialog } from "./Dialog.tsx";
+
+interface InfoDialogProps {
+  open: boolean;
+  onClose: () => void;
+}
+
+/**
+ * About / credits modal. Triggered from the small info button in
+ * the sidebar footer. Replaces v1's logo-driven InfoDialog with a
+ * plain text approach since v3 doesn't ship with a brand GIF asset.
+ */
+export function InfoDialog({ open, onClose }: InfoDialogProps) {
+  return (
+    <Dialog open={open} onClose={onClose} ariaLabel="About Pavoia">
+      <div className="space-y-4">
+        <div>
+          <h2 className="bg-gradient-to-br from-fuchsia-300 via-amber-200 to-emerald-300 bg-clip-text text-2xl font-bold text-transparent">
+            pavoia webradio
+          </h2>
+          <p className="mt-1 text-sm text-slate-400">
+            v3 — Plex-driven HLS radio
+          </p>
+        </div>
+
+        <p className="text-sm leading-relaxed text-slate-300">
+          Eleven stages curated by gaende. Each one streams from its
+          own Plex playlist; track changes are picked up at the next
+          poll cycle. No queue, no skip, no algorithm — just the next
+          track when this one ends.
+        </p>
+
+        <p className="text-sm leading-relaxed text-slate-400">
+          The bus stage is a UI-only easter egg. Some things must be
+          experienced in person.
+        </p>
+
+        <div className="flex justify-end pt-2">
+          <button
+            type="button"
+            onClick={onClose}
+            className="rounded-lg border border-slate-700 bg-slate-800 px-4 py-2 text-sm text-slate-200 transition-colors hover:bg-slate-700"
+          >
+            Close
+          </button>
+        </div>
+      </div>
+    </Dialog>
+  );
+}

--- a/apps/web/src/components/MobileDrawer.tsx
+++ b/apps/web/src/components/MobileDrawer.tsx
@@ -1,0 +1,64 @@
+import { useEffect } from "react";
+
+interface MobileDrawerProps {
+  open: boolean;
+  onClose: () => void;
+  children: React.ReactNode;
+}
+
+/**
+ * Slide-in drawer from the left. Shown only at < md breakpoints
+ * (the desktop sidebar takes over at md+). Backdrop dismisses on
+ * click; ESC dismisses; auto-closes on route change is the parent's
+ * responsibility (Layout watches the active stage).
+ *
+ * Body scroll lock via overflow-hidden prevents the underlying
+ * page from scrolling while the drawer is open. Focus management
+ * is intentionally minimal — the drawer's content (Sidebar) is
+ * keyboard-friendly via the existing TanStack Router Links.
+ */
+export function MobileDrawer({ open, onClose, children }: MobileDrawerProps) {
+  useEffect(() => {
+    if (!open) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") onClose();
+    };
+    document.addEventListener("keydown", onKey);
+    const prevOverflow = document.body.style.overflow;
+    document.body.style.overflow = "hidden";
+    return () => {
+      document.removeEventListener("keydown", onKey);
+      document.body.style.overflow = prevOverflow;
+    };
+  }, [open, onClose]);
+
+  return (
+    <div
+      className={`fixed inset-0 z-40 md:hidden ${
+        open ? "pointer-events-auto" : "pointer-events-none"
+      }`}
+      aria-hidden={!open}
+    >
+      {/* Backdrop. Tap-to-dismiss; opacity transitions for a soft fade. */}
+      <button
+        type="button"
+        aria-label="Close stages menu"
+        onClick={onClose}
+        tabIndex={open ? 0 : -1}
+        className={`absolute inset-0 bg-black/70 transition-opacity duration-200 ${
+          open ? "opacity-100" : "opacity-0"
+        }`}
+      />
+      {/* Panel. Slide-in from left; 88vw cap leaves a peek of the
+       * backdrop so it's obvious the drawer is dismissable. */}
+      <aside
+        className={`relative h-full w-[88vw] max-w-sm transform border-r border-slate-800 bg-[#0a0410] transition-transform duration-200 ${
+          open ? "translate-x-0" : "-translate-x-full"
+        }`}
+        aria-label="Stages"
+      >
+        {children}
+      </aside>
+    </div>
+  );
+}

--- a/apps/web/src/components/MobileDrawer.tsx
+++ b/apps/web/src/components/MobileDrawer.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from "react";
+import { useEffect, useRef } from "react";
 
 interface MobileDrawerProps {
   open: boolean;
@@ -12,23 +12,54 @@ interface MobileDrawerProps {
  * click; ESC dismisses; auto-closes on route change is the parent's
  * responsibility (Layout watches the active stage).
  *
- * Body scroll lock via overflow-hidden prevents the underlying
- * page from scrolling while the drawer is open. Focus management
- * is intentionally minimal — the drawer's content (Sidebar) is
- * keyboard-friendly via the existing TanStack Router Links.
+ * Accessibility:
+ *   - When closed, the panel is `inert` so its descendants don't
+ *     receive focus via Tab from the page underneath. (CR feedback
+ *     on PR #29.)
+ *   - When open, role="dialog" + aria-modal + aria-label so screen
+ *     readers treat it as a modal layer; initial focus moves to the
+ *     panel and is restored to the previously-focused element on
+ *     close. There's no cross-platform cheap focus-trap primitive
+ *     in React; we rely on the listener pattern + initial focus to
+ *     keep the keyboard inside the drawer for the common case.
+ *   - Body scroll lock via overflow-hidden prevents the underlying
+ *     page from scrolling while the drawer is open.
  */
 export function MobileDrawer({ open, onClose, children }: MobileDrawerProps) {
+  const panelRef = useRef<HTMLDivElement | null>(null);
+  const restoreFocusRef = useRef<HTMLElement | null>(null);
+
   useEffect(() => {
     if (!open) return;
+
+    // Capture the element that triggered the open so we can restore
+    // focus on close (typical accessible-modal pattern).
+    restoreFocusRef.current = document.activeElement as HTMLElement | null;
+
     const onKey = (e: KeyboardEvent) => {
       if (e.key === "Escape") onClose();
     };
     document.addEventListener("keydown", onKey);
     const prevOverflow = document.body.style.overflow;
     document.body.style.overflow = "hidden";
+
+    // Move focus into the panel on open so subsequent Tab keys land
+    // on its first focusable descendant.
+    panelRef.current?.focus();
+
     return () => {
       document.removeEventListener("keydown", onKey);
       document.body.style.overflow = prevOverflow;
+      // Restore focus to the trigger if it's still in the DOM.
+      const el = restoreFocusRef.current;
+      restoreFocusRef.current = null;
+      if (el && document.body.contains(el)) {
+        try {
+          el.focus();
+        } catch {
+          // Element may have been disabled mid-cycle. No-op.
+        }
+      }
     };
   }, [open, onClose]);
 
@@ -37,9 +68,9 @@ export function MobileDrawer({ open, onClose, children }: MobileDrawerProps) {
       className={`fixed inset-0 z-40 md:hidden ${
         open ? "pointer-events-auto" : "pointer-events-none"
       }`}
-      aria-hidden={!open}
     >
-      {/* Backdrop. Tap-to-dismiss; opacity transitions for a soft fade. */}
+      {/* Backdrop. Tap-to-dismiss; opacity transitions for a soft fade.
+       * Tabindex -1 when closed so it's not in the tab order. */}
       <button
         type="button"
         aria-label="Close stages menu"
@@ -50,15 +81,28 @@ export function MobileDrawer({ open, onClose, children }: MobileDrawerProps) {
         }`}
       />
       {/* Panel. Slide-in from left; 88vw cap leaves a peek of the
-       * backdrop so it's obvious the drawer is dismissable. */}
-      <aside
-        className={`relative h-full w-[88vw] max-w-sm transform border-r border-slate-800 bg-[#0a0410] transition-transform duration-200 ${
+       * backdrop so it's obvious the drawer is dismissable.
+       *
+       * The `inert` attribute on the panel when closed pulls the
+       * entire subtree out of the focus order — ensures Sidebar's
+       * tabs/Links never receive Tab focus from the page below
+       * while the drawer is hidden. tabIndex=-1 lets us programmatically
+       * focus the panel itself when the drawer opens. */}
+      <div
+        ref={panelRef}
+        role="dialog"
+        aria-modal={open}
+        aria-label="Stages menu"
+        tabIndex={-1}
+        // React 19 forwards the `inert` attribute as a boolean.
+        // `inert={true}` toggles the HTML attribute on/off.
+        {...(open ? {} : { inert: true })}
+        className={`relative h-full w-[88vw] max-w-sm transform border-r border-slate-800 bg-[#0a0410] transition-transform duration-200 outline-none ${
           open ? "translate-x-0" : "-translate-x-full"
         }`}
-        aria-label="Stages"
       >
         {children}
-      </aside>
+      </div>
     </div>
   );
 }

--- a/apps/web/src/components/MobileHeader.tsx
+++ b/apps/web/src/components/MobileHeader.tsx
@@ -1,0 +1,31 @@
+interface MobileHeaderProps {
+  onOpenDrawer: () => void;
+}
+
+/**
+ * Slim header strip shown on screens narrower than `md`. Two
+ * elements: the brand mark + a hamburger button that opens the
+ * drawer (which contains the same StagesList the desktop sidebar
+ * shows). Hidden on md+ where the sidebar is always visible.
+ */
+export function MobileHeader({ onOpenDrawer }: MobileHeaderProps) {
+  return (
+    <header className="sticky top-0 z-30 flex items-center justify-between border-b border-slate-800 bg-[#0a0410]/95 px-4 py-3 backdrop-blur md:hidden">
+      <h1 className="bg-gradient-to-r from-fuchsia-400 to-amber-300 bg-clip-text text-lg font-bold tracking-tight text-transparent">
+        Pavoia
+      </h1>
+      <button
+        type="button"
+        onClick={onOpenDrawer}
+        aria-label="Open stages menu"
+        className="flex h-10 w-10 items-center justify-center rounded-lg border border-slate-700 text-slate-300 transition-colors hover:bg-slate-800/60"
+      >
+        <svg viewBox="0 0 24 24" width="22" height="22" fill="currentColor" aria-hidden="true">
+          <rect x="3" y="6" width="18" height="2" rx="1" />
+          <rect x="3" y="11" width="18" height="2" rx="1" />
+          <rect x="3" y="16" width="18" height="2" rx="1" />
+        </svg>
+      </button>
+    </header>
+  );
+}

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -4,29 +4,36 @@ import { StageItem } from "./StageItem.tsx";
 interface SidebarProps {
   /** id of the currently-routed stage, or null if no stage selected */
   activeStageId: string | null;
+  /** Open the about/credits dialog (footer "i" button). */
+  onOpenInfo: () => void;
+  /** Open the Bus stage easter egg (clicked from the disabled row). */
+  onOpenBus: () => void;
 }
 
 /**
- * Desktop sidebar (mobile drawer comes in Slice E). Renders the
- * static catalog of stages from /api/stages — the source of truth
- * for icons/accents/gradients/order is the server (which gets it
- * from packages/shared/stages.ts).
+ * Renders the static catalog of stages from /api/stages — the
+ * source of truth for icons/accents/gradients/order is the server
+ * (which gets it from packages/shared/stages.ts).
+ *
+ * Layout uses this same component for both the desktop sidebar
+ * (md:flex) and the mobile drawer's panel content; the drawer
+ * provides its own animation + backdrop chrome around it.
  */
-export function Sidebar({ activeStageId }: SidebarProps) {
+export function Sidebar({ activeStageId, onOpenInfo, onOpenBus }: SidebarProps) {
   const { data: stages, isLoading, isError, error } = useStages();
 
   return (
     <aside
-      className="flex w-full flex-col border-r border-slate-800 bg-[#0a0410] md:w-80"
+      className="flex h-full w-full flex-col bg-[#0a0410] md:w-80 md:border-r md:border-slate-800"
       aria-label="Stages"
     >
-      <header className="flex items-center px-6 py-5">
+      <header className="hidden items-center px-6 py-5 md:flex">
         <h1 className="bg-gradient-to-r from-fuchsia-400 to-amber-300 bg-clip-text text-xl font-bold tracking-tight text-transparent">
           Pavoia
         </h1>
       </header>
 
-      <nav className="flex-1 overflow-y-auto px-3 pb-6">
+      <nav className="flex-1 overflow-y-auto px-3 pt-3 pb-6 md:pt-0">
         {isLoading ? (
           <div className="px-3 py-2 text-sm text-slate-500">
             Loading stages…
@@ -50,12 +57,27 @@ export function Sidebar({ activeStageId }: SidebarProps) {
                 <StageItem
                   stage={stage}
                   isActive={stage.id === activeStageId}
+                  onOpenBus={onOpenBus}
                 />
               </li>
             ))}
           </ul>
         )}
       </nav>
+
+      <footer className="border-t border-slate-800 px-3 py-3">
+        <button
+          type="button"
+          onClick={onOpenInfo}
+          className="flex w-full items-center gap-2 rounded-lg px-3 py-2 text-sm text-slate-400 transition-colors hover:bg-slate-800/60 hover:text-slate-200"
+          aria-label="About Pavoia"
+        >
+          <svg viewBox="0 0 24 24" width="16" height="16" fill="currentColor" aria-hidden="true">
+            <path d="M12 2a10 10 0 100 20 10 10 0 000-20zm0 5a1.25 1.25 0 110 2.5A1.25 1.25 0 0112 7zm1.5 11h-3v-1h.75v-4.5h-.75v-1h2.25v5.5h.75v1z" />
+          </svg>
+          About
+        </button>
+      </footer>
     </aside>
   );
 }

--- a/apps/web/src/components/StageItem.tsx
+++ b/apps/web/src/components/StageItem.tsx
@@ -4,39 +4,39 @@ import type { Stage } from "@pavoia/shared";
 interface StageItemProps {
   stage: Stage;
   isActive: boolean;
+  /** Triggered when the listener clicks the disabled Bus row. */
+  onOpenBus: () => void;
 }
 
 /**
  * A single stage row in the sidebar. v1's pattern, modernized:
  *   - left accent border in the stage's own color
  *   - active state fills the row with a subtle accent tint
- *   - disabled stages (Bus) render but don't navigate
- *
- * Hover preview popover is deferred to Slice F.
+ *   - disabled stages (Bus) render but don't navigate; clicking
+ *     opens the BusMysteryCard dialog instead
  */
-export function StageItem({ stage, isActive }: StageItemProps) {
+export function StageItem({ stage, isActive, onOpenBus }: StageItemProps) {
   const accent = stage.accent;
   const baseClasses =
-    "group block rounded-lg border-l-4 bg-slate-900/40 px-4 py-3 transition-all hover:bg-slate-800/60";
+    "group block w-full text-left rounded-lg border-l-4 bg-slate-900/40 px-4 py-3 transition-all hover:bg-slate-800/60";
   const activeClasses = isActive
     ? "ring-1 ring-inset"
     : "";
 
   if (stage.disabled) {
-    // Bus is a UI-only easter egg — interactive but not navigable.
-    // Slice F will wire up the BusMysteryCard dialog. For now,
-    // render visually but disable navigation to /stage/:id.
+    // Bus is a UI-only easter egg — render as a button that opens
+    // the mystery dialog instead of navigating to /stage/bus.
     return (
-      <div
-        role="button"
-        aria-disabled="true"
-        className={`${baseClasses} ${activeClasses} cursor-default opacity-60`}
+      <button
+        type="button"
+        onClick={onOpenBus}
+        className={`${baseClasses} ${activeClasses} cursor-pointer opacity-80 hover:opacity-100`}
         style={{
           borderLeftColor: accent,
         }}
       >
         <Inner stage={stage} />
-      </div>
+      </button>
     );
   }
 

--- a/apps/web/src/components/StagePlayer.tsx
+++ b/apps/web/src/components/StagePlayer.tsx
@@ -1,6 +1,7 @@
 import type { Stage } from "@pavoia/shared";
 
 import { useHls } from "../audio/useHls.ts";
+import { EqualizerBars } from "./EqualizerBars.tsx";
 import { PlayPauseButton } from "./PlayPauseButton.tsx";
 
 interface StagePlayerProps {
@@ -38,8 +39,13 @@ export function StagePlayer({ stage, streamUrl }: StagePlayerProps) {
         aria-live="polite"
         aria-atomic="true"
       >
-        <div className="text-sm font-medium text-slate-200">
-          {labelForState(state, stage)}
+        <div className="flex items-center gap-2">
+          {state === "playing" ? (
+            <EqualizerBars color={stage.accent} />
+          ) : null}
+          <div className="text-sm font-medium text-slate-200">
+            {labelForState(state, stage)}
+          </div>
         </div>
         {error ? (
           <p className="mt-0.5 truncate text-xs text-rose-400/80">{error}</p>

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -1,1 +1,18 @@
 @import "tailwindcss";
+
+/* EqualizerBars pulse — used as a "live" indicator next to the
+ * Play/Pause button. Each bar consumes its own animation-duration
+ * so the pattern looks organic. The min height of 25 % keeps the
+ * bar visually present on the trough. */
+@keyframes eq-bar {
+  0%, 100% {
+    height: 25%;
+  }
+  50% {
+    height: 100%;
+  }
+}
+
+@theme {
+  --animate-eq-bar: eq-bar 1s ease-in-out infinite;
+}

--- a/apps/web/src/pages/Layout.tsx
+++ b/apps/web/src/pages/Layout.tsx
@@ -1,20 +1,28 @@
+import { useEffect, useState } from "react";
 import { Outlet, useRouterState } from "@tanstack/react-router";
 
+import { BusMysteryCard } from "../components/BusMysteryCard.tsx";
+import { InfoDialog } from "../components/InfoDialog.tsx";
+import { MobileDrawer } from "../components/MobileDrawer.tsx";
+import { MobileHeader } from "../components/MobileHeader.tsx";
 import { Sidebar } from "../components/Sidebar.tsx";
 
 /**
- * Outer page chrome: sidebar + main outlet. Identifies the active
- * stage from the routed location (typed via TanStack Router's
- * generated tree) instead of a raw routeId string match.
+ * Outer page chrome: mobile header + drawer (or desktop sidebar) +
+ * main outlet + dialogs. Identifies the active stage from the
+ * routed location (typed via TanStack Router) instead of a raw
+ * routeId string match.
  *
- * Mobile becomes a stack (sidebar on top, content below) until
- * Slice E replaces it with a proper drawer.
+ * State machine for ephemeral overlays:
+ *   - drawerOpen: mobile slide-in menu
+ *   - infoOpen:   about/credits dialog (triggered from sidebar
+ *                 footer "i" button)
+ *   - busOpen:    Bus stage easter egg (triggered when listener
+ *                 clicks the disabled Bus row)
  */
 export function Layout() {
   const activeStageId = useRouterState({
     select: (state) => {
-      // The stage-detail route declares params { stageId: string };
-      // TanStack hands us the merged params for the current match.
       const params = state.matches[state.matches.length - 1]?.params as
         | { stageId?: string }
         | undefined;
@@ -22,12 +30,45 @@ export function Layout() {
     },
   });
 
+  const [drawerOpen, setDrawerOpen] = useState(false);
+  const [infoOpen, setInfoOpen] = useState(false);
+  const [busOpen, setBusOpen] = useState(false);
+
+  // Auto-close the drawer when the route changes (i.e. the user
+  // tapped a stage). Without this the drawer stays open over the
+  // newly-routed content, which is jarring.
+  useEffect(() => {
+    setDrawerOpen(false);
+  }, [activeStageId]);
+
   return (
     <div className="flex min-h-dvh flex-col md:flex-row">
-      <Sidebar activeStageId={activeStageId} />
+      <MobileHeader onOpenDrawer={() => setDrawerOpen(true)} />
+
+      {/* Desktop sidebar — visible at md+. */}
+      <div className="hidden md:flex md:flex-col">
+        <Sidebar
+          activeStageId={activeStageId}
+          onOpenInfo={() => setInfoOpen(true)}
+          onOpenBus={() => setBusOpen(true)}
+        />
+      </div>
+
+      {/* Mobile drawer — same Sidebar content, slide-in panel. */}
+      <MobileDrawer open={drawerOpen} onClose={() => setDrawerOpen(false)}>
+        <Sidebar
+          activeStageId={activeStageId}
+          onOpenInfo={() => setInfoOpen(true)}
+          onOpenBus={() => setBusOpen(true)}
+        />
+      </MobileDrawer>
+
       <main className="flex-1 overflow-hidden">
         <Outlet />
       </main>
+
+      <InfoDialog open={infoOpen} onClose={() => setInfoOpen(false)} />
+      <BusMysteryCard open={busOpen} onClose={() => setBusOpen(false)} />
     </div>
   );
 }


### PR DESCRIPTION
## Summary

Player polish round. Adds the four nice-to-haves from the v1 port list that fit cleanly on top of Slices A–E.

## What ships

- **EqualizerBars** + index.css keyframe — decorative four-bar pulsing animation rendered next to the Play/Pause button when state === \"playing\". No audio analysis, just a \"stage is live\" affordance. Tailwind 4 \`@theme\` token + \`@keyframes\`.

- **MobileHeader + MobileDrawer** — below md breakpoint, sticky thin header with brand + hamburger replaces the awkward stacked sidebar fallback. Tapping hamburger slides the same Sidebar content in from the left over a backdrop. ESC dismisses, backdrop tap dismisses, route change auto-closes (Layout effect on activeStageId). Body scroll lock while open.

- **Dialog** — thin wrapper around the native \`<dialog>\` element. Browsers handle modal stacking, focus trap, and ESC dismissal. Click-outside-to-dismiss via \`target === ref.current\`.

- **InfoDialog** — about/credits modal triggered from the new \"About\" button in the sidebar footer. Gradient title + short blurb + bus easter-egg hint. v1's logo-driven version is reduced to text since v3 doesn't ship a brand GIF.

- **BusMysteryCard** — the Bus easter egg, ported from v1. Disabled stages were previously aria-disabled divs; now they're buttons that open this dialog. \"Some things must be experienced in person.\"

## Layout state machine

Three pieces of ephemeral overlay state in Layout:

| state | trigger | dismiss |
|---|---|---|
| \`drawerOpen\` | hamburger | backdrop / ESC / route change |
| \`infoOpen\` | sidebar footer About | backdrop / ESC / Close button |
| \`busOpen\` | clicking Bus row | backdrop / ESC / Got it button |

Sidebar takes \`onOpenInfo\` + \`onOpenBus\` callbacks and renders identically in desktop position AND inside the mobile drawer panel.

## What this does NOT do

- No ArtistDrawer (needs Plex artist endpoint on engine — separate PR)
- No StreamPreview hover popover — desktop-only UX, wait until ArtistDrawer lands
- No useSwipeNavigation — mobile gesture polish, separate PR

## Verified

- [x] typecheck clean
- [x] Vite build: main 328 KB / 103 KB gzipped (was 322 / 101); StagePlayer chunk unchanged at 526 KB / 164 KB gzipped
- [x] CodeRabbit pre-push: clean
- [x] \`npm test\` green (284 engine + web echo)
- [ ] CodeRabbit GH App review on pushed HEAD
- [ ] Codex independent review

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Mobile-optimized navigation with a sticky header and slide-in drawer menu
  * Bus-themed hint dialog for locked stages
  * About/credits information modal
  * Animated equalizer visualization during audio playback
  * Locked "Bus" stages are now actionable (improved UX)

* **Accessibility & UX**
  * Drawer and dialogs have improved focus and dismissal behavior; drawer auto-closes on stage change
<!-- end of auto-generated comment: release notes by coderabbit.ai -->